### PR TITLE
feat: restore worktree support, add tests, create CLAUDE.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,6 @@ LINEAR_TEAM_KEY=ENG
 # Must match the state name exactly (case-sensitive)
 TRIGGER_STATE=Next
 
-# State set when Nightshift starts working on a ticket
-IN_PROGRESS_STATE=In Progress
-
 # State set after the PR is created
 IN_REVIEW_STATE=In Review
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# Nightshift
+
+Autonomous Linear-to-PR agent. Polls Linear for tickets in a trigger state, dispatches Claude Code to implement them, creates PRs, and moves tickets to review.
+
+## Architecture
+
+```
+main loop (poll) → fetch_trigger_issues → process_ticket (background subshell per ticket)
+  → create_worktree → run_claude → check output → commit/push → gh pr create → linear update
+```
+
+Worktrees are created at `~/.nightshift-worktrees/<IDENTIFIER>` so multiple tickets can run concurrently without sharing a working directory.
+
+## Key Functions
+
+| Function | Purpose |
+|----------|---------|
+| `create_worktree` | Creates git worktree + branch from latest main |
+| `cleanup_worktree` | Removes worktree via `git worktree remove --force` |
+| `run_claude` | Invokes `claude --print` with timeout; takes `workdir` as first param |
+| `process_ticket` | Full lifecycle: worktree → claude → review → commit → PR → Linear update |
+| `build_prompt` | Generates the prompt from ticket metadata |
+| `gemini_review` | Optional second-model review gate |
+| `fetch_trigger_issues` | Queries Linear GraphQL for tickets in trigger state |
+
+## Configuration
+
+Copy `.env.example` to `.env`. All config is documented there. Key variables:
+- `REPO_PATH` — absolute path to the target repo
+- `LINEAR_API_KEY`, `LINEAR_TEAM_KEY` — Linear access
+- `MAX_CONCURRENT` — number of parallel tickets (each gets its own worktree)
+
+## Log File Structure
+
+Log files at `.agent-logs/<IDENTIFIER>.log` **append across attempts**:
+
+```
+--- Attempt 2024-01-01T00:00:00 ---
+DEBUG: pwd = /path
+<claude output>
+--- Attempt 2024-01-01T01:00:00 ---
+DEBUG: pwd = /path
+<claude output>
+```
+
+### IMPORTANT: log_offset pattern
+
+The `log_offset + tail -c` pattern in `process_ticket` is a critical bug fix. It records the file size before Claude runs, then uses `tail -c +$offset` to extract only the current attempt's output for BLOCKED/rate-limit checks. **Do not replace this with a grep over the full file** — that re-detects failures from previous attempts and causes false positives.
+
+## Running Tests
+
+```bash
+bash tests/run_tests.bash
+```
+
+Tests use plain bash (no bats). The `NIGHTSHIFT_TESTING=true` guard prevents the entrypoint from executing when sourcing `nightshift.sh`.
+
+## Syntax Check
+
+```bash
+bash -n nightshift.sh
+```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -25,7 +25,7 @@ Common mismatches:
 - `"In review"` vs `"In Review"` (capitalization)
 - Custom state names that differ from the defaults
 
-Fix: update `TRIGGER_STATE` / `IN_PROGRESS_STATE` / `IN_REVIEW_STATE` in `.env` to match exactly.
+Fix: update `TRIGGER_STATE` / `IN_REVIEW_STATE` in `.env` to match exactly.
 
 **Check 2: Team key mismatch**
 
@@ -193,12 +193,14 @@ Claude made its best guess about what was needed. Without specific file paths, e
 
 **Fix:** Improve the ticket. See [WRITING-GOOD-TICKETS.md](WRITING-GOOD-TICKETS.md).
 
-Close the PR, delete the branch, and re-queue the ticket with more context:
+Close the PR, delete the branch/worktree, and re-queue the ticket with more context:
 
 ```bash
-# Delete the branch
+# Remove worktree if it exists
+cd /path/to/repo && git worktree remove --force ~/.nightshift-worktrees/ENG-42 2>/dev/null || true
+# Delete the remote and local branch
 git push origin --delete nightshift/eng-42
-cd /path/to/repo && git branch -D nightshift/eng-42 2>/dev/null || true
+git branch -D nightshift/eng-42 2>/dev/null || true
 ```
 
 ---
@@ -207,19 +209,21 @@ cd /path/to/repo && git branch -D nightshift/eng-42 2>/dev/null || true
 
 **Symptom:** Nightshift exits unexpectedly. A ticket is stuck in "In Progress" with no PR.
 
