### PR TITLE
CI: vet + build + test -race + golangci-lint on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
       - name: go test
         run: go test -race ./...
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: test + vet + build + lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test
+        run: go test -race ./...
+
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.5.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,25 @@
+# Minimal golangci-lint config — defaults plus gofmt.
+#
+# errcheck excludes the noisy `defer Close()` / `fmt.Fprintf` patterns where
+# checking the error is rarely actionable. Real unchecked errors elsewhere
+# still fail the lint.
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+        - (*net/http.Response).Body.Close
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - os.Remove
+
+formatters:
+  enable:
+    - gofmt

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -152,7 +152,7 @@ func (c *Client) Ping(ctx context.Context) (string, error) {
 		return "", err
 	}
 	if resp.Viewer.ID == "" {
-		return "", fmt.Errorf("Linear returned no viewer — is the API key valid?")
+		return "", fmt.Errorf("linear returned no viewer — is the API key valid?")
 	}
 	return resp.Viewer.Name, nil
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -33,8 +33,8 @@ type Pipeline struct {
 	active            map[string]struct{} // identifiers in-flight
 	failedAttempts    map[string]int      // per-ticket retry counter
 	totalDispatches   int
-	successCount     int
-	failCount        int
+	successCount      int
+	failCount         int
 	rateLimitDetected bool
 }
 

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -555,10 +555,10 @@ func copyFile(src, dst string) error {
 }
 
 type envValues struct {
-	linearKey, team, trigger, review                   string
-	mainBranch, repoPath                               string
-	concurrency, dispatches, retries, timeoutMin       string
-	geminiKey, tgEnabled, tgToken, tgChat              string
+	linearKey, team, trigger, review             string
+	mainBranch, repoPath                         string
+	concurrency, dispatches, retries, timeoutMin string
+	geminiKey, tgEnabled, tgToken, tgChat        string
 }
 
 func writeEnvFile(path string, v envValues) error {


### PR DESCRIPTION
## Summary

Closes [ENG-171](https://linear.app/amazz/issue/ENG-171/ci-run-go-test-go-vet-lint-on-every-pr). Adds a single GitHub Actions workflow that gates every PR and every push to `main`:

```
go vet ./...
go build ./...
go test -race ./...
golangci-lint run
```

Pinned: Go version reads from `go.mod` (1.23) via `actions/setup-go@v5`; `golangci-lint@v2.5.0` matches what was run locally to clear the existing tree.

## `.golangci.yml`

Minimal — v2 default linter set (errcheck, gosimple, govet, ineffassign, staticcheck, unused) plus the `gofmt` formatter. `errcheck` excludes the conventional "fine to ignore" patterns:

- `(io.Closer).Close` / `(*os.File).Close` / `(*net/http.Response).Body.Close` — checking on defer is rarely actionable
- `fmt.Fprintf` / `fmt.Fprintln` — log writes; if logging is hosed we have bigger problems
- `os.Remove` — lock-file cleanup in defers

Anything else unchecked still trips the lint.

## Drive-by fixes (so CI is green from commit 1)

- `gofmt` alignment in `internal/pipeline/pipeline.go` (struct field comments) and `internal/setup/wizard.go`
- `staticcheck ST1005` in `linear.Client.Ping` — lowercase the `"linear returned no viewer"` error string

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test -race ./...` — all 5 suites pass
- [x] `golangci-lint run` v2.5.0 — `0 issues`
- [ ] CI run on this PR — green (you can watch it land in the checks panel)

After this lands, mark the CI status check required on `main` via branch protection — that's the bit that actually enforces the gate.

https://claude.ai/code/session_01N8uh6QWm9uBw3u5nxSyC53

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8uh6QWm9uBw3u5nxSyC53)_