### PR TITLE
ENG-167: Multi-repo support via repo:<key> Linear labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,11 +23,25 @@ IN_REVIEW_STATE=In Review
 
 # ── Repository ────────────────────────────────────────────────────────────────
 
-# Absolute path to the git repository Nightshift will work in
+# Nightshift can work on a single repo, many repos, or both.
+#
+# Single repo: set REPO_PATH below. Every ticket without a repo label uses it.
+#
+# Many repos: create repos.json (copy repos.example.json) mapping a short key
+# to a git URL. Add a "repo:<key>" label to a Linear ticket and Nightshift
+# clones that repo on demand and works there — no need to edit this file when
+# switching projects. REPO_PATH then acts as the fallback for unlabelled tickets.
+
+# Absolute path to the default git repository.
+# Optional if repos.json defines at least one repo.
 REPO_PATH=/path/to/your/repo
 
-# Base branch for new branches and PRs
+# Base branch for new branches and PRs (per-repo branches can override this
+# via the "branch" field in repos.json)
 MAIN_BRANCH=main
+
+# Path to the multi-repo map. Defaults to repos.json next to nightshift.sh.
+# REPOS_FILE=/path/to/repos.json
 
 # ── Agent ─────────────────────────────────────────────────────────────────────
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Environment — contains secrets
 .env
 
+# Multi-repo map — user-specific repo list
+repos.json
+
 # Agent logs — runtime output
 .agent-logs/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Autonomous Linear-to-PR agent. Polls Linear for tickets in a trigger state, disp
 
 ```
 main loop (poll) → fetch_trigger_issues → process_ticket (background subshell per ticket)
-  → create_worktree → run_claude → check output → commit/push → gh pr create → linear update
+  → resolve_repo → create_worktree → run_claude → check output → commit/push → gh pr create → linear update
 ```
 
 Worktrees are created at `~/.nightshift-worktrees/<IDENTIFIER>` so multiple tickets can run concurrently without sharing a working directory.
@@ -15,18 +15,32 @@ Worktrees are created at `~/.nightshift-worktrees/<IDENTIFIER>` so multiple tick
 
 | Function | Purpose |
 |----------|---------|
-| `create_worktree` | Creates git worktree + branch from latest main |
+| `resolve_repo` | Picks the target repo for a ticket from its `repo:<key>` label; echoes `path<TAB>branch` |
+| `repo_key_from_labels` | Extracts the `repo:` key from a ticket's label list |
+| `ensure_repo_clone` | Clones a repo on first use (fetches after) into `REPO_CACHE_BASE`, lock-guarded |
+| `create_worktree` | Creates git worktree + branch from latest main (takes `repo_path`, `branch` params) |
 | `cleanup_worktree` | Removes worktree via `git worktree remove --force` |
 | `run_claude` | Invokes `claude --print` with timeout; takes `workdir` as first param |
-| `process_ticket` | Full lifecycle: worktree → claude → review → commit → PR → Linear update |
+| `process_ticket` | Full lifecycle: resolve repo → worktree → claude → review → commit → PR → Linear update |
 | `build_prompt` | Generates the prompt from ticket metadata |
 | `gemini_review` | Optional second-model review gate |
-| `fetch_trigger_issues` | Queries Linear GraphQL for tickets in trigger state |
+| `fetch_trigger_issues` | Queries Linear GraphQL for tickets in trigger state (includes labels) |
+
+## Multi-Repo Routing
+
+A ticket targets a repo via a Linear label `repo:<key>`. Keys are defined in
+`repos.json` (see `repos.example.json`), mapping each key to a git URL and
+optional base branch. `resolve_repo` reads the label, and `ensure_repo_clone`
+clones the repo on demand into `~/.nightshift-repos/<key>` (reused after).
+A ticket with no `repo:` label falls back to `REPO_PATH`, so single-repo
+setups are unaffected. Concurrent tickets for the same repo are serialised by
+an atomic-`mkdir` lock under `REPO_CACHE_BASE/.locks` (cleared at startup).
 
 ## Configuration
 
 Copy `.env.example` to `.env`. All config is documented there. Key variables:
-- `REPO_PATH` — absolute path to the target repo
+- `REPO_PATH` — absolute path to the default repo (fallback for unlabelled tickets)
+- `REPOS_FILE` — path to `repos.json` for label-based multi-repo routing
 - `LINEAR_API_KEY`, `LINEAR_TEAM_KEY` — Linear access
 - `MAX_CONCURRENT` — number of parallel tickets (each gets its own worktree)
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ All config lives in `.env`. Copy `.env.example` to get started.
 | `TRIGGER_STATE` | `Next` | Linear column to watch for new work |
 | `IN_PROGRESS_STATE` | `In Progress` | State set when Nightshift picks up a ticket |
 | `IN_REVIEW_STATE` | `In Review` | State set after PR is created |
-| `REPO_PATH` | *(required)* | Absolute path to your git repository |
+| `REPO_PATH` | *(required\*)* | Absolute path to the default git repository |
 | `MAIN_BRANCH` | `main` | Base branch for new PRs |
+| `REPOS_FILE` | `repos.json` | Multi-repo map — route tickets to repos with `repo:<key>` labels |
 | `MAX_CONCURRENT` | `3` | Maximum tickets processed simultaneously |
 | `POLL_INTERVAL` | `30` | Seconds between Linear polls |
 | `USE_AGENT_TEAMS` | `false` | Enable Claude Code Agent Teams (multi-agent parallelism) |
@@ -102,6 +103,39 @@ All config lives in `.env`. Copy `.env.example` to get started.
 | `MAX_REVIEW_RETRIES` | `1` | Fix passes Claude gets after Gemini flags issues |
 
 State names are **case-sensitive** and must match your Linear board exactly.
