### PR TITLE
fix: render PR summary as markdown instead of code block

### DIFF
--- a/nightshift.sh
+++ b/nightshift.sh
@@ -566,7 +566,7 @@ EOF
   # ── Build PR Body ──────────────────────────────────────────────────────────
   # Extract the last ~1200 chars of Claude output as a summary
   local summary
-  summary=$(tail -c 1500 "$log_file" 2>/dev/null | head -c 1200 || true)
+  summary=$(tail -n 40 "$log_file" 2>/dev/null || true)
 
   local review_section=""
   if [ -n "${GEMINI_API_KEY:-}" ]; then
@@ -600,9 +600,7 @@ ${review_output}
 
 ## What was implemented
 
-\`\`\`
 ${summary}
-\`\`\`
 ${review_section}
 ---
 


### PR DESCRIPTION
## Summary
- Changed summary extraction from byte-based (`tail -c 1500 | head -c 1200`) to line-based (`tail -n 40`) for cleaner output
- Removed triple-backtick wrapping around the summary in the PR body so Claude's markdown renders properly instead of appearing as a raw code block

## Test plan
- [ ] Run nightshift against a test ticket and verify the generated PR body renders the summary as formatted markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)