### PR TITLE
ENG-129: Cleanup command — purge stale worktrees, branches, and old agent logs

### DIFF
--- a/nightshift.sh
+++ b/nightshift.sh
@@ -335,7 +335,6 @@ startup_cleanup() {
   log "Running startup cleanup..."
   git -C "$REPO_PATH" worktree prune 2>/dev/null || true
   git -C "$REPO_PATH" fetch --prune 2>/dev/null || true
-  rm -rf "$WORKTREE_BASE"/*/ 2>/dev/null || true
   log "✅ Startup cleanup done"
 }
 
@@ -386,20 +385,19 @@ run_cleanup() {
   git -C "$REPO_PATH" worktree prune 2>/dev/null || true
 
   # ── Merged local branches ─────────────────────────────────────────────────
-  local merged=""
-  merged=$(git -C "$REPO_PATH" branch --merged "$MAIN_BRANCH" 2>/dev/null \
+  local merged_branches=()
+  mapfile -t merged_branches < <(git -C "$REPO_PATH" branch --merged "$MAIN_BRANCH" 2>/dev/null \
     | grep -vE "^\*|main|staging|master" \
     | sed 's/^[[:space:]]*//' || true)
 
-  if [ -n "$merged" ]; then
-    echo "Merged branches to delete ($(echo "$merged" | wc -l | tr -d ' ')):"
-    echo "$merged" | while IFS= read -r b; do echo "  - $b"; done
+  if [ "${#merged_branches[@]}" -gt 0 ]; then
+    echo "Merged branches to delete (${#merged_branches[@]}):"
+    printf "  - %s\n" "${merged_branches[@]}"
 
     if [ "$force" = true ] || confirm "Delete these merged branches?"; then
-      while IFS= read -r branch; do
-        [ -z "$branch" ] && continue
+      for branch in "${merged_branches[@]}"; do
         git -C "$REPO_PATH" branch -d "$branch" 2>/dev/null && merged_deleted=$((merged_deleted + 1))
-      done <<< "$merged"
+      done
     fi
     echo ""
   fi


### PR DESCRIPTION
## Summary

- Adds `./nightshift.sh cleanup` subcommand (interactive — shows what will be deleted, asks for confirmation)
- Adds `./nightshift.sh cleanup --force` for non-interactive use (CI, cron)
- Runs lightweight auto-cleanup on every startup (prune worktrees, prune remote refs, clear worktree dirs)

### What it cleans

| Resource | Behavior |
|----------|----------|
| Worktree directories | Removes all dirs in `.worktrees/` |
| Merged local branches | Deletes with `git branch -d` (safe — excludes main/staging/master) |
| Unmerged nightshift branches | Force-deletes with `git branch -D`, but **skips branches with open PRs** |
| Remote tracking refs | `git fetch --prune` |
| Agent logs | Deletes `.log` files older than 7 days |

Shows a summary after cleanup with counts of everything removed.

## Test plan

- [ ] `./nightshift.sh cleanup` shows resources and prompts before each deletion
- [ ] `./nightshift.sh cleanup --force` deletes everything without prompting
- [ ] Branches with open PRs are skipped (not force-deleted)
- [ ] `main`, `staging`, `master` branches are never deleted
- [ ] Auto-cleanup runs on normal startup (visible in logs)
- [ ] Script still works normally when no cleanup is needed (empty dirs, no stale branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)