+
+\* `REPO_PATH` is required unless `repos.json` defines at least one repo — see below.
+
+---
+
+## Working on multiple repos
+
+By default Nightshift works on the single repo at `REPO_PATH`. To let one
+Nightshift instance serve **any** repo — without editing `.env` when you switch
+projects — use a repos file and Linear labels.
+
+1. Copy `repos.example.json` to `repos.json` and map a short key to each repo:
+
+   ```json
+   {
+     "my-app":       { "url": "git@github.com:you/my-app.git",       "branch": "main" },
+     "side-project": { "url": "https://github.com/you/side-project.git", "branch": "master" }
+   }
+   ```
+
+2. In Linear, create a label named `repo:my-app` (matching a key above) and add
+   it to a ticket. When you move that ticket to your trigger state, Nightshift
+   reads the label, clones the repo on demand into `~/.nightshift-repos/`, and
+   works there.
+
+Tickets **without** a `repo:` label fall back to `REPO_PATH`, so existing
+single-repo setups keep working unchanged. The polling/cron trigger is
+unchanged — only the repo each ticket targets is now decided per ticket.
+
+Notes:
+- The `branch` field is optional and defaults to `MAIN_BRANCH`.
+- Repo keys are case-sensitive and must match the label exactly after `repo:`.
+- A repo is cloned once and reused; later tickets just fetch the latest base branch.
 
 ---
 
@@ -249,17 +283,11 @@ Nightshift creates PRs — it doesn't merge them. You review and merge manually.
 
 ### Can I run multiple repos simultaneously?
 
