### PR TITLE
Add Makefile for common dev + ops commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,12 @@ build-pi: ## Cross-compile for Raspberry Pi (arm64)
 
 update: ## Pull, rebuild, and restart the systemd service
 	git pull
-	go build -o $(BINARY) $(PKG)
+	# Build to a side file first so a failed build can't leave us with no
+	# binary, and so we can swap the live one with an atomic rename — rename
+	# is allowed while the old binary is executing (the kernel keeps the old
+	# inode alive for the running process; the path gets the new inode).
+	go build -o $(BINARY).new $(PKG)
+	mv $(BINARY).new $(BINARY)
 	systemctl --user restart nightshift
 
 start: ## Start the systemd service

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Nightshift — common dev + ops commands
+#
+# Run `make` (no target) to see this list. Tab-indent all recipes — Make
+# requires real tabs, not spaces.
+
+BINARY := nightshift
+PKG    := ./cmd/nightshift
+
+.DEFAULT_GOAL := help
+.PHONY: help build test vet run setup cleanup build-pi update start stop restart status logs
+
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} \
+		/^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2 }' \
+		$(MAKEFILE_LIST)
+
+# ── Build & test ────────────────────────────────────────────────────────────
+
+build: ## Compile the local binary
+	go build -o $(BINARY) $(PKG)
+
+test: ## Run the test suite
+	go test ./...
+
+vet: ## Run go vet
+	go vet ./...
+
+# ── Run locally (foreground) ────────────────────────────────────────────────
+
+run: build ## Build and start the poll loop in the foreground
+	./$(BINARY)
+
+setup: build ## Build and run the interactive setup wizard
+	./$(BINARY) setup
+
+cleanup: build ## Build and run cleanup
+	./$(BINARY) cleanup
+
+# ── Cross-compile (run on the Mac, scp the output to the Pi) ────────────────
+
+build-pi: ## Cross-compile for Raspberry Pi (arm64)
+	GOOS=linux GOARCH=arm64 go build -o $(BINARY)-pi $(PKG)
+
+# ── systemd service management (run on the Pi) ──────────────────────────────
+
+update: ## Pull, rebuild, and restart the systemd service
+	git pull
+	go build -o $(BINARY) $(PKG)
+	systemctl --user restart nightshift
+
+start: ## Start the systemd service
+	systemctl --user start nightshift
+
+stop: ## Stop the systemd service
+	systemctl --user stop nightshift
+
+restart: ## Restart the systemd service (does not rebuild)
+	systemctl --user restart nightshift
+
+status: ## Show service status
+	systemctl --user status nightshift
+
+logs: ## Tail live logs (Ctrl+C to stop)
+	journalctl --user-unit=nightshift.service -f


### PR DESCRIPTION
## Summary

Adds a `Makefile` consolidating the commands we've been running by hand on the Mac and the Pi — build, test, cross-compile, and systemd service management.

`make` (no target) prints the full list:

```
help          Show this help
build         Compile the local binary
test          Run the test suite
vet           Run go vet
run           Build and start the poll loop in the foreground
setup         Build and run the interactive setup wizard
cleanup       Build and run cleanup
build-pi      Cross-compile for Raspberry Pi (arm64)
update        Pull, rebuild, and restart the systemd service
start         Start the systemd service
stop          Stop the systemd service
restart       Restart the systemd service (does not rebuild)
status        Show service status
logs          Tail live logs (Ctrl+C to stop)
```

The standout one for day-to-day Pi use is `make update` — pulls latest, rebuilds, and restarts the systemd service in a single command. To avoid `ETXTBSY` when overwriting a running binary on Linux, `update` builds to `<binary>.new` and then atomically renames into place; a failed build never leaves the service without a binary at `ExecStart`.

Linear: [ENG-170](https://linear.app/amazz/issue/ENG-170/add-makefile-for-common-dev-ops-commands)

## Test plan

- [x] `make help` renders cleanly
- [x] `make build` compiles
- [ ] On the Pi: `make update` does the full pull → build → restart cycle (gated by next Pi update)

https://claude.ai/code/session_01N8uh6QWm9uBw3u5nxSyC53