-**Clean up stale branches:**
+**Clean up stale worktrees and branches:**
 
 ```bash
-# Check if a nightshift branch was left behind
+# Check for leftover worktrees
+ls ~/.nightshift-worktrees/
+
+# Remove a stale worktree
 cd /path/to/your/repo
-git branch | grep nightshift/
+git worktree remove --force ~/.nightshift-worktrees/ENG-42
 
-# Delete a stale nightshift branch
-git checkout main
-git branch -D nightshift/eng-42
+# Prune worktree metadata
+git worktree prune
 
-# Return to main
-git checkout main && git pull origin main
+# Delete a stale local branch if needed
+git branch -D nightshift/eng-42 2>/dev/null
 ```
 
 **Reset the ticket state:**

--- a/nightshift.sh
+++ b/nightshift.sh
@@ -40,7 +40,6 @@ fi
 LINEAR_API_KEY="${LINEAR_API_KEY:-}"
 LINEAR_TEAM_KEY="${LINEAR_TEAM_KEY:-ENG}"
 TRIGGER_STATE="${TRIGGER_STATE:-Next}"
-IN_PROGRESS_STATE="${IN_PROGRESS_STATE:-In Progress}"
 IN_REVIEW_STATE="${IN_REVIEW_STATE:-In Review}"
 REPO_PATH="${REPO_PATH:-}"
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
@@ -63,6 +62,7 @@ TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-}"
 
 # Paths
 LOG_DIR="$SCRIPT_DIR/.agent-logs"
+WORKTREE_BASE="$HOME/.nightshift-worktrees"
 
 # ─── Global State ────────────────────────────────────────────────────────────
 
@@ -77,7 +77,6 @@ SESSION_START=$SECONDS
 
 # Resolved Linear state IDs (populated at startup)
 STATE_ID_TRIGGER=""
-STATE_ID_IN_PROGRESS=""
 STATE_ID_IN_REVIEW=""
 
 # ─── Validation ──────────────────────────────────────────────────────────────
@@ -190,22 +189,20 @@ resolve_state_ids() {
   fi
 
   STATE_ID_TRIGGER=$(echo "$nodes" | jq -r ".[] | select(.name == \"${TRIGGER_STATE}\") | .id")
-  STATE_ID_IN_PROGRESS=$(echo "$nodes" | jq -r ".[] | select(.name == \"${IN_PROGRESS_STATE}\") | .id")
   STATE_ID_IN_REVIEW=$(echo "$nodes" | jq -r ".[] | select(.name == \"${IN_REVIEW_STATE}\") | .id")
 
   local missing=0
-  [ -z "$STATE_ID_TRIGGER" ]     && { echo "❌ State not found: \"${TRIGGER_STATE}\"" >&2;     missing=$((missing + 1)); }
-  [ -z "$STATE_ID_IN_PROGRESS" ] && { echo "❌ State not found: \"${IN_PROGRESS_STATE}\"" >&2; missing=$((missing + 1)); }
-  [ -z "$STATE_ID_IN_REVIEW" ]   && { echo "❌ State not found: \"${IN_REVIEW_STATE}\"" >&2;   missing=$((missing + 1)); }
+  [ -z "$STATE_ID_TRIGGER" ]   && { echo "❌ State not found: \"${TRIGGER_STATE}\"" >&2;   missing=$((missing + 1)); }
+  [ -z "$STATE_ID_IN_REVIEW" ] && { echo "❌ State not found: \"${IN_REVIEW_STATE}\"" >&2; missing=$((missing + 1)); }
 
   if [ "$missing" -gt 0 ]; then
     echo "" >&2
     echo "   Available states: $(echo "$nodes" | jq -r '.[].name' | paste -sd ', ')" >&2
-    echo "   Update TRIGGER_STATE / IN_PROGRESS_STATE / IN_REVIEW_STATE in .env" >&2
+    echo "   Update TRIGGER_STATE / IN_REVIEW_STATE in .env" >&2
     exit 1
   fi
 
-  log "✅ States resolved: \"$TRIGGER_STATE\" | \"$IN_PROGRESS_STATE\" | \"$IN_REVIEW_STATE\""
+  log "✅ States resolved: \"$TRIGGER_STATE\" | \"$IN_REVIEW_STATE\""
 }
 
 fetch_trigger_issues() {
@@ -328,38 +325,43 @@ Then provide your review comments."
   fi
 }
 