-Yes. Run separate instances of `nightshift.sh` with separate `.env` files pointing to different repos.
-
-```bash
-# Terminal 1
-NIGHTSHIFT_ENV=/path/to/repo-a/.nightshift.env ./nightshift.sh
-
-# Terminal 2
-NIGHTSHIFT_ENV=/path/to/repo-b/.nightshift.env ./nightshift.sh
-```
-
-Or just copy the nightshift directory for each repo and configure `.env` separately.
+Yes — a single Nightshift instance can serve any number of repos. Create a
+`repos.json` and add a `repo:<key>` label to each ticket. See
+[Working on multiple repos](#working-on-multiple-repos). Tickets for different
+repos are processed concurrently, each in its own worktree, up to
+`MAX_CONCURRENT`.
 
 ### What if Claude gets stuck?
 

--- a/nightshift.sh
+++ b/nightshift.sh
@@ -440,6 +440,31 @@ resolve_repo() {
   printf '%s\t%s\n' "$dir" "$branch"
 }
 
+# Determine a repo's default branch for cleanup purposes.
+# Prefers the branch declared in repos.json (for on-demand clones), then the
+# remote's own default via origin/HEAD, then the global MAIN_BRANCH.
+default_branch_for_repo() {
+  local repo="$1"
+  local branch=""
+
+  # On-demand clones live at $REPO_CACHE_BASE/<key> — look the key up.
+  case "$repo" in
+    "$REPO_CACHE_BASE"/*)
+      if [ -f "$REPOS_FILE" ]; then
+        branch=$(jq -r --arg k "$(basename "$repo")" '.[$k].branch // empty' \
+          "$REPOS_FILE" 2>/dev/null || true)
+      fi
+      ;;
+  esac
+
+  if [ -z "$branch" ]; then
+    branch=$(git -C "$repo" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null \
+      | sed 's#^origin/##' || true)
+  fi
+
+  echo "${branch:-$MAIN_BRANCH}"
+}
+
 # ─── Worktree Management ──────────────────────────────────────────────────────
 
 branch_name_for() {
@@ -540,10 +565,14 @@ run_cleanup() {
   for repo in "${repo_dirs[@]}"; do
     echo "📁 $repo"
 
+    # Each repo may use a different default branch (main, master, trunk…).
+    local base_branch
+    base_branch=$(default_branch_for_repo "$repo")
+
     # Merged local branches
     local merged_branches=()
-    mapfile -t merged_branches < <(git -C "$repo" branch --merged "$MAIN_BRANCH" 2>/dev/null \
-      | grep -vE "^\*|main|staging|master" \
+    mapfile -t merged_branches < <(git -C "$repo" branch --merged "origin/$base_branch" 2>/dev/null \
+      | grep -vE "^\*|main|staging|master|$base_branch" \
       | sed 's/^[[:space:]]*//' || true)
 
     if [ "${#merged_branches[@]}" -gt 0 ]; then
@@ -559,7 +588,7 @@ run_cleanup() {
 
     # Unmerged nightshift branches
     local unmerged=""
-    unmerged=$(git -C "$repo" branch --no-merged "$MAIN_BRANCH" 2>/dev/null \
+    unmerged=$(git -C "$repo" branch --no-merged "origin/$base_branch" 2>/dev/null \
       | grep -E "nightshift/" \
       | sed 's/^[[:space:]]*//' || true)
 

--- a/nightshift.sh
+++ b/nightshift.sh
@@ -43,6 +43,7 @@ TRIGGER_STATE="${TRIGGER_STATE:-Next}"
 IN_REVIEW_STATE="${IN_REVIEW_STATE:-In Review}"
 REPO_PATH="${REPO_PATH:-}"
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
+REPOS_FILE="${REPOS_FILE:-$SCRIPT_DIR/repos.json}"
 MAX_CONCURRENT="${MAX_CONCURRENT:-3}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
 USE_AGENT_TEAMS="${USE_AGENT_TEAMS:-false}"
@@ -63,6 +64,7 @@ TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-}"
 # Paths
 LOG_DIR="$SCRIPT_DIR/.agent-logs"
 WORKTREE_BASE="$HOME/.nightshift-worktrees"
+REPO_CACHE_BASE="$HOME/.nightshift-repos"
 
 # ─── Global State ────────────────────────────────────────────────────────────
 
@@ -89,11 +91,25 @@ validate_config() {
     errors=$((errors + 1))
   fi
 
-  if [ -z "$REPO_PATH" ]; then
-    echo "❌ REPO_PATH is required — set it in .env" >&2
-    errors=$((errors + 1))
-  elif [ ! -d "$REPO_PATH/.git" ]; then
-    echo "❌ REPO_PATH ($REPO_PATH) is not a git repository" >&2
+  # A repo can be supplied two ways: a default REPO_PATH, or a repos file
+  # mapping `repo:<key>` labels to git URLs. At least one must be usable.
+  local repos_ok=false
+  if [ -f "$REPOS_FILE" ]; then
+    if jq -e 'type == "object" and length > 0' "$REPOS_FILE" >/dev/null 2>&1; then
+      repos_ok=true
+    else
+      echo "❌ REPOS_FILE ($REPOS_FILE) must be a non-empty JSON object — see repos.example.json" >&2
+      errors=$((errors + 1))
+    fi
+  fi
+
+  if [ -n "$REPO_PATH" ]; then
+    if [ ! -d "$REPO_PATH/.git" ]; then
+      echo "❌ REPO_PATH ($REPO_PATH) is not a git repository" >&2
+      errors=$((errors + 1))
+    fi
+  elif [ "$repos_ok" != true ]; then
+    echo "❌ No repository configured — set REPO_PATH in .env or add repos to $REPOS_FILE" >&2
     errors=$((errors + 1))
   fi
 
@@ -210,7 +226,7 @@ fetch_trigger_issues() {
   # Inline the state name directly — no GraphQL variables, no escaping layers.
   local payload response
   payload=$(jq -n --arg state "$TRIGGER_STATE" \
-    '{"query": ("{ teams { nodes { issues(filter: { state: { name: { eq: \"" + $state + "\" } } }, orderBy: updatedAt, first: 20) { nodes { id identifier title description url } } } } }")}')
+    '{"query": ("{ teams { nodes { issues(filter: { state: { name: { eq: \"" + $state + "\" } } }, orderBy: updatedAt, first: 20) { nodes { id identifier title description url labels { nodes { name } } } } } } }")}')
 
   response=$(curl -s -X POST \
     -H "Content-Type: application/json" \
@@ -325,6 +341,105 @@ Then provide your review comments."
   fi
 }
 
+# ─── Repository Resolution ────────────────────────────────────────────────────
+
+# Extract the repo key from a ticket's labels.
+# Looks for a label of the form "repo:<key>" (case-insensitive prefix).
+# Echoes the key, or nothing if no such label exists.
+repo_key_from_labels() {
+  local labels="$1"
+  printf '%s\n' "$labels" \
+    | grep -iE '^[[:space:]]*repo:' \
+    | head -1 \
+    | sed -E 's/^[[:space:]]*[Rr][Ee][Pp][Oo]:[[:space:]]*//' \
+    | sed -E 's/[[:space:]]+$//'
+}
+
+# Clone a repo on first use, fetch it on subsequent uses.
+# A per-repo lock (atomic mkdir) serialises concurrent tickets for the same repo.
+# Echoes the local clone path on success.
+ensure_repo_clone() {
+  local key="$1"
+  local url="$2"
+  local dir="$REPO_CACHE_BASE/$key"
+  local lock_dir="$REPO_CACHE_BASE/.locks"
+  local lock="$lock_dir/$key"
+
+  mkdir -p "$lock_dir"
+
+  # Acquire the lock — mkdir is atomic, so only one process wins.
+  # Stale locks are cleared at startup, so a bounded wait is safe.
+  local waited=0
+  while ! mkdir "$lock" 2>/dev/null; do
+    sleep 2
+    waited=$((waited + 2))
+    if [ "$waited" -ge 300 ]; then
+      echo "timed out waiting for repo lock: $key" >&2
+      return 1
+    fi
+  done
+
+  local rc=0
+  if [ -d "$dir/.git" ]; then
+    git -C "$dir" fetch origin --prune --quiet >/dev/null 2>&1 || true
+  else
+    if ! git clone --quiet "$url" "$dir" >/dev/null 2>&1; then
+      rm -rf "$dir"
+      rc=1
+    fi
+  fi
+
+  rmdir "$lock" 2>/dev/null || true
+  [ "$rc" -eq 0 ] || return 1
+  echo "$dir"
+}
+
+# Resolve which repo a ticket targets, based on its labels.
+# Echoes "<repo_path><TAB><branch>" on success.
+# On failure, prints a human-readable reason to stderr and returns 1.
+resolve_repo() {
+  local identifier="$1"
+  local labels="$2"
+
+  local key
+  key=$(repo_key_from_labels "$labels")
+
+  # No repo: label — fall back to the default REPO_PATH.
+  if [ -z "$key" ]; then
+    if [ -z "$REPO_PATH" ]; then
+      echo "Ticket has no \`repo:\` label and no default REPO_PATH is configured." >&2
+      return 1
+    fi
+    printf '%s\t%s\n' "$REPO_PATH" "$MAIN_BRANCH"
+    return 0
+  fi
+
+  if [ ! -f "$REPOS_FILE" ]; then
+    echo "Ticket is labelled \`repo:${key}\` but no repos file exists at ${REPOS_FILE}." >&2
+    return 1
+  fi
+
+  local url branch
+  url=$(jq -r --arg k "$key" '.[$k].url // empty' "$REPOS_FILE" 2>/dev/null || true)
+  branch=$(jq -r --arg k "$key" '.[$k].branch // empty' "$REPOS_FILE" 2>/dev/null || true)
+
+  if [ -z "$url" ]; then
+    local available
+    available=$(jq -r 'keys | join(", ")' "$REPOS_FILE" 2>/dev/null || true)
+    echo "Repo key \`${key}\` is not defined in ${REPOS_FILE}. Known repos: ${available:-none}." >&2
+    return 1
+  fi
+  [ -z "$branch" ] && branch="$MAIN_BRANCH"
+
+  local dir
+  if ! dir=$(ensure_repo_clone "$key" "$url"); then
+    echo "Failed to clone or update repo \`${key}\` from ${url}." >&2
+    return 1
+  fi
+
+  printf '%s\t%s\n' "$dir" "$branch"
+}
+
 # ─── Worktree Management ──────────────────────────────────────────────────────
 
 branch_name_for() {
@@ -333,14 +448,16 @@ branch_name_for() {
 
 create_worktree() {
   local identifier="$1"
+  local repo_path="${2:-$REPO_PATH}"
+  local main_branch="${3:-$MAIN_BRANCH}"
   local branch_name
   branch_name=$(branch_name_for "$identifier")
   local worktree_path="$WORKTREE_BASE/$identifier"
 
   (
-    cd "$REPO_PATH" || { echo "Cannot cd to REPO_PATH: $REPO_PATH" >&2; return 1; }
+    cd "$repo_path" || { echo "Cannot cd to repo: $repo_path" >&2; return 1; }
 
-    git fetch origin "$MAIN_BRANCH" --quiet >/dev/null 2>&1 || true
+    git fetch origin "$main_branch" --quiet >/dev/null 2>&1 || true
 
     # Remove stale local branch if exists
     git branch -D "$branch_name" >/dev/null 2>&1 || true
@@ -349,7 +466,7 @@ create_worktree() {
     git worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
 
     # Create worktree with a new branch from latest main
-    if ! git worktree add -b "$branch_name" "$worktree_path" "origin/$MAIN_BRANCH" >/dev/null 2>&1; then
+    if ! git worktree add -b "$branch_name" "$worktree_path" "origin/$main_branch" >/dev/null 2>&1; then
       echo "git worktree add failed for: $worktree_path" >&2
       return 1
     fi
@@ -360,13 +477,14 @@ create_worktree() {
 
 cleanup_worktree() {
   local identifier="$1"
+  local repo_path="${2:-$REPO_PATH}"
   local worktree_path="$WORKTREE_BASE/$identifier"
 
   if [ -z "$identifier" ]; then
     return
   fi
 
-  git -C "$REPO_PATH" worktree remove --force "$worktree_path" >/dev/null 2>&1 || rm -rf "$worktree_path"
+  git -C "$repo_path" worktree remove --force "$worktree_path" >/dev/null 2>&1 || rm -rf "$worktree_path"
 }
 
 # ─── Cleanup ────────────────────────────────────────────────────────────────
@@ -374,8 +492,18 @@ cleanup_worktree() {
 # Lightweight cleanup run silently on every startup
 startup_cleanup() {
   log "Running startup cleanup..."
-  git -C "$REPO_PATH" fetch --prune 2>/dev/null || true
-  git -C "$REPO_PATH" worktree prune 2>/dev/null || true
+  if [ -n "$REPO_PATH" ]; then
+    git -C "$REPO_PATH" fetch --prune 2>/dev/null || true
+    git -C "$REPO_PATH" worktree prune 2>/dev/null || true
+  fi
+  # Stale per-repo clone locks — nothing holds them at startup, so clear them.
+  rm -rf "$REPO_CACHE_BASE/.locks" 2>/dev/null || true
+  # Prune dangling worktree refs in every cached repo.
+  if [ -d "$REPO_CACHE_BASE" ]; then
+    for d in "$REPO_CACHE_BASE"/*/; do
+      [ -d "${d}.git" ] && git -C "$d" worktree prune 2>/dev/null || true
+    done
+  fi
   log "✅ Startup cleanup done"
 }
 
@@ -390,75 +518,90 @@ run_cleanup() {
   echo "🧹 Nightshift Cleanup"
   echo ""
 
-  # ── Validate REPO_PATH ────────────────────────────────────────────────────
-  if [ -z "$REPO_PATH" ]; then
-    echo "❌ REPO_PATH is required — set it in .env" >&2
-    exit 1
-  elif [ ! -d "$REPO_PATH/.git" ]; then
-    echo "❌ REPO_PATH ($REPO_PATH) is not a git repository" >&2
+  # ── Gather repositories to clean ──────────────────────────────────────────
+  # The default REPO_PATH plus every on-demand clone under REPO_CACHE_BASE.
+  local repo_dirs=()
+  local d repo branch
+  if [ -n "$REPO_PATH" ] && [ -d "$REPO_PATH/.git" ]; then
+    repo_dirs+=("$REPO_PATH")
+  fi
+  if [ -d "$REPO_CACHE_BASE" ]; then
+    for d in "$REPO_CACHE_BASE"/*/; do
+      [ -d "${d}.git" ] && repo_dirs+=("${d%/}")
+    done
+  fi
+
+  if [ "${#repo_dirs[@]}" -eq 0 ]; then
+    echo "❌ No repositories found — set REPO_PATH in .env, or let Nightshift clone repos via labels first." >&2
     exit 1
   fi
 
-  # ── Merged local branches ─────────────────────────────────────────────────
-  local merged_branches=()
-  mapfile -t merged_branches < <(git -C "$REPO_PATH" branch --merged "$MAIN_BRANCH" 2>/dev/null \
-    | grep -vE "^\*|main|staging|master" \
-    | sed 's/^[[:space:]]*//' || true)
+  # ── Per-repo branch cleanup ───────────────────────────────────────────────
+  for repo in "${repo_dirs[@]}"; do
+    echo "📁 $repo"
 
-  if [ "${#merged_branches[@]}" -gt 0 ]; then
-    echo "Merged branches to delete (${#merged_branches[@]}):"
-    printf "  - %s\n" "${merged_branches[@]}"
+    # Merged local branches
+    local merged_branches=()
+    mapfile -t merged_branches < <(git -C "$repo" branch --merged "$MAIN_BRANCH" 2>/dev/null \
+      | grep -vE "^\*|main|staging|master" \
+      | sed 's/^[[:space:]]*//' || true)
 
-    if [ "$force" = true ] || confirm "Delete these merged branches?"; then
-      for branch in "${merged_branches[@]}"; do
-        git -C "$REPO_PATH" branch -d "$branch" 2>/dev/null && merged_deleted=$((merged_deleted + 1))
-      done
-    fi
-    echo ""
-  fi
+    if [ "${#merged_branches[@]}" -gt 0 ]; then
+      echo "Merged branches to delete (${#merged_branches[@]}):"
+      printf "  - %s\n" "${merged_branches[@]}"
 
-  # ── Unmerged nightshift branches ──────────────────────────────────────────
-  local unmerged=""
-  unmerged=$(git -C "$REPO_PATH" branch --no-merged "$MAIN_BRANCH" 2>/dev/null \
-    | grep -E "nightshift/" \
-    | sed 's/^[[:space:]]*//' || true)
-
-  if [ -n "$unmerged" ]; then
-    echo "⚠️  Unmerged Nightshift branches (from failed runs):"
-    echo "$unmerged" | while IFS= read -r b; do echo "  - $b"; done
-
-    # Check for open PRs before deleting
-    local safe_to_delete=()
-    local has_open_pr=()
-    while IFS= read -r branch; do
-      [ -z "$branch" ] && continue
-      local pr_count
-      pr_count=$(gh pr list --repo "$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null)" \
-        --head "$branch" --state open --json number 2>/dev/null \
-        | jq 'length' 2>/dev/null || echo "0")
-      if [ "$pr_count" -gt 0 ]; then
-        has_open_pr+=("$branch")
-      else
-        safe_to_delete+=("$branch")
-      fi
-    done <<< "$unmerged"
-
-    if [ "${#has_open_pr[@]}" -gt 0 ]; then
-      echo ""
-      echo "  Skipping (have open PRs):"
-      for b in "${has_open_pr[@]}"; do echo "    - $b"; done
-    fi
-
-    if [ "${#safe_to_delete[@]}" -gt 0 ]; then
-      echo ""
-      if [ "$force" = true ] || confirm "Force-delete ${#safe_to_delete[@]} unmerged branch(es) without open PRs?"; then
-        for branch in "${safe_to_delete[@]}"; do
-          git -C "$REPO_PATH" branch -D "$branch" 2>/dev/null && unmerged_deleted=$((unmerged_deleted + 1))
+      if [ "$force" = true ] || confirm "Delete these merged branches?"; then
+        for branch in "${merged_branches[@]}"; do
+          git -C "$repo" branch -d "$branch" 2>/dev/null && merged_deleted=$((merged_deleted + 1))
         done
       fi
     fi
+
+    # Unmerged nightshift branches
+    local unmerged=""
+    unmerged=$(git -C "$repo" branch --no-merged "$MAIN_BRANCH" 2>/dev/null \
+      | grep -E "nightshift/" \
+      | sed 's/^[[:space:]]*//' || true)
+
+    if [ -n "$unmerged" ]; then
+      echo "⚠️  Unmerged Nightshift branches (from failed runs):"
+      echo "$unmerged" | while IFS= read -r b; do echo "  - $b"; done
+
+      # Check for open PRs before deleting
+      local safe_to_delete=()
+      local has_open_pr=()
+      while IFS= read -r branch; do
+        [ -z "$branch" ] && continue
+        local pr_count
+        pr_count=$(gh pr list --repo "$(git -C "$repo" remote get-url origin 2>/dev/null)" \
+          --head "$branch" --state open --json number 2>/dev/null \
+          | jq 'length' 2>/dev/null || echo "0")
+        if [ "$pr_count" -gt 0 ]; then
+          has_open_pr+=("$branch")
+        else
+          safe_to_delete+=("$branch")
+        fi
+      done <<< "$unmerged"
+
+      if [ "${#has_open_pr[@]}" -gt 0 ]; then
+        echo "  Skipping (have open PRs):"
+        for b in "${has_open_pr[@]}"; do echo "    - $b"; done
+      fi
+
+      if [ "${#safe_to_delete[@]}" -gt 0 ]; then
+        if [ "$force" = true ] || confirm "Force-delete ${#safe_to_delete[@]} unmerged branch(es) without open PRs?"; then
+          for branch in "${safe_to_delete[@]}"; do
+            git -C "$repo" branch -D "$branch" 2>/dev/null && unmerged_deleted=$((unmerged_deleted + 1))
+          done
+        fi
+      fi
+    fi
+
+    # Prune dangling worktree refs + stale remote tracking refs
+    git -C "$repo" worktree prune 2>/dev/null || true
+    git -C "$repo" fetch --prune 2>/dev/null || true
     echo ""
-  fi
+  done
 
   # ── Stale worktrees ───────────────────────────────────────────────────────
   if [ -d "$WORKTREE_BASE" ]; then
@@ -473,18 +616,18 @@ run_cleanup() {
 
       if [ "$force" = true ] || confirm "Remove these worktrees?"; then
         for d in "${worktree_dirs[@]}"; do
-          git -C "$REPO_PATH" worktree remove --force "$d" 2>/dev/null || rm -rf "$d"
+          rm -rf "$d"
+        done
+        for repo in "${repo_dirs[@]}"; do
+          git -C "$repo" worktree prune 2>/dev/null || true
         done
       fi
       echo ""
     fi
-    git -C "$REPO_PATH" worktree prune 2>/dev/null || true
   fi
 
-  # ── Prune remote tracking refs ────────────────────────────────────────────
-  echo "Pruning stale remote tracking refs..."
-  git -C "$REPO_PATH" fetch --prune 2>/dev/null || true
-  echo ""
+  # ── Stale repo clone locks ────────────────────────────────────────────────
+  rm -rf "$REPO_CACHE_BASE/.locks" 2>/dev/null || true
 
   # ── Old agent logs (>7 days) ──────────────────────────────────────────────
   if [ -d "$LOG_DIR" ]; then
@@ -617,12 +760,13 @@ PROMPT
 process_ticket() {
   local issue_json="$1"
 
-  local issue_id identifier title description url
+  local issue_id identifier title description url labels
   issue_id=$(echo "$issue_json"    | jq -r '.id')
   identifier=$(echo "$issue_json"  | jq -r '.identifier')
   title=$(echo "$issue_json"       | jq -r '.title')
   description=$(echo "$issue_json" | jq -r '.description // "No description provided."')
   url=$(echo "$issue_json"         | jq -r '.url')
+  labels=$(echo "$issue_json"      | jq -r '.labels.nodes[]?.name // empty' 2>/dev/null || true)
 
   local log_file="$LOG_DIR/${identifier}.log"
   echo "--- Attempt $(date -Iseconds) ---" >> "$log_file"
@@ -630,12 +774,32 @@ process_ticket() {
   tlog "$identifier" "Starting: $title"
   tlog "$identifier" "Log: $log_file"
 
+  # ── Resolve Target Repo ────────────────────────────────────────────────────
+  # A `repo:<key>` label routes the ticket to a repo in $REPOS_FILE.
+  # With no such label, Nightshift falls back to the default REPO_PATH.
+  local repo_info repo_path main_branch
+  if ! repo_info=$(resolve_repo "$identifier" "$labels" 2>&1); then
+    tlog "$identifier" "❌ Repo resolution failed: $repo_info"
+    linear_set_state "$issue_id" "$STATE_ID_TRIGGER" 2>/dev/null || true
+    linear_comment "$issue_id" "❌ **Nightshift: Could not pick a repository**
+
+${repo_info}
+
+Add a \`repo:<key>\` label matching an entry in your repos file, then move the ticket back to **${TRIGGER_STATE}**." 2>/dev/null || true
+    notify "❌ *${identifier}* — ${title}
+Repo resolution failed."
+    return 1
+  fi
+  repo_path=$(printf '%s' "$repo_info" | cut -f1)
+  main_branch=$(printf '%s' "$repo_info" | cut -f2)
+  tlog "$identifier" "Repo: $repo_path (base: $main_branch)"
+
   # ── Create Worktree ────────────────────────────────────────────────────────
   # Note: Linear's GitHub integration auto-moves tickets to "In Progress"
   # when a branch with the ticket ID is created, so no manual state update needed.
   local worktree_path branch_name
   branch_name=$(branch_name_for "$identifier")
-  if ! worktree_path=$(create_worktree "$identifier"); then
+  if ! worktree_path=$(create_worktree "$identifier" "$repo_path" "$main_branch"); then
     tlog "$identifier" "❌ Worktree creation failed"
     linear_set_state "$issue_id" "$STATE_ID_TRIGGER" 2>/dev/null || true
     linear_comment "$issue_id" "❌ **Nightshift: Setup failed**
@@ -678,7 +842,7 @@ The ticket may be too complex for a single session. Consider breaking it into sm
 Ticket moved back to **${TRIGGER_STATE}**." 2>/dev/null || true
     notify "⏰ *${identifier}* — ${title}
 Timed out after ${AGENT_TIMEOUT_MINUTES}m. Moving back to ${TRIGGER_STATE}."
-    cleanup_worktree "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" "$repo_path" 2>/dev/null || true
     return 1
   fi
 
@@ -700,7 +864,7 @@ Ticket moved back to **${TRIGGER_STATE}**. Nightshift is shutting down to avoid 
     notify "🛑 *Usage limit detected*
 Nightshift stopped after ${TOTAL_DISPATCHES} dispatches.
 ✅ ${SUCCESS_COUNT} PRs created | ❌ ${FAIL_COUNT} failed"
-    cleanup_worktree "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" "$repo_path" 2>/dev/null || true
     SHUTTING_DOWN=true
     return 1
   fi
@@ -719,7 +883,7 @@ Claude exited with code \`${exit_code}\`. Will retry on next poll cycle (up to $
 Ticket moved back to **${TRIGGER_STATE}**." 2>/dev/null || true
     notify "❌ *${identifier}* — ${title}
 Failed (attempt ${attempts}/${MAX_RETRIES}, exit code ${exit_code})"
-    cleanup_worktree "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" "$repo_path" 2>/dev/null || true
     return 1
   fi
 
@@ -739,7 +903,7 @@ Claude got blocked on this ticket:
 Please clarify in the ticket comments, then move back to **${TRIGGER_STATE}** to retry." 2>/dev/null || true
     notify "⚠️ *${identifier}* — Blocked
 ${blocked_line}"
-    cleanup_worktree "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" "$repo_path" 2>/dev/null || true
     tlog "$identifier" "Moved back to '$TRIGGER_STATE'"
     return 0
   fi
@@ -757,7 +921,7 @@ ${blocked_line}"
 Claude completed the session without modifying any files. This usually means the ticket description is too vague or needs more context.
 
 Add more detail to the ticket description and move back to **${TRIGGER_STATE}** to retry. See the [Writing Good Tickets guide](https://github.com/your-org/nightshift/blob/main/docs/WRITING-GOOD-TICKETS.md) for tips." 2>/dev/null || true
-    cleanup_worktree "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" "$repo_path" 2>/dev/null || true
     return 0
   fi
 
@@ -887,12 +1051,12 @@ ${review_section}
 *Implemented by [Nightshift](https://github.com/your-org/nightshift) 🌙 using Claude Code${impl_mode}*"
 
   # ── Create PR ──────────────────────────────────────────────────────────────
-  cd "$REPO_PATH"
+  cd "$repo_path"
   local pr_url=""
   if ! pr_url=$(gh pr create \
     --title "${identifier}: ${title}" \
     --body "$pr_body" \
-    --base "$MAIN_BRANCH" \
+    --base "$main_branch" \
     --head "$branch_name" 2>&1); then
     tlog "$identifier" "❌ PR creation failed: $pr_url"
     linear_set_state "$issue_id" "$STATE_ID_TRIGGER" 2>/dev/null || true
@@ -908,7 +1072,7 @@ ${pr_url}
 \`\`\`
 
 Ticket moved back to **${TRIGGER_STATE}**." 2>/dev/null || true
-    cleanup_worktree "$identifier" 2>/dev/null || true
+    cleanup_worktree "$identifier" "$repo_path" 2>/dev/null || true
     return 1
   fi
 
@@ -928,7 +1092,7 @@ Moved to **${IN_REVIEW_STATE}**. Ready for your review!" 2>/dev/null || true
   tlog "$identifier" "✅ Done — moved to '$IN_REVIEW_STATE'"
 
   # ── Cleanup ────────────────────────────────────────────────────────────────
-  cleanup_worktree "$identifier" 2>/dev/null || true
+  cleanup_worktree "$identifier" "$repo_path" 2>/dev/null || true
 }
 
 # ─── Process Management ──────────────────────────────────────────────────────
@@ -996,14 +1160,22 @@ trap handle_shutdown SIGINT SIGTERM
 # ─── Startup Banner ──────────────────────────────────────────────────────────
 
 print_banner() {
-  local agent_mode review_mode notify_mode
+  local agent_mode review_mode notify_mode repo_mode
   agent_mode="$( [ "${USE_AGENT_TEAMS}" = "true" ] && echo "Agent Teams" || echo "Single agent")"
   review_mode="$( [ -n "${GEMINI_API_KEY:-}" ] && echo "Gemini (${GEMINI_MODEL})" || echo "Disabled")"
   notify_mode="$( [ "${TELEGRAM_ENABLED}" = "true" ] && echo "Telegram" || echo "Disabled")"
 
+  if [ -f "$REPOS_FILE" ]; then
+    local repo_count
+    repo_count=$(jq -r 'keys | length' "$REPOS_FILE" 2>/dev/null || echo "0")
+    repo_mode="${repo_count} repo(s) via repo: labels — default: ${REPO_PATH:-none}"
+  else
+    repo_mode="${REPO_PATH:-none}"
+  fi
+
   echo ""
   printf "🌙 Nightshift v%s\n" "$VERSION"
-  printf "   Repo:           %s\n" "$REPO_PATH"
+  printf "   Repo:           %s\n" "$repo_mode"
   printf "   Worktrees:      %s\n" "$WORKTREE_BASE"
   printf "   Team:           %s\n" "$LINEAR_TEAM_KEY"
   printf "   Watching:       \"%s\" column\n" "$TRIGGER_STATE"

--- a/repos.example.json
+++ b/repos.example.json
@@ -1,0 +1,10 @@
+{
+  "my-app": {
+    "url": "git@github.com:your-org/my-app.git",
+    "branch": "main"
+  },
+  "side-project": {
+    "url": "https://github.com/your-org/side-project.git",
+    "branch": "master"
+  }
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -14,6 +14,9 @@ export REPO_PATH="/tmp/nightshift-test-repo"
 export MAIN_BRANCH="main"
 export LOG_DIR="/tmp/nightshift-test-logs"
 export WORKTREE_BASE="/tmp/nightshift-test-worktrees"
+# Point at a path that does not exist so tests start in single-repo mode.
+# REPOS_FILE is read with a :- default, so this export survives sourcing.
+export REPOS_FILE="/tmp/nightshift-test-repos.json"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/nightshift.sh"

--- a/tests/test_repo_resolve.bash
+++ b/tests/test_repo_resolve.bash
@@ -80,6 +80,14 @@ result2=$(resolve_repo "ENG-5" "repo:app")
 assert_equals "$REPO_CACHE_BASE/app" "$(printf '%s' "$result2" | cut -f1)" \
   "second resolution reuses the cached clone"
 
+# ── default_branch_for_repo ──────────────────────────────────────────────────
+echo "--- default_branch_for_repo ---"
+
+assert_equals "trunk" "$(default_branch_for_repo "$REPO_CACHE_BASE/app")" \
+  "default branch comes from repos.json for a cached clone"
+assert_equals "main" "$(default_branch_for_repo "/tmp/not-a-cached-repo")" \
+  "default branch falls back to MAIN_BRANCH for an unknown repo"
+
 # ── resolve_repo: branch defaults to MAIN_BRANCH when omitted ────────────────
 echo "--- resolve_repo default branch ---"
 

--- a/tests/test_repo_resolve.bash
+++ b/tests/test_repo_resolve.bash
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tests for label-based multi-repo resolution
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/test_helper.bash"
+
+echo "=== Repo Resolution Tests ==="
+
+# ── repo_key_from_labels ─────────────────────────────────────────────────────
+echo "--- repo_key_from_labels ---"
+
+assert_equals "my-app" "$(repo_key_from_labels $'bug\nrepo:my-app\npriority')" \
+  "extracts key from a repo: label among others"
+assert_equals "my-app" "$(repo_key_from_labels 'Repo: my-app')" \
+  "matches case-insensitively and trims surrounding space"
+assert_equals "" "$(repo_key_from_labels $'bug\nfeature')" \
+  "returns empty when there is no repo: label"
+
+# ── resolve_repo: no label falls back to REPO_PATH ───────────────────────────
+echo "--- resolve_repo fallback to REPO_PATH ---"
+
+REPO_PATH="/tmp/some-default-repo"
+MAIN_BRANCH="main"
+REPOS_FILE="/tmp/nightshift-test-repos.json"
+rm -f "$REPOS_FILE"
+
+result=$(resolve_repo "ENG-1" "bug")
+assert_equals $'/tmp/some-default-repo\tmain' "$result" \
+  "no label resolves to REPO_PATH and MAIN_BRANCH"
+
+# ── resolve_repo: labelled ticket but no repos file ──────────────────────────
+echo "--- resolve_repo missing repos file ---"
+
+if resolve_repo "ENG-2" "repo:ghost" 2>/dev/null; then
+  failed="no"
+else
+  failed="yes"
+fi
+assert_equals "yes" "$failed" "labelled ticket fails when repos file is absent"
+
+# ── resolve_repo: unknown key ────────────────────────────────────────────────
+echo "--- resolve_repo unknown key ---"
+
+cat > "$REPOS_FILE" <<'EOF'
+{ "known": { "url": "/tmp/does-not-matter" } }
+EOF
+
+err=$(resolve_repo "ENG-3" "repo:unknown" 2>&1 || true)
+assert_contains "$err" "not defined" "unknown repo key reports a clear error"
+
+# ── resolve_repo: valid key clones on demand ─────────────────────────────────
+echo "--- resolve_repo clone-on-demand ---"
+
+SRC_REPO=$(make_test_tmpdir)
+git -C "$SRC_REPO" init -b trunk --quiet
+git -C "$SRC_REPO" config user.email "test@test.com"
+git -C "$SRC_REPO" config user.name "Test"
+git -C "$SRC_REPO" config commit.gpgsign false
+echo "hello" > "$SRC_REPO/file.txt"
+git -C "$SRC_REPO" add -A
+git -C "$SRC_REPO" commit -m "init" --quiet
+
+REPO_CACHE_BASE=$(make_test_tmpdir)
+cat > "$REPOS_FILE" <<EOF
+{ "app": { "url": "$SRC_REPO", "branch": "trunk" } }
+EOF
+
+result=$(resolve_repo "ENG-4" "repo:app")
+resolved_path=$(printf '%s' "$result" | cut -f1)
+resolved_branch=$(printf '%s' "$result" | cut -f2)
+
+assert_equals "$REPO_CACHE_BASE/app" "$resolved_path" "valid key resolves to a cached clone path"
+assert_equals "trunk" "$resolved_branch" "branch is read from the repos file"
+
+if [ -d "$resolved_path/.git" ]; then clone_ok="yes"; else clone_ok="no"; fi
+assert_equals "yes" "$clone_ok" "repo is cloned on demand"
+
+# Second resolution reuses the existing clone (fetch path, not clone)
+result2=$(resolve_repo "ENG-5" "repo:app")
+assert_equals "$REPO_CACHE_BASE/app" "$(printf '%s' "$result2" | cut -f1)" \
+  "second resolution reuses the cached clone"
+
+# ── resolve_repo: branch defaults to MAIN_BRANCH when omitted ────────────────
+echo "--- resolve_repo default branch ---"
+
+cat > "$REPOS_FILE" <<EOF
+{ "app2": { "url": "$SRC_REPO" } }
+EOF
+
+result=$(resolve_repo "ENG-6" "repo:app2")
+assert_equals "main" "$(printf '%s' "$result" | cut -f2)" \
+  "branch falls back to MAIN_BRANCH when not set in repos file"
+
+rm -f "$REPOS_FILE"
+
+print_test_summary

--- a/tests/test_worktree.bash
+++ b/tests/test_worktree.bash
@@ -14,6 +14,7 @@ WORKTREE_BASE=$(make_test_tmpdir)
 git -C "$TEST_REPO" init -b main --quiet
 git -C "$TEST_REPO" config user.email "test@test.com"
 git -C "$TEST_REPO" config user.name "Test"
+git -C "$TEST_REPO" config commit.gpgsign false
 echo "init" > "$TEST_REPO/README.md"
 git -C "$TEST_REPO" add -A
 git -C "$TEST_REPO" commit -m "init" --quiet


### PR DESCRIPTION
## Summary

Lets one Nightshift instance serve any repo without editing `.env` per project.

- A `repos.json` maps a short key to a git URL + optional base branch. Adding a `repo:<key>` label to a Linear ticket routes it to that repo.
- Repos are cloned on demand into `~/.nightshift-repos/` and reused after, with an atomic-`mkdir` lock guarding concurrent clones of the same repo.
- Tickets with no `repo:` label fall back to `REPO_PATH`, so single-repo setups are unchanged.
- The polling/cron trigger is untouched — only per-ticket repo resolution was added. `validate_config`, `run_cleanup`, startup cleanup, and the banner are all updated for multi-repo.

## Changes

- `nightshift.sh`: `resolve_repo`, `repo_key_from_labels`, `ensure_repo_clone`; `create_worktree`/`cleanup_worktree` take repo params; `fetch_trigger_issues` now requests labels
- `repos.example.json`, updated `.env.example`, `.gitignore`, README, CLAUDE.md
- `tests/test_repo_resolve.bash` (new); fixture commit signing disabled in `test_worktree.bash`

## Test plan

- [x] `bash -n nightshift.sh` — syntax clean
- [x] `bash tests/run_tests.bash` — all 5 suites pass
- [ ] Manual: label a ticket `repo:<key>`, confirm it clones and PRs against the right repo
- [ ] Manual: unlabelled ticket still uses `REPO_PATH`

## Linear

ENG-167 — https://linear.app/amazz/issue/ENG-167/multi-repo-support-route-tickets-to-repos-via-repoltkeygt

Note: the Go rewrite previously bundled into the closed #41 is split out as its own separate effort.

https://claude.ai/code/session_01LN267NHCgx2sTx8YG3jtYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN267NHCgx2sTx8YG3jtYu)_