-# ─── Branch Management ────────────────────────────────────────────────────────
+# ─── Worktree Management ──────────────────────────────────────────────────────
 
-create_branch() {
+create_worktree() {
   local identifier="$1"
   local branch_name
   branch_name="nightshift/$(echo "$identifier" | tr '[:upper:]' '[:lower:]')"
+  local worktree_path="$WORKTREE_BASE/$identifier"
 
-  cd "$REPO_PATH" || { echo "Cannot cd to REPO_PATH: $REPO_PATH" >&2; return 1; }
+  (
+    cd "$REPO_PATH" || { echo "Cannot cd to REPO_PATH: $REPO_PATH" >&2; return 1; }
 
-  git fetch origin "$MAIN_BRANCH" --quiet >/dev/null 2>&1 || true
+    git fetch origin "$MAIN_BRANCH" --quiet >/dev/null 2>&1 || true
 
-  # Remove stale local branch if exists
-  git branch -D "$branch_name" >/dev/null 2>&1 || true
+    # Remove stale local branch if exists
+    git branch -D "$branch_name" >/dev/null 2>&1 || true
 
-  # Start from latest main
-  git checkout "$MAIN_BRANCH" --quiet >/dev/null 2>&1 || true
-  git reset --hard "origin/$MAIN_BRANCH" --quiet >/dev/null 2>&1 || true
+    # Remove stale worktree if exists
+    git worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
 
-  # Create and switch to the feature branch (suppress git output)
-  if ! git checkout -b "$branch_name" "origin/$MAIN_BRANCH" >/dev/null 2>&1; then
-    echo "git checkout -b failed for branch: $branch_name" >&2
-    return 1
-  fi
+    # Create worktree with a new branch from latest main
+    if ! git worktree add -b "$branch_name" "$worktree_path" "origin/$MAIN_BRANCH" >/dev/null 2>&1; then
+      echo "git worktree add failed for: $worktree_path" >&2
+      return 1
+    fi
+  ) || return 1
 
-  echo "$branch_name"
+  echo "$worktree_path"
 }
 
-cleanup_branch() {
+cleanup_worktree() {
   local identifier="$1"
-  # Return to main branch after processing
-  cd "$REPO_PATH" 2>/dev/null || true
-  git checkout "$MAIN_BRANCH" --quiet 2>/dev/null || true
+  local worktree_path="$WORKTREE_BASE/$identifier"
+
+  (
+    cd "$REPO_PATH" 2>/dev/null || return 0
+    git worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
+  )
 }
 
 # ─── Cleanup ────────────────────────────────────────────────────────────────
@@ -368,6 +370,7 @@ cleanup_branch() {
 startup_cleanup() {
   log "Running startup cleanup..."
   git -C "$REPO_PATH" fetch --prune 2>/dev/null || true
+  git -C "$REPO_PATH" worktree prune 2>/dev/null || true
   log "✅ Startup cleanup done"
 }
 
@@ -452,6 +455,27 @@ run_cleanup() {
     echo ""
   fi
 
+  # ── Stale worktrees ───────────────────────────────────────────────────────
+  if [ -d "$WORKTREE_BASE" ]; then
+    local worktree_dirs=()
+    while IFS= read -r -d '' d; do
+      worktree_dirs+=("$d")
+    done < <(find "$WORKTREE_BASE" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+
+    if [ "${#worktree_dirs[@]}" -gt 0 ]; then
+      echo "Stale worktrees (${#worktree_dirs[@]}):"
+      for d in "${worktree_dirs[@]}"; do echo "  - $(basename "$d")"; done
+
+      if [ "$force" = true ] || confirm "Remove these worktrees?"; then
+        for d in "${worktree_dirs[@]}"; do
+          git -C "$REPO_PATH" worktree remove --force "$d" 2>/dev/null || rm -rf "$d"
+        done
+      fi
+      echo ""
+    fi
+    git -C "$REPO_PATH" worktree prune 2>/dev/null || true
+  fi
+
   # ── Prune remote tracking refs ────────────────────────────────────────────
   echo "Pruning stale remote tracking refs..."
   git -C "$REPO_PATH" fetch --prune 2>/dev/null || true
@@ -497,11 +521,12 @@ confirm() {
 # ─── Claude Invocation ───────────────────────────────────────────────────────
 
 run_claude() {
-  local prompt="$1"
-  local log_file="$2"
+  local workdir="$1"
+  local prompt="$2"
+  local log_file="$3"
   local timeout_minutes="${AGENT_TIMEOUT_MINUTES}"
 
-  cd "$REPO_PATH" || { echo "FATAL: cannot cd to REPO_PATH: $REPO_PATH" >> "$log_file"; return 1; }
+  cd "$workdir" || { echo "FATAL: cannot cd to workdir: $workdir" >> "$log_file"; return 1; }
 
   {
     echo "DEBUG: pwd = $(pwd)"
@@ -510,11 +535,11 @@ run_claude() {
 
   if [ "${USE_AGENT_TEAMS}" = "true" ]; then
     timeout "${timeout_minutes}m" bash -c \
-      'CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 claude \
+      'cd "$0" || exit 1; CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 claude \
         --dangerously-skip-permissions \
         --print \
         --output-format text \
-        -p "$1" >> "$2" 2>&1' _ "$prompt" "$log_file"
+        -p "$1" >> "$2" 2>&1' "$workdir" "$prompt" "$log_file"
   else
     timeout "${timeout_minutes}m" claude \
       --dangerously-skip-permissions \
@@ -600,25 +625,25 @@ process_ticket() {
   tlog "$identifier" "Starting: $title"
   tlog "$identifier" "Log: $log_file"
 
-  # ── Create Branch ──────────────────────────────────────────────────────────
+  # ── Create Worktree ────────────────────────────────────────────────────────
   # Note: Linear's GitHub integration auto-moves tickets to "In Progress"
   # when a branch with the ticket ID is created, so no manual state update needed.
-  local branch_name
-  if ! branch_name=$(create_branch "$identifier"); then
-    tlog "$identifier" "❌ Branch creation failed"
+  local worktree_path branch_name
+  branch_name="nightshift/$(echo "$identifier" | tr '[:upper:]' '[:lower:]')"
+  if ! worktree_path=$(create_worktree "$identifier"); then
+    tlog "$identifier" "❌ Worktree creation failed"
     linear_set_state "$issue_id" "$STATE_ID_TRIGGER" 2>/dev/null || true
     linear_comment "$issue_id" "❌ **Nightshift: Setup failed**
 
-Could not create branch. This may be a branch naming conflict.
+Could not create worktree. This may be a branch naming conflict.
 
-Check that branch \`nightshift/$(echo "$identifier" | tr '[:upper:]' '[:lower:]')\` does not already exist on the remote.
+Check that branch \`${branch_name}\` does not already exist on the remote.
 
 Ticket moved back to **${TRIGGER_STATE}**." 2>/dev/null || true
     return 1
   fi
 
-  tlog "$identifier" "Branch: $branch_name (in $REPO_PATH)"
-  cd "$REPO_PATH" || { tlog "$identifier" "❌ Cannot cd to REPO_PATH: $REPO_PATH"; return 1; }
+  tlog "$identifier" "Worktree: $worktree_path (branch: $branch_name)"
 
   # ── Run Claude ─────────────────────────────────────────────────────────────
   local prompt
@@ -631,7 +656,7 @@ Ticket moved back to **${TRIGGER_STATE}**." 2>/dev/null || true
   [ -f "$log_file" ] && log_offset=$(wc -c < "$log_file")
 
   local exit_code=0
-  run_claude "$prompt" "$log_file" || exit_code=$?
+  run_claude "$worktree_path" "$prompt" "$log_file" || exit_code=$?
 
   # ── Check for timeout ───────────────────────────────────────────────────────
   if [ "$exit_code" -eq 124 ]; then
@@ -648,7 +673,7 @@ The ticket may be too complex for a single session. Consider breaking it into sm
 Ticket moved back to **${TRIGGER_STATE}**." 2>/dev/null || true
     notify "⏰ *${identifier}* — ${title}
 Timed out after ${AGENT_TIMEOUT_MINUTES}m. Moving back to ${TRIGGER_STATE}."
-    cleanup_branch "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" 2>/dev/null || true
     return 1
   fi
 
@@ -670,7 +695,7 @@ Ticket moved back to **${TRIGGER_STATE}**. Nightshift is shutting down to avoid 
     notify "🛑 *Usage limit detected*
 Nightshift stopped after ${TOTAL_DISPATCHES} dispatches.
 ✅ ${SUCCESS_COUNT} PRs created | ❌ ${FAIL_COUNT} failed"
-    cleanup_branch "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" 2>/dev/null || true
     SHUTTING_DOWN=true
     return 1
   fi
@@ -689,7 +714,7 @@ Claude exited with code \`${exit_code}\`. Will retry on next poll cycle (up to $
 Ticket moved back to **${TRIGGER_STATE}**." 2>/dev/null || true
     notify "❌ *${identifier}* — ${title}
 Failed (attempt ${attempts}/${MAX_RETRIES}, exit code ${exit_code})"
-    cleanup_branch "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" 2>/dev/null || true
     return 1
   fi
 
@@ -709,13 +734,13 @@ Claude got blocked on this ticket:
 Please clarify in the ticket comments, then move back to **${TRIGGER_STATE}** to retry." 2>/dev/null || true
     notify "⚠️ *${identifier}* — Blocked
 ${blocked_line}"
-    cleanup_branch "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" 2>/dev/null || true
     tlog "$identifier" "Moved back to '$TRIGGER_STATE'"
     return 0
   fi
 
   # ── Check for Changes ──────────────────────────────────────────────────────
-  cd "$REPO_PATH"
+  cd "$worktree_path"
   local has_changes
   has_changes=$(git status --porcelain 2>/dev/null || true)
 
@@ -727,7 +752,7 @@ ${blocked_line}"
 Claude completed the session without modifying any files. This usually means the ticket description is too vague or needs more context.
 
 Add more detail to the ticket description and move back to **${TRIGGER_STATE}** to retry. See the [Writing Good Tickets guide](https://github.com/your-org/nightshift/blob/main/docs/WRITING-GOOD-TICKETS.md) for tips." 2>/dev/null || true
-    cleanup_branch "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" 2>/dev/null || true
     return 0
   fi
 
@@ -778,7 +803,7 @@ ${review_output}
 
         tlog "$identifier" "Asking Claude to fix review issues..."
         local fix_exit=0
-        run_claude "$fix_prompt" "$log_file" || fix_exit=$?
+        run_claude "$worktree_path" "$fix_prompt" "$log_file" || fix_exit=$?
         if [ "$fix_exit" -ne 0 ]; then
           tlog "$identifier" "⚠️  Fix attempt exited with code $fix_exit"
         fi
@@ -794,7 +819,7 @@ ${review_output}
   fi
 
   # ── Commit & Push ──────────────────────────────────────────────────────────
-  cd "$REPO_PATH"
+  cd "$worktree_path"
 
   local impl_mode=""
   [ "${USE_AGENT_TEAMS}" = "true" ] && impl_mode=" (Agent Teams)"
@@ -878,7 +903,7 @@ ${pr_url}
 \`\`\`
 
 Ticket moved back to **${TRIGGER_STATE}**." 2>/dev/null || true
-    cleanup_branch "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" 2>/dev/null || true
     return 1
   fi
 
@@ -898,7 +923,7 @@ Moved to **${IN_REVIEW_STATE}**. Ready for your review!" 2>/dev/null || true
   tlog "$identifier" "✅ Done — moved to '$IN_REVIEW_STATE'"
 
   # ── Cleanup ────────────────────────────────────────────────────────────────
-  cleanup_branch "$identifier" 2>/dev/null || true
+  cleanup_worktree "$identifier" 2>/dev/null || true
 }
 
 # ─── Process Management ──────────────────────────────────────────────────────
@@ -974,6 +999,7 @@ print_banner() {
   echo ""
   printf "🌙 Nightshift v%s\n" "$VERSION"
   printf "   Repo:           %s\n" "$REPO_PATH"
+  printf "   Worktrees:      %s\n" "$WORKTREE_BASE"
   printf "   Team:           %s\n" "$LINEAR_TEAM_KEY"
   printf "   Watching:       \"%s\" column\n" "$TRIGGER_STATE"
   printf "   Mode:           %s\n" "$agent_mode"
@@ -993,7 +1019,7 @@ print_banner() {
 
 main() {
   validate_config
-  mkdir -p "$LOG_DIR"
+  mkdir -p "$LOG_DIR" "$WORKTREE_BASE"
   startup_cleanup
   resolve_state_ids
   print_banner
@@ -1081,6 +1107,9 @@ Watching \"${TRIGGER_STATE}\" column for ${LINEAR_TEAM_KEY} tickets"
     sleep "$POLL_INTERVAL"
   done
 }
+
+# ─── Test Guard ────────────────────────────────────────────────────────────────
+[[ "${NIGHTSHIFT_TESTING:-}" == "true" ]] && return 0 2>/dev/null
 
 # ─── Entrypoint ───────────────────────────────────────────────────────────────
 

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run all nightshift tests
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOTAL_SUITES=0
+FAILED_SUITES=0
+
+for test_file in "$SCRIPT_DIR"/test_*.bash; do
+  [ -f "$test_file" ] || continue
+  TOTAL_SUITES=$((TOTAL_SUITES + 1))
+  echo ""
+  echo "Running $(basename "$test_file")..."
+  echo ""
+  if bash "$test_file"; then
+    echo "  >> SUITE PASSED"
+  else
+    echo "  >> SUITE FAILED"
+    FAILED_SUITES=$((FAILED_SUITES + 1))
+  fi
+done
+
+echo ""
+echo "=============================="
+echo "Test suites: $((TOTAL_SUITES - FAILED_SUITES))/$TOTAL_SUITES passed"
+if [ "$FAILED_SUITES" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Test helper — shared setup for nightshift tests
+
+set -euo pipefail
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_TOTAL=0
+
+# Source nightshift.sh in test mode (stops before entrypoint)
+export NIGHTSHIFT_TESTING=true
+export LINEAR_API_KEY="test-key"
+export REPO_PATH="/tmp/nightshift-test-repo"
+export MAIN_BRANCH="main"
+export LOG_DIR="/tmp/nightshift-test-logs"
+export WORKTREE_BASE="/tmp/nightshift-test-worktrees"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/nightshift.sh"
+
+# ── Assertions ────────────────────────────────────────────────────────────────
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local msg="${3:-"expected '$expected', got '$actual'"}"
+  TESTS_TOTAL=$((TESTS_TOTAL + 1))
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $msg"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "  FAIL: $msg"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="${3:-"output should contain '$needle'"}"
+  TESTS_TOTAL=$((TESTS_TOTAL + 1))
+  if echo "$haystack" | grep -qF -- "$needle"; then
+    echo "  PASS: $msg"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "  FAIL: $msg"
+    echo "    needle:   '$needle'"
+    echo "    haystack: '$haystack'"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="${3:-"output should NOT contain '$needle'"}"
+  TESTS_TOTAL=$((TESTS_TOTAL + 1))
+  if echo "$haystack" | grep -qF -- "$needle"; then
+    echo "  FAIL: $msg"
+    echo "    found:    '$needle'"
+    echo "    haystack: '$haystack'"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  else
+    echo "  PASS: $msg"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  fi
+}
+
+print_test_summary() {
+  echo ""
+  echo "Results: $TESTS_PASSED/$TESTS_TOTAL passed, $TESTS_FAILED failed"
+  [ "$TESTS_FAILED" -eq 0 ]
+}

--- a/tests/test_log_parsing.bash
+++ b/tests/test_log_parsing.bash
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Tests for log_offset + tail -c pattern (critical regression tests)
+#
+# The log file appends across attempts. Without log_offset, BLOCKED/rate-limit
+# from a previous attempt would be re-detected on subsequent attempts.
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/test_helper.bash"
+
+echo "=== Log Parsing Tests ==="
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+TMPLOG=$(mktemp)
+trap 'rm -f "$TMPLOG"' EXIT
+
+# ── Test: BLOCKED in old output is NOT detected ──────────────────────────────
+echo "--- BLOCKED detection with log_offset ---"
+
+# Simulate: first attempt wrote BLOCKED, second attempt is clean
+cat > "$TMPLOG" <<'EOF'
+--- Attempt 2024-01-01T00:00:00 ---
+DEBUG: pwd = /repo
+BLOCKED: Wrong repository
+--- Attempt 2024-01-01T01:00:00 ---
+DEBUG: pwd = /repo
+All done, implementation complete.
+EOF
+
+# log_offset points to just before the second attempt
+log_offset=$(echo -n "--- Attempt 2024-01-01T00:00:00 ---
+DEBUG: pwd = /repo
+BLOCKED: Wrong repository
+" | wc -c)
+
+current_output=$(tail -c +"$((log_offset + 1))" "$TMPLOG" 2>/dev/null || true)
+blocked_line=$(echo "$current_output" | grep -i "^BLOCKED:" | head -1 || true)
+
+assert_equals "" "$blocked_line" "BLOCKED in old output should NOT be detected"
+
+# ── Test: BLOCKED in new output IS detected ──────────────────────────────────
+
+cat > "$TMPLOG" <<'EOF'
+--- Attempt 2024-01-01T00:00:00 ---
+DEBUG: pwd = /repo
+All good first time.
+--- Attempt 2024-01-01T01:00:00 ---
+DEBUG: pwd = /repo
+BLOCKED: Missing API credentials
+EOF
+
+log_offset=$(echo -n "--- Attempt 2024-01-01T00:00:00 ---
+DEBUG: pwd = /repo
+All good first time.
+" | wc -c)
+
+current_output=$(tail -c +"$((log_offset + 1))" "$TMPLOG" 2>/dev/null || true)
+blocked_line=$(echo "$current_output" | grep -i "^BLOCKED:" | head -1 || true)
+
+assert_contains "$blocked_line" "BLOCKED: Missing API credentials" "BLOCKED in new output should be detected"
+
+# ── Test: rate limit in old output is NOT detected ───────────────────────────
+echo "--- Rate limit detection with log_offset ---"
+
+cat > "$TMPLOG" <<'EOF'
+--- Attempt 2024-01-01T00:00:00 ---
+Error: rate limit exceeded
+--- Attempt 2024-01-01T01:00:00 ---
+Implementation complete.
+EOF
+
+log_offset=$(echo -n "--- Attempt 2024-01-01T00:00:00 ---
+Error: rate limit exceeded
+" | wc -c)
+
+current_output=$(tail -c +"$((log_offset + 1))" "$TMPLOG" 2>/dev/null || true)
+rate_hit=""
+if echo "$current_output" | grep -qi "rate.limit\|usage.limit\|exceeded.*limit\|too many requests" 2>/dev/null; then
+  rate_hit="yes"
+fi
+
+assert_equals "" "$rate_hit" "rate limit in old output should NOT be detected"
+
+# ── Test: rate limit in new output IS detected ───────────────────────────────
+
+cat > "$TMPLOG" <<'EOF'
+--- Attempt 2024-01-01T00:00:00 ---
+All good.
+--- Attempt 2024-01-01T01:00:00 ---
+Error: too many requests
+EOF
+
+log_offset=$(echo -n "--- Attempt 2024-01-01T00:00:00 ---
+All good.
+" | wc -c)
+
+current_output=$(tail -c +"$((log_offset + 1))" "$TMPLOG" 2>/dev/null || true)
+rate_hit=""
+if echo "$current_output" | grep -qi "rate.limit\|usage.limit\|exceeded.*limit\|too many requests" 2>/dev/null; then
+  rate_hit="yes"
+fi
+
+assert_equals "yes" "$rate_hit" "rate limit in new output should be detected"
+
+print_test_summary

--- a/tests/test_pr_summary.bash
+++ b/tests/test_pr_summary.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Tests for PR summary extraction logic
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/test_helper.bash"
+
+echo "=== PR Summary Tests ==="
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+TMPLOG=$(mktemp)
+trap 'rm -f "$TMPLOG"' EXIT
+
+# ── Test: DEBUG lines are stripped ────────────────────────────────────────────
+echo "--- DEBUG line stripping ---"
+
+cat > "$TMPLOG" <<'EOF'
+--- Attempt 2024-01-01T00:00:00 ---
+DEBUG: pwd = /repo
+DEBUG: branch = nightshift/eng-42
+Here is the summary of changes.
+Added a new feature.
+EOF
+
+summary=$(awk '/^--- Attempt /{buf=""; next} {buf = buf $0 "\n"} END{printf "%s", buf}' "$TMPLOG" 2>/dev/null \
+  | grep -v '^DEBUG: ' \
+  | tail -n 40 || true)
+
+assert_not_contains "$summary" "DEBUG:" "summary should not contain DEBUG lines"
+assert_contains "$summary" "Added a new feature" "summary should contain actual content"
+
+# ── Test: only content after last attempt marker is used ─────────────────────
+echo "--- last attempt extraction ---"
+
+cat > "$TMPLOG" <<'EOF'
+--- Attempt 2024-01-01T00:00:00 ---
+First attempt output that should be ignored.
+--- Attempt 2024-01-01T01:00:00 ---
+DEBUG: pwd = /repo
+Second attempt — this is the real summary.
+EOF
+
+summary=$(awk '/^--- Attempt /{buf=""; next} {buf = buf $0 "\n"} END{printf "%s", buf}' "$TMPLOG" 2>/dev/null \
+  | grep -v '^DEBUG: ' \
+  | tail -n 40 || true)
+
+assert_not_contains "$summary" "First attempt" "summary should not contain first attempt output"
+assert_contains "$summary" "Second attempt" "summary should contain last attempt output"
+
+# ── Test: attempt markers are not in the summary ─────────────────────────────
+echo "--- attempt marker exclusion ---"
+
+assert_not_contains "$summary" "--- Attempt" "summary should not contain attempt markers"
+
+print_test_summary

--- a/tests/test_worktree.bash
+++ b/tests/test_worktree.bash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tests for worktree creation and cleanup
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/test_helper.bash"
+
+echo "=== Worktree Tests ==="
+
+# ── Setup: create a temporary bare-ish repo to act as REPO_PATH ──────────────
+TEST_REPO=$(mktemp -d)
+WORKTREE_BASE=$(mktemp -d)
+trap 'rm -rf "$TEST_REPO" "$WORKTREE_BASE"' EXIT
+
+# Initialize a repo with at least one commit
+git -C "$TEST_REPO" init -b main --quiet
+git -C "$TEST_REPO" config user.email "test@test.com"
+git -C "$TEST_REPO" config user.name "Test"
+echo "init" > "$TEST_REPO/README.md"
+git -C "$TEST_REPO" add -A
+git -C "$TEST_REPO" commit -m "init" --quiet
+
+# create_worktree needs origin/main, so set up a local remote
+git -C "$TEST_REPO" remote add origin "$TEST_REPO" 2>/dev/null || true
+git -C "$TEST_REPO" fetch origin --quiet 2>/dev/null || true
+
+# Override globals for tests
+REPO_PATH="$TEST_REPO"
+MAIN_BRANCH="main"
+
+# ── Test: create_worktree returns a clean path ───────────────────────────────
+echo "--- create_worktree output ---"
+
+result=$(create_worktree "ENG-100")
+assert_contains "$result" "$WORKTREE_BASE/ENG-100" "worktree path should contain identifier"
+assert_not_contains "$result" "Preparing" "output should not contain git noise"
+
+# ── Test: worktree directory actually exists ─────────────────────────────────
+echo "--- worktree directory existence ---"
+
+if [ -d "$result" ]; then
+  dir_exists="yes"
+else
+  dir_exists="no"
+fi
+assert_equals "yes" "$dir_exists" "worktree directory should exist after creation"
+
+# Verify the branch is correct inside the worktree
+branch_in_worktree=$(git -C "$result" branch --show-current 2>/dev/null)
+assert_equals "nightshift/eng-100" "$branch_in_worktree" "worktree should be on the correct branch"
+
+# ── Test: cleanup_worktree removes the worktree ─────────────────────────────
+echo "--- cleanup_worktree ---"
+
+cleanup_worktree "ENG-100"
+if [ -d "$WORKTREE_BASE/ENG-100" ]; then
+  cleanup_worked="no"
+else
+  cleanup_worked="yes"
+fi
+assert_equals "yes" "$cleanup_worked" "worktree directory should be removed after cleanup"
+
+# ── Test: create_worktree fails gracefully on bad repo ───────────────────────
+echo "--- create_worktree with bad repo ---"
+
+REPO_PATH="/nonexistent/path"
+result=""
+if result=$(create_worktree "ENG-999" 2>/dev/null); then
+  bad_repo_handled="no"
+else
+  bad_repo_handled="yes"
+fi
+assert_equals "yes" "$bad_repo_handled" "create_worktree should fail on bad repo path"
+
+print_test_summary


### PR DESCRIPTION
## Summary

- **Restore worktree isolation** for `MAX_CONCURRENT > 1` — each ticket gets its own worktree at `~/.nightshift-worktrees/<ID>` instead of sharing `REPO_PATH`
- **Add plain-bash test suite** (15 tests across 4 suites) covering log_offset parsing, worktree lifecycle, and PR summary extraction
- **Create CLAUDE.md** with architecture docs, key functions, and the log_offset bug fix warning
- **Remove dead `IN_PROGRESS_STATE` code** (config, global, resolution, validation)
- **Update docs** — TROUBLESHOOTING.md and .env.example updated for worktrees and removed IN_PROGRESS_STATE

## Test plan

- [x] `bash -n nightshift.sh` — no parse errors
- [x] `bash tests/run_tests.bash` — all 15 tests pass
- [ ] Manual: verify `create_worktree` returns a clean path with no git noise
- [ ] Manual: trace `worktree_path` through `process_ticket` confirming cwd is correct at each step
- [ ] Manual: confirm `log_offset + tail -c` pattern is preserved for BLOCKED/rate-limit checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)