### PR TITLE
Auto-iterate on PR review feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,30 @@ GEMINI_MODEL=gemini-2.5-pro
 # How many fix passes Claude gets after Gemini flags issues
 # Set to 0 to create the PR immediately with Gemini's comments attached
 MAX_REVIEW_RETRIES=1
+
+# ── Auto-iterate on PR Review Feedback (optional) ─────────────────────────────
+# When enabled, Nightshift periodically polls the open PRs it created. New
+# comments / reviews trigger Claude to address them on the SAME branch (so the
+# PR just gets a follow-up commit instead of being abandoned).
+
+# Set to true to enable. Default off — single-shot behaviour stays unchanged.
+AUTO_ITERATE_PRS=false
+
+# Per-PR safety cap. After this many re-engagements on the same PR, Nightshift
+# stops and asks for human attention (Telegram + Linear comment).
+MAX_PR_ITERATIONS=3
+
+# Seconds between PR scans. Less aggressive than the Linear poll because PR
+# events are rarer.
+PR_POLL_INTERVAL=120
+
+# Comma-separated GitHub logins / bot names whose feedback Nightshift will
+# act on. Humans are always trusted; bots have to be explicitly listed.
+# Empty = humans only — the safe default after a bot reviewer was confidently
+# wrong about a config file (see PR #50).
+# Example: gemini-code-assist,coderabbit
+TRUSTED_REVIEWERS=
+
+# Where Nightshift persists its per-PR cursor + iteration counter.
+# Defaults to $HOME/.nightshift-state.json.
+# STATE_FILE=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Nightshift
 
-Autonomous Linear-to-PR agent in Go. Polls Linear for tickets in a trigger state, dispatches Claude Code to implement them, creates PRs, and moves tickets to review.
+Autonomous Linear-to-PR agent in Go. Polls Linear for tickets in a trigger state, dispatches Claude Code to implement them, creates PRs, and moves tickets to review. Optionally (`AUTO_ITERATE_PRS=true`) it also watches the PRs it opened and pushes follow-up commits in response to review feedback.
 
 ## Architecture
 
@@ -11,6 +11,25 @@ poll loop → linear.FetchTriggerIssues → pipeline.process (bounded goroutine)
 ```
 
 Worktrees live at `~/.nightshift-worktrees/<IDENTIFIER>` so multiple tickets run concurrently without sharing a working directory.
+
+## Auto-iterate on PR feedback (optional)
+
+When `AUTO_ITERATE_PRS=true`, a **second** poll loop runs alongside the Linear one:
+
+```
+PR poll loop → github.ListNightshiftPRs → github.GetPR → watch.Scan (diff vs state cursor)
+  → pipeline.iteratePR (bounded, shares the worker pool + active-set)
+  → repo.ResumeWorktree → agent.BuildFixPrompt → agent.Run → commit/push (same branch)
+  → state.Update (advance cursor + bump iteration count)
+```
+
+- **Opt-in**, off by default. Both loops run on the same `WaitGroup` so shutdown drains in-flight iterations.
+- Only acts on PRs **Nightshift authored** — identified purely by the `nightshift/<id>` branch prefix (`repo.BranchName`). `CreateWorktree` and `ResumeWorktree` both use it; `watch`/`iterate` filter on it. **Keep creation and watching on the same prefix** or the watcher silently never finds its own PRs.
+- Feedback captured: conversation comments, review summaries (`CHANGES_REQUESTED` / non-empty `COMMENTED`), and inline review-thread comments (fetched separately via `gh api`, non-fatal on failure). `APPROVED`/`DISMISSED` and empty `COMMENTED` advance the cursor without acting.
+- Trusted-reviewer rule (`watch.actionable`): humans always actionable; bots only if their login is in `TRUSTED_REVIEWERS`.
+- Guards: per-PR `MAX_PR_ITERATIONS` cap (timeouts/rate-limits don't count), restart-safe cursor in `state`, `pipeline.active` dedupe so a ticket can't be freshly-dispatched and iterated at once.
+- Cursors are stored as **timestamps**, not opaque node IDs — naturally ordered. Conversation and inline comments share the comment cursor (comment timestamps are globally ordered).
+- Nightshift does **not** post back to the GitHub PR thread (no replies, no thread resolution); it pushes a follow-up commit and notifies via Telegram/Linear.
 
 ## Multi-repo
 
@@ -27,11 +46,14 @@ If a ticket's project has no registry entry, Nightshift falls back to `REPO_PATH
 | `cmd/nightshift` | Entry point + subcommand dispatch (`run` / `setup` / `cleanup` / `version`) |
 | `internal/config` | `.env` parser, `repos.json` loader, validated `Config` |
 | `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `SetState`, `Comment` |
-| `internal/repo` | Project → repo slug + registry; clone-on-demand; worktree create/cleanup |
-| `internal/agent` | Claude Code runner (`exec`) with timeout; prompt builder; log_offset parsing |
+| `internal/repo` | Project → repo slug + registry; clone-on-demand; worktree create/cleanup; `BranchName`; `CreateWorktree` (from main) + `ResumeWorktree` (pull existing remote branch) |
+| `internal/agent` | Claude Code runner (`exec`) with timeout; implement-prompt builder; `BuildFixPrompt` (review-feedback prompt); log_offset parsing |
 | `internal/review` | Optional Gemini second-model review gate |
 | `internal/notify` | Optional Telegram notifier (fire-and-forget) |
-| `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle |
+| `internal/github` | Thin `gh` CLI wrapper: `ListNightshiftPRs`, `GetPR` (comments + reviews + inline review-thread comments via REST) |
+| `internal/state` | File-backed PR cursor store (`~/.nightshift-state.json`): per-PR comment/review cursors + iteration count; atomic, mutex-guarded |
+| `internal/watch` | Side-effect-free classifier: diffs a PR's feedback against the cursor, applies trusted-reviewer rules, emits actionable events |
+| `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle (`process.go`); PR-watch loop + per-PR re-engagement (`iterate.go`) |
 | `internal/setup` | Interactive setup wizard (`./nightshift setup`) |
 | `internal/cleanup` | Cleanup subcommand: branches, worktrees, old logs |
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ When a ticket comes in, Nightshift reads its project, finds the matching repo, a
 
 ## Auto-iterate on PR review feedback (optional)
 
-By default Nightshift's job ends when the PR is created. Set `AUTO_ITERATE_PRS=true` and Nightshift will also poll the PRs it created — when a new review comment or `CHANGES_REQUESTED` review lands, it re-engages Claude **on the same branch** and pushes a follow-up commit. The PR just updates; no new PR, no lost context.
+By default Nightshift's job ends when the PR is created. Set `AUTO_ITERATE_PRS=true` and Nightshift will also poll the PRs it created — when new feedback lands, it re-engages Claude **on the same branch** and pushes a follow-up commit. The PR just updates; no new PR, no lost context.
+
+It picks up all three kinds of feedback: top-level conversation comments, submitted reviews (`CHANGES_REQUESTED` / non-empty `COMMENTED`), and **inline review-thread comments** attached to specific lines — the latter are passed to Claude with their `file:line` location so it knows exactly where each note applies.
 
 ```env
 AUTO_ITERATE_PRS=true

--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ When a ticket comes in, Nightshift reads its project, finds the matching repo, a
 
 ---
 
+## Auto-iterate on PR review feedback (optional)
+
+By default Nightshift's job ends when the PR is created. Set `AUTO_ITERATE_PRS=true` and Nightshift will also poll the PRs it created — when a new review comment or `CHANGES_REQUESTED` review lands, it re-engages Claude **on the same branch** and pushes a follow-up commit. The PR just updates; no new PR, no lost context.
+
+```env
+AUTO_ITERATE_PRS=true
+MAX_PR_ITERATIONS=3              # safety cap per PR
+PR_POLL_INTERVAL=120             # seconds between PR scans
+TRUSTED_REVIEWERS=               # CSV of bots/logins; empty = humans only
+```
+
+**Safety guards built in:**
+- **Iteration cap.** After `MAX_PR_ITERATIONS` re-engagements on the same PR, Nightshift stops and pings you (Telegram + Linear comment). Prevents flake-loops and stuck reviews from grinding through your API quota.
+- **Trusted-reviewer allowlist.** Humans are always trusted. Bots are only acted on if their login is in `TRUSTED_REVIEWERS`. Default is empty = humans only — bot reviews are still seen and logged, but Nightshift won't act on them blindly. (The default exists because a bot reviewer once confidently misread a `golangci-lint` v2 config as v1; applying its "fix" would have broken CI.)
+- **Cursor persistence.** State at `~/.nightshift-state.json` tracks how far the watcher has caught up. Restarts don't re-react to historical comments.
+- **Telegram heads-up** on each re-engage (always — not gated by `TELEGRAM_VERBOSE`).
+
+Disabled by default; set `AUTO_ITERATE_PRS=true` to opt in, or run the wizard.
+
+---
+
 ## Configuration
 
 Run `./nightshift setup` to generate config, or copy `.env.example` → `.env` and `repos.example.json` → `repos.json` by hand.

--- a/internal/agent/fix_prompt.go
+++ b/internal/agent/fix_prompt.go
@@ -21,6 +21,10 @@ type FeedbackItem struct {
 	State string
 	// URL points back to the comment on GitHub (optional, comments only).
 	URL string
+	// Path / Line locate an inline review comment in the diff. Empty for
+	// conversation comments and reviews.
+	Path string
+	Line int
 }
 
 // FixPromptInput is everything BuildFixPrompt needs to assemble a prompt the
@@ -50,6 +54,13 @@ func BuildFixPrompt(in FixPromptInput) string {
 		header := fmt.Sprintf("### %d) %s by @%s", i+1, sectionLabel(f.Kind, f.State), f.Author)
 		feedback.WriteString(header)
 		feedback.WriteByte('\n')
+		if f.Path != "" {
+			if f.Line > 0 {
+				fmt.Fprintf(&feedback, "on `%s:%d`\n", f.Path, f.Line)
+			} else {
+				fmt.Fprintf(&feedback, "on `%s`\n", f.Path)
+			}
+		}
 		if f.URL != "" {
 			fmt.Fprintf(&feedback, "(%s)\n", f.URL)
 		}

--- a/internal/agent/fix_prompt.go
+++ b/internal/agent/fix_prompt.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FeedbackItem is one piece of feedback rendered into a fix prompt — a
+// conversation comment or a review body. Kept stringly-typed so the agent
+// package doesn't have to depend on internal/github or internal/watch.
+type FeedbackItem struct {
+	// Kind is "comment" or "review" — controls the section heading.
+	Kind string
+	// Author is the GitHub login that posted it.
+	Author string
+	// Body is the markdown body.
+	Body string
+	// State is "" for comments; for reviews it's APPROVED /
+	// CHANGES_REQUESTED / COMMENTED — rendered alongside the author for
+	// extra context.
+	State string
+	// URL points back to the comment on GitHub (optional, comments only).
+	URL string
+}
+
+// FixPromptInput is everything BuildFixPrompt needs to assemble a prompt the
+// implementing agent can act on without re-reading the PR.
+type FixPromptInput struct {
+	Identifier  string
+	Title       string
+	Description string
+	PRNumber    int
+	PRURL       string
+	Feedback    []FeedbackItem
+}
+
+// BuildFixPrompt renders a fix prompt for Claude when reviewers (or bots in
+// the trust list) have left actionable feedback on the PR for this ticket.
+// The prompt explicitly instructs Claude to address ONLY the listed feedback
+// and not to do unrelated work — the goal is a tight follow-up commit, not
+// a do-over.
+func BuildFixPrompt(in FixPromptInput) string {
+	desc := in.Description
+	if desc == "" {
+		desc = "No description provided."
+	}
+
+	var feedback strings.Builder
+	for i, f := range in.Feedback {
+		header := fmt.Sprintf("### %d) %s by @%s", i+1, sectionLabel(f.Kind, f.State), f.Author)
+		feedback.WriteString(header)
+		feedback.WriteByte('\n')
+		if f.URL != "" {
+			fmt.Fprintf(&feedback, "(%s)\n", f.URL)
+		}
+		feedback.WriteByte('\n')
+		feedback.WriteString(strings.TrimSpace(f.Body))
+		feedback.WriteString("\n\n")
+	}
+
+	return fmt.Sprintf(`A reviewer has left feedback on the PR you opened for this Linear ticket. Address it on the same branch — your changes will be pushed as a follow-up commit.
+
+## Ticket: %s — %s
+%s
+
+## PR
+#%d — %s
+
+## Feedback to address
+
+%s
+## Rules
+
+- Address ONLY the feedback listed above. Do not refactor unrelated code or pick up new work.
+- If a piece of feedback is wrong or inapplicable, briefly say so and skip it — do not silently ignore it.
+- Run the test suite and the linter (`+"`golangci-lint run`"+`, if configured) after your changes; fix anything you broke.
+- If you cannot address a piece of feedback because more context is needed, say BLOCKED: <reason> and stop.
+- Do NOT create a new PR, push a new branch, or close the existing PR — Nightshift handles that.
+
+## When done
+
+Summarise which pieces of feedback you addressed and how, and call out any you deliberately skipped (with the reason).
+`, in.Identifier, in.Title, desc, in.PRNumber, in.PRURL, feedback.String())
+}
+
+func sectionLabel(kind, state string) string {
+	switch kind {
+	case "review":
+		if state != "" {
+			return "Review (" + state + ")"
+		}
+		return "Review"
+	default:
+		return "Comment"
+	}
+}

--- a/internal/agent/fix_prompt_test.go
+++ b/internal/agent/fix_prompt_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildFixPrompt_IncludesTicketContextAndAllFeedback(t *testing.T) {
+	out := BuildFixPrompt(FixPromptInput{
+		Identifier:  "ENG-42",
+		Title:       "Add custom font family",
+		Description: "We want Inter across the app.",
+		PRNumber:    59,
+		PRURL:       "https://github.com/me/trade-mate/pull/59",
+		Feedback: []FeedbackItem{
+			{
+				Kind:   "comment",
+				Author: "alice",
+				Body:   "Don't forget the bold variant",
+				URL:    "https://github.com/me/trade-mate/pull/59#issuecomment-1",
+			},
+			{
+				Kind:   "review",
+				State:  "CHANGES_REQUESTED",
+				Author: "bob",
+				Body:   "The fallback chain is missing.",
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"ENG-42",
+		"Add custom font family",
+		"We want Inter across the app.",
+		"#59",
+		"https://github.com/me/trade-mate/pull/59",
+		"@alice",
+		"@bob",
+		"Don't forget the bold variant",
+		"The fallback chain is missing.",
+		"Review (CHANGES_REQUESTED)",
+		"BLOCKED:", // the rules section
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("fix prompt missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestBuildFixPrompt_HandlesMissingDescription(t *testing.T) {
+	out := BuildFixPrompt(FixPromptInput{
+		Identifier: "ENG-1",
+		Title:      "Tiny fix",
+		Feedback:   []FeedbackItem{{Kind: "comment", Author: "alice", Body: "do it"}},
+	})
+	if !strings.Contains(out, "No description provided.") {
+		t.Error("expected fallback description placeholder")
+	}
+}
+
+func TestSectionLabel(t *testing.T) {
+	cases := map[[2]string]string{
+		{"review", "CHANGES_REQUESTED"}: "Review (CHANGES_REQUESTED)",
+		{"review", ""}:                  "Review",
+		{"comment", ""}:                 "Comment",
+		{"comment", "anything"}:         "Comment",
+	}
+	for in, want := range cases {
+		if got := sectionLabel(in[0], in[1]); got != want {
+			t.Errorf("sectionLabel(%q, %q) = %q, want %q", in[0], in[1], got, want)
+		}
+	}
+}

--- a/internal/agent/fix_prompt_test.go
+++ b/internal/agent/fix_prompt_test.go
@@ -47,6 +47,23 @@ func TestBuildFixPrompt_IncludesTicketContextAndAllFeedback(t *testing.T) {
 	}
 }
 
+func TestBuildFixPrompt_RendersInlineCommentLocation(t *testing.T) {
+	out := BuildFixPrompt(FixPromptInput{
+		Identifier: "ENG-42",
+		Title:      "Fix race",
+		Feedback: []FeedbackItem{{
+			Kind:   "comment",
+			Author: "alice",
+			Body:   "keep the mutex held",
+			Path:   "internal/state/state.go",
+			Line:   122,
+		}},
+	})
+	if !strings.Contains(out, "internal/state/state.go:122") {
+		t.Errorf("expected inline comment location in prompt\n---\n%s", out)
+	}
+}
+
 func TestBuildFixPrompt_HandlesMissingDescription(t *testing.T) {
 	out := BuildFixPrompt(FixPromptInput{
 		Identifier: "ENG-1",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,10 @@ const (
 	DefaultAgentTimeout     = 45 * time.Minute
 	DefaultGeminiModel      = "gemini-2.5-pro"
 	DefaultMaxReviewRetries = 1
+
+	// Auto-iterate (ENG-173) — disabled by default; opt in via .env.
+	DefaultMaxPRIterations = 3
+	DefaultPRPollInterval  = 2 * time.Minute
 )
 
 // Config is Nightshift's resolved runtime configuration.
@@ -64,6 +68,13 @@ type Config struct {
 	GeminiAPIKey     string
 	GeminiModel      string
 	MaxReviewRetries int
+
+	// Auto-iterate on PR review feedback (ENG-173) — off by default.
+	AutoIteratePRs   bool
+	MaxPRIterations  int
+	PRPollInterval   time.Duration
+	TrustedReviewers []string // GitHub logins/bots Nightshift will act on (default: humans only)
+	StateFile        string   // where the per-PR cursor + iteration count is persisted
 
 	// Derived paths
 	ScriptDir    string
@@ -128,6 +139,14 @@ func Load(scriptDir string) (*Config, error) {
 
 	timeoutMin := getint(fileEnv, "AGENT_TIMEOUT_MINUTES", int(DefaultAgentTimeout/time.Minute))
 	cfg.AgentTimeout = time.Duration(timeoutMin) * time.Minute
+
+	// Auto-iterate
+	cfg.AutoIteratePRs = getbool(fileEnv, "AUTO_ITERATE_PRS", false)
+	cfg.MaxPRIterations = getint(fileEnv, "MAX_PR_ITERATIONS", DefaultMaxPRIterations)
+	prPollSecs := getint(fileEnv, "PR_POLL_INTERVAL", int(DefaultPRPollInterval/time.Second))
+	cfg.PRPollInterval = time.Duration(prPollSecs) * time.Second
+	cfg.TrustedReviewers = getlist(fileEnv, "TRUSTED_REVIEWERS")
+	cfg.StateFile = getenv(fileEnv, "STATE_FILE", filepath.Join(home, ".nightshift-state.json"))
 
 	cfg.Registry, err = LoadRepoRegistry(reposFile)
 	if err != nil {
@@ -220,4 +239,25 @@ func getint(fileEnv map[string]string, key string, def int) int {
 		return def
 	}
 	return n
+}
+
+// getlist parses a comma-separated value into a trimmed, empty-filtered slice.
+// Returns nil (not an empty slice) when the value is absent, which lets callers
+// distinguish "no entries configured" from "configured to empty list."
+func getlist(fileEnv map[string]string, key string) []string {
+	v := getenv(fileEnv, key, "")
+	if v == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // nightshiftEnvKeys are every env var Nightshift reads. Tests clear them all
@@ -18,6 +19,8 @@ var nightshiftEnvKeys = []string{
 	"TELEGRAM_ENABLED", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID",
 	"GEMINI_API_KEY", "GEMINI_MODEL", "MAX_REVIEW_RETRIES",
 	"REPOS_FILE", "REPOS_BASE", "WORKTREE_BASE", "LOG_DIR",
+	"AUTO_ITERATE_PRS", "MAX_PR_ITERATIONS", "PR_POLL_INTERVAL",
+	"TRUSTED_REVIEWERS", "STATE_FILE",
 }
 
 func isolateEnv(t *testing.T) {
@@ -162,6 +165,69 @@ REPO_PATH="`+notARepo+`"`)
 	}
 	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "not a git repository") {
 		t.Fatalf("expected not-a-git-repo error, got %v", err)
+	}
+}
+
+func TestLoad_AutoIterateDefaults(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"`)
+	writeFile(t, filepath.Join(dir, "repos.json"), `{"repos": {}}`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.AutoIteratePRs {
+		t.Errorf("AutoIteratePRs should default to false")
+	}
+	if cfg.MaxPRIterations != DefaultMaxPRIterations {
+		t.Errorf("MaxPRIterations: got %d, want %d", cfg.MaxPRIterations, DefaultMaxPRIterations)
+	}
+	if cfg.PRPollInterval != DefaultPRPollInterval {
+		t.Errorf("PRPollInterval: got %v, want %v", cfg.PRPollInterval, DefaultPRPollInterval)
+	}
+	if cfg.TrustedReviewers != nil {
+		t.Errorf("TrustedReviewers should default to nil (= humans only), got %v", cfg.TrustedReviewers)
+	}
+	if cfg.StateFile == "" {
+		t.Error("StateFile should have a default path")
+	}
+}
+
+func TestLoad_TrustedReviewersParsesCSV(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"
+TRUSTED_REVIEWERS="gemini-code-assist, coderabbit,humanreviewer"
+AUTO_ITERATE_PRS="true"
+MAX_PR_ITERATIONS="5"
+PR_POLL_INTERVAL="60"`)
+	writeFile(t, filepath.Join(dir, "repos.json"), `{"repos": {}}`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cfg.AutoIteratePRs {
+		t.Error("AutoIteratePRs should be true")
+	}
+	if cfg.MaxPRIterations != 5 {
+		t.Errorf("MaxPRIterations: got %d", cfg.MaxPRIterations)
+	}
+	if cfg.PRPollInterval != 60*time.Second {
+		t.Errorf("PRPollInterval: got %v", cfg.PRPollInterval)
+	}
+	want := []string{"gemini-code-assist", "coderabbit", "humanreviewer"}
+	if len(cfg.TrustedReviewers) != len(want) {
+		t.Fatalf("TrustedReviewers length: got %d, want %d (%v)", len(cfg.TrustedReviewers), len(want), cfg.TrustedReviewers)
+	}
+	for i, w := range want {
+		if cfg.TrustedReviewers[i] != w {
+			t.Errorf("TrustedReviewers[%d]: got %q, want %q", i, cfg.TrustedReviewers[i], w)
+		}
 	}
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,0 +1,121 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os/exec"
+	"strings"
+)
+
+// Client is a `gh`-CLI wrapper. Stateless — safe to use concurrently.
+type Client struct{}
+
+// New returns a ready-to-use Client.
+func New() *Client { return &Client{} }
+
+// ListNightshiftPRs returns every open PR that Nightshift created across the
+// given repositories (any branch matching the `nightshift/` prefix authored
+// by the current `gh` user).
+//
+// repoURLs are the git URLs from repos.json (or REPO_PATH). Each is reduced
+// to `owner/name` before being passed to `gh`. Per-repo errors are logged
+// (not returned) so a single unreachable repo doesn't kill the whole sweep.
+func (c *Client) ListNightshiftPRs(ctx context.Context, repoURLs []string) ([]PR, error) {
+	var out []PR
+	for _, raw := range repoURLs {
+		ownerRepo, err := ExtractOwnerRepo(raw)
+		if err != nil {
+			slog.Warn("github: skipping repo (cannot extract owner/name)", "url", raw, "err", err)
+			continue
+		}
+
+		cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+			"--repo", ownerRepo,
+			"--author", "@me",
+			"--state", "open",
+			"--json", "url,number,title,headRefName",
+		)
+		stdout, err := cmd.Output()
+		if err != nil {
+			slog.Warn("github: gh pr list failed", "repo", ownerRepo, "err", err)
+			continue
+		}
+
+		var prs []PR
+		if err := json.Unmarshal(stdout, &prs); err != nil {
+			slog.Warn("github: decode pr list output", "repo", ownerRepo, "err", err)
+			continue
+		}
+
+		for _, pr := range prs {
+			if strings.HasPrefix(pr.HeadRefName, "nightshift/") {
+				out = append(out, pr)
+			}
+		}
+	}
+	return out, nil
+}
+
+// GetPR fetches the full view of a PR — comments, reviews, state — used by
+// the watcher to diff against the cursor in state.json.
+func (c *Client) GetPR(ctx context.Context, prURL string) (*Details, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prURL,
+		"--json", "url,number,state,comments,reviews",
+	)
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view %s: %w", prURL, err)
+	}
+	var d Details
+	if err := json.Unmarshal(stdout, &d); err != nil {
+		return nil, fmt.Errorf("decode gh pr view %s: %w", prURL, err)
+	}
+	return &d, nil
+}
+
+// ExtractOwnerRepo reduces a git remote URL (SSH or HTTPS) to its `owner/name`
+// form, which is what `gh --repo` wants. An already-reduced "owner/name" is
+// returned as-is.
+//
+//	git@github.com:me/auth.git   → me/auth
+//	https://github.com/me/auth   → me/auth
+//	me/auth                      → me/auth
+func ExtractOwnerRepo(raw string) (string, error) {
+	s := strings.TrimSuffix(strings.TrimSpace(raw), ".git")
+
+	if strings.HasPrefix(s, "git@") {
+		idx := strings.Index(s, ":")
+		if idx < 0 {
+			return "", fmt.Errorf("ssh URL missing ':' in %q", raw)
+		}
+		rest := s[idx+1:]
+		if !looksLikeOwnerRepo(rest) {
+			return "", fmt.Errorf("unexpected ssh URL shape: %q", raw)
+		}
+		return rest, nil
+	}
+
+	if strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "http://") {
+		u, err := url.Parse(s)
+		if err != nil {
+			return "", fmt.Errorf("parse URL %q: %w", raw, err)
+		}
+		rest := strings.Trim(u.Path, "/")
+		if !looksLikeOwnerRepo(rest) {
+			return "", fmt.Errorf("URL path %q is not owner/name", u.Path)
+		}
+		return rest, nil
+	}
+
+	if looksLikeOwnerRepo(s) {
+		return s, nil
+	}
+	return "", fmt.Errorf("cannot extract owner/name from %q", raw)
+}
+
+func looksLikeOwnerRepo(s string) bool {
+	return strings.Count(s, "/") == 1 && !strings.HasPrefix(s, "/") && !strings.HasSuffix(s, "/")
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -77,7 +77,52 @@ func (c *Client) GetPR(ctx context.Context, prURL string) (*Details, error) {
 	if err := json.Unmarshal(stdout, &d); err != nil {
 		return nil, fmt.Errorf("decode gh pr view %s: %w", prURL, err)
 	}
+
+	// Inline review-thread comments aren't returned by `gh pr view`; pull
+	// them from the REST API. Non-fatal: on failure we degrade to
+	// conversation comments + review summaries rather than skipping the PR.
+	if rc, err := c.listReviewComments(ctx, prURL); err != nil {
+		slog.Warn("github: fetch inline review comments failed", "url", prURL, "err", err)
+	} else {
+		d.ReviewComments = rc
+	}
 	return &d, nil
+}
+
+// listReviewComments fetches the inline review-thread comments for a PR via
+// the REST API (paginated — bots can leave many on one review).
+func (c *Client) listReviewComments(ctx context.Context, prURL string) ([]ReviewComment, error) {
+	apiPath, err := reviewCommentsAPIPath(prURL)
+	if err != nil {
+		return nil, err
+	}
+	var stderr strings.Builder
+	cmd := exec.CommandContext(ctx, "gh", "api", "--paginate", apiPath)
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api %s: %w (%s)", apiPath, err, strings.TrimSpace(stderr.String()))
+	}
+	var comments []ReviewComment
+	if err := json.Unmarshal(stdout, &comments); err != nil {
+		return nil, fmt.Errorf("decode review comments %s: %w", apiPath, err)
+	}
+	return comments, nil
+}
+
+// reviewCommentsAPIPath turns a PR URL into the REST path for its inline
+// review comments: https://github.com/owner/name/pull/12 →
+// repos/owner/name/pulls/12/comments.
+func reviewCommentsAPIPath(prURL string) (string, error) {
+	u, err := url.Parse(prURL)
+	if err != nil {
+		return "", fmt.Errorf("parse PR URL %q: %w", prURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" || parts[0] == "" || parts[1] == "" || parts[3] == "" {
+		return "", fmt.Errorf("unexpected PR URL shape: %q", prURL)
+	}
+	return fmt.Sprintf("repos/%s/%s/pulls/%s/comments", parts[0], parts[1], parts[3]), nil
 }
 
 // ExtractOwnerRepo reduces a git remote URL (SSH or HTTPS) to its `owner/name`

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -32,15 +32,17 @@ func (c *Client) ListNightshiftPRs(ctx context.Context, repoURLs []string) ([]PR
 			continue
 		}
 
+		var stderr strings.Builder
 		cmd := exec.CommandContext(ctx, "gh", "pr", "list",
 			"--repo", ownerRepo,
 			"--author", "@me",
 			"--state", "open",
 			"--json", "url,number,title,headRefName",
 		)
+		cmd.Stderr = &stderr
 		stdout, err := cmd.Output()
 		if err != nil {
-			slog.Warn("github: gh pr list failed", "repo", ownerRepo, "err", err)
+			slog.Warn("github: gh pr list failed", "repo", ownerRepo, "err", err, "stderr", strings.TrimSpace(stderr.String()))
 			continue
 		}
 
@@ -62,12 +64,14 @@ func (c *Client) ListNightshiftPRs(ctx context.Context, repoURLs []string) ([]PR
 // GetPR fetches the full view of a PR — comments, reviews, state — used by
 // the watcher to diff against the cursor in state.json.
 func (c *Client) GetPR(ctx context.Context, prURL string) (*Details, error) {
+	var stderr strings.Builder
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prURL,
 		"--json", "url,number,state,comments,reviews",
 	)
+	cmd.Stderr = &stderr
 	stdout, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("gh pr view %s: %w", prURL, err)
+		return nil, fmt.Errorf("gh pr view %s: %w (%s)", prURL, err, strings.TrimSpace(stderr.String()))
 	}
 	var d Details
 	if err := json.Unmarshal(stdout, &d); err != nil {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -103,9 +104,25 @@ func (c *Client) listReviewComments(ctx context.Context, prURL string) ([]Review
 	if err != nil {
 		return nil, fmt.Errorf("gh api %s: %w (%s)", apiPath, err, strings.TrimSpace(stderr.String()))
 	}
-	var comments []ReviewComment
-	if err := json.Unmarshal(stdout, &comments); err != nil {
+	comments, err := decodeReviewComments(stdout)
+	if err != nil {
 		return nil, fmt.Errorf("decode review comments %s: %w", apiPath, err)
+	}
+	return comments, nil
+}
+
+// decodeReviewComments parses the output of `gh api --paginate`. Depending on
+// the gh version this is either a single merged JSON array or several arrays
+// concatenated (one per page); a streaming decoder handles both.
+func decodeReviewComments(stdout []byte) ([]ReviewComment, error) {
+	dec := json.NewDecoder(bytes.NewReader(stdout))
+	var comments []ReviewComment
+	for dec.More() {
+		var page []ReviewComment
+		if err := dec.Decode(&page); err != nil {
+			return nil, err
+		}
+		comments = append(comments, page...)
 	}
 	return comments, nil
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,56 @@
+package github
+
+import "testing"
+
+func TestExtractOwnerRepo(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"git@github.com:me/auth.git", "me/auth", false},
+		{"git@github.com:me/auth", "me/auth", false},
+		{"https://github.com/me/auth.git", "me/auth", false},
+		{"https://github.com/me/auth", "me/auth", false},
+		{"http://github.com/me/auth", "me/auth", false},
+		{"me/auth", "me/auth", false},
+		{"  me/auth  ", "me/auth", false},
+
+		{"garbage", "", true},
+		{"git@github.com:", "", true},
+		{"https://github.com/just-owner", "", true},
+		{"https://github.com/a/b/c", "", true},
+		{"/leading/slash", "", true},
+	}
+	for _, c := range cases {
+		got, err := ExtractOwnerRepo(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ExtractOwnerRepo(%q): err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ExtractOwnerRepo(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestActorIsBot(t *testing.T) {
+	if (Actor{Type: "Bot"}).IsBot() != true {
+		t.Error("Bot type should report IsBot true")
+	}
+	if (Actor{Type: "User"}).IsBot() != false {
+		t.Error("User type should report IsBot false")
+	}
+}
+
+func TestDetailsIsOpen(t *testing.T) {
+	if !(Details{State: "OPEN"}).IsOpen() {
+		t.Error("State=OPEN should be open")
+	}
+	if (Details{State: "CLOSED"}).IsOpen() {
+		t.Error("State=CLOSED should not be open")
+	}
+	if (Details{State: "MERGED"}).IsOpen() {
+		t.Error("State=MERGED should not be open")
+	}
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -34,6 +34,30 @@ func TestExtractOwnerRepo(t *testing.T) {
 	}
 }
 
+func TestReviewCommentsAPIPath(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"https://github.com/me/auth/pull/12", "repos/me/auth/pulls/12/comments", false},
+		{"https://github.com/me/auth/pull/12/files", "repos/me/auth/pulls/12/comments", false},
+		{"https://github.com/me/auth/issues/12", "", true},
+		{"https://github.com/me/auth", "", true},
+		{"https://github.com/me", "", true},
+	}
+	for _, c := range cases {
+		got, err := reviewCommentsAPIPath(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("reviewCommentsAPIPath(%q): err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("reviewCommentsAPIPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestActorIsBot(t *testing.T) {
 	if (Actor{Type: "Bot"}).IsBot() != true {
 		t.Error("Bot type should report IsBot true")

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -2,6 +2,29 @@ package github
 
 import "testing"
 
+func TestDecodeReviewComments(t *testing.T) {
+	// Single merged array (modern gh).
+	single := `[{"id":1,"user":{"login":"alice","type":"User"},"body":"a","path":"x.go","line":1}]`
+	// Concatenated arrays, one per page (older gh --paginate).
+	concat := `[{"id":1,"user":{"login":"a","type":"User"},"body":"a"}]` +
+		`[{"id":2,"user":{"login":"gemini","type":"Bot"},"body":"b"}]`
+
+	got, err := decodeReviewComments([]byte(single))
+	if err != nil || len(got) != 1 || got[0].Author.Login != "alice" || got[0].Line != 1 {
+		t.Errorf("single: got %+v err %v", got, err)
+	}
+
+	got, err = decodeReviewComments([]byte(concat))
+	if err != nil || len(got) != 2 || got[1].Author.Login != "gemini" {
+		t.Errorf("concatenated: got %+v err %v", got, err)
+	}
+
+	got, err = decodeReviewComments([]byte(""))
+	if err != nil || len(got) != 0 {
+		t.Errorf("empty: got %+v err %v", got, err)
+	}
+}
+
 func TestExtractOwnerRepo(t *testing.T) {
 	cases := []struct {
 		in      string

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -45,6 +45,21 @@ type Review struct {
 	SubmittedAt time.Time `json:"submittedAt"`
 }
 
+// ReviewComment is an inline review-thread comment attached to a specific
+// file + line in the PR diff (e.g. a "Suggested change"). These are NOT
+// returned by `gh pr view`; they come from the REST API
+// repos/{owner}/{repo}/pulls/{n}/comments, hence the snake_case tags and the
+// nested `user` object instead of `author`.
+type ReviewComment struct {
+	ID        int64     `json:"id"`
+	Author    Actor     `json:"user"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+	URL       string    `json:"html_url"`
+	Path      string    `json:"path"`
+	Line      int       `json:"line"`
+}
+
 // Details is the full view of a PR Nightshift needs to decide whether to
 // re-engage and how. Mirrors the JSON shape `gh pr view --json ...` returns.
 type Details struct {
@@ -53,6 +68,9 @@ type Details struct {
 	State    string    `json:"state"` // OPEN | CLOSED | MERGED
 	Comments []Comment `json:"comments"`
 	Reviews  []Review  `json:"reviews"`
+	// ReviewComments are inline review-thread comments, fetched separately
+	// from the REST API and merged in by GetPR (gh pr view omits them).
+	ReviewComments []ReviewComment `json:"-"`
 }
 
 // IsOpen reports whether the PR is open (not closed or merged).

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -1,0 +1,59 @@
+// Package github wraps the `gh` CLI for the operations Nightshift's watcher
+// needs: listing PRs Nightshift authored, fetching their comments and reviews,
+// and (later) pulling check-run status. Stays thin — types mirror what `gh`
+// returns under --json, so decoding is JSON unmarshal straight onto these.
+package github
+
+import "time"
+
+// Actor is the GitHub user/bot that authored a comment or review. `gh`
+// returns `type: "User"|"Bot"` — Nightshift treats bots specially in the
+// trusted-reviewer filter.
+type Actor struct {
+	Login string `json:"login"`
+	Type  string `json:"type"`
+}
+
+// IsBot reports whether the actor is a GitHub App / Bot account.
+func (a Actor) IsBot() bool { return a.Type == "Bot" }
+
+// PR is the lightweight view returned by `gh pr list`.
+type PR struct {
+	URL         string `json:"url"`
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	HeadRefName string `json:"headRefName"`
+}
+
+// Comment is a top-level PR conversation comment (not an inline review
+// comment). `gh pr view --json comments` returns these.
+type Comment struct {
+	ID        string    `json:"id"`
+	Author    Actor     `json:"author"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"createdAt"`
+	URL       string    `json:"url"`
+}
+
+// Review is a submitted PR review. State is one of APPROVED,
+// CHANGES_REQUESTED, COMMENTED, DISMISSED.
+type Review struct {
+	ID          string    `json:"id"`
+	Author      Actor     `json:"author"`
+	Body        string    `json:"body"`
+	State       string    `json:"state"`
+	SubmittedAt time.Time `json:"submittedAt"`
+}
+
+// Details is the full view of a PR Nightshift needs to decide whether to
+// re-engage and how. Mirrors the JSON shape `gh pr view --json ...` returns.
+type Details struct {
+	URL      string    `json:"url"`
+	Number   int       `json:"number"`
+	State    string    `json:"state"` // OPEN | CLOSED | MERGED
+	Comments []Comment `json:"comments"`
+	Reviews  []Review  `json:"reviews"`
+}
+
+// IsOpen reports whether the PR is open (not closed or merged).
+func (d Details) IsOpen() bool { return d.State == "OPEN" }

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -139,6 +139,26 @@ func (c *Client) Comment(ctx context.Context, issueID, body string) error {
 	return nil
 }
 
+// GetIssueByIdentifier fetches a single issue by its human-readable
+// identifier (e.g. "ENG-42"). Linear's API accepts identifiers in addition
+// to UUIDs for the `issue(id:)` argument.
+func (c *Client) GetIssueByIdentifier(ctx context.Context, identifier string) (Issue, error) {
+	query := `query($id: String!) {
+	  issue(id: $id) { id identifier title description url project { name } }
+	}`
+
+	var resp struct {
+		Issue *Issue `json:"issue"`
+	}
+	if err := c.Do(ctx, query, map[string]any{"id": identifier}, &resp); err != nil {
+		return Issue{}, err
+	}
+	if resp.Issue == nil {
+		return Issue{}, fmt.Errorf("linear returned no issue for identifier %q", identifier)
+	}
+	return *resp.Issue, nil
+}
+
 // Ping verifies the API key works by fetching the authenticated viewer.
 // Returns the viewer's display name on success.
 func (c *Client) Ping(ctx context.Context) (string, error) {

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -100,7 +100,10 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 		if len(p.active) >= p.cfg.MaxConcurrent {
 			p.mu.Unlock()
 			slog.Info("pr iteration deferred — at capacity", "id", identifier)
-			return // try again next tick
+			// continue, not return: this PR waits for the next tick, but
+			// later non-actionable PRs in this batch still need their cursors
+			// advanced.
+			continue
 		}
 		p.active[identifier] = struct{}{}
 		p.mu.Unlock()
@@ -124,21 +127,29 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	// Heads-up Telegram (always — not gated by TELEGRAM_VERBOSE).
 	p.telegram.Send(ctx, fmt.Sprintf("🔄 *%s* — addressing review on PR #%d", identifier, ch.PR.Number))
 
+	// On every failure path below we record the iteration before returning.
+	// Otherwise the cursor never advances and the next poll re-discovers the
+	// same feedback, re-runs, and fails again — an infinite retry loop. The
+	// only exceptions are infra failures (timeout / rate-limit), handled
+	// further down, which intentionally retry.
 	project, err := p.matchPRtoProject(ch.PR.URL)
 	if err != nil {
 		logger.Error("could not match PR to a registered project", "err", err)
+		p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
 		return
 	}
 
 	resolved, err := p.resolver.Resolve(ctx, project)
 	if err != nil {
 		logger.Error("repo resolve failed", "err", err)
+		p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
 		return
 	}
 
 	wt, err := repo.ResumeWorktree(ctx, p.cfg.WorktreeBase, identifier, resolved.Path)
 	if err != nil {
 		logger.Error("resume worktree failed", "err", err)
+		p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
 		return
 	}
 	defer repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, identifier)
@@ -204,6 +215,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	}
 	if runErr != nil {
 		logger.Error("claude run failed", "err", runErr)
+		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 		return
 	}
 
@@ -223,21 +235,25 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	hasChanges, err := workingTreeChanged(ctx, wt.Path)
 	if err != nil {
 		logger.Error("git status failed", "err", err)
+		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 		return
 	}
 	if hasChanges {
 		if err := runIn(ctx, wt.Path, "git", "add", "-A"); err != nil {
 			logger.Error("git add failed", "err", err)
+			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 			return
 		}
 		commitMsg := fmt.Sprintf("fix: address review feedback on %s\n\nFollow-up commit by Nightshift addressing %d new feedback item(s).",
 			identifier, len(ch.Events))
 		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
 			logger.Error("git commit failed", "err", err)
+			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 			return
 		}
 		if err := runIn(ctx, wt.Path, "git", "push", "origin", wt.Branch); err != nil {
 			logger.Error("git push failed", "err", err)
+			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 			return
 		}
 		logger.Info("pushed follow-up commit", "branch", wt.Branch)

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -213,7 +213,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 				blocked, p.cfg.TriggerState))
 		}
 		// Advance cursor + count attempt so we don't loop on the same feedback.
-		p.recordIteration(ch, identifier, ch.PR.Number, issueID)
+		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 		return
 	}
 
@@ -243,12 +243,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		logger.Info("iteration produced no diff — feedback addressed without code edits, or Claude chose not to act")
 	}
 
-	p.recordIteration(ch, identifier, ch.PR.Number, issueID)
+	p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 }
 
 // recordIteration bumps the per-PR iteration counter, advances the comment +
 // review cursors, and fires the cap-hit notifications on the transition.
-func (p *Pipeline) recordIteration(ch watch.PRChanges, identifier string, prNumber int, issueID string) {
+func (p *Pipeline) recordIteration(ctx context.Context, ch watch.PRChanges, identifier string, prNumber int, issueID string) {
 	var iterations int
 	if err := p.store.Update(ch.PR.URL, func(r *state.PRState) {
 		if r.TicketID == "" {
@@ -268,11 +268,11 @@ func (p *Pipeline) recordIteration(ch watch.PRChanges, identifier string, prNumb
 	}
 
 	if iterations >= p.cfg.MaxPRIterations {
-		p.telegram.Send(context.Background(), fmt.Sprintf(
+		p.telegram.Send(ctx, fmt.Sprintf(
 			"🛑 *%s* — PR #%d hit iteration cap (%d attempts). Needs human attention.",
 			identifier, prNumber, iterations))
 		if issueID != "" {
-			_ = p.linear.Comment(context.Background(), issueID, fmt.Sprintf(
+			_ = p.linear.Comment(ctx, issueID, fmt.Sprintf(
 				"🛑 **Nightshift: PR iteration cap reached** (%d attempts on PR %s).\n\nNeeds a human to take a look — Nightshift won't re-engage on this PR again unless you reset the iteration count in `~/.nightshift-state.json` or close the PR.",
 				iterations, ch.PR.URL))
 		}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -163,6 +163,8 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			Body:   ev.Body,
 			URL:    ev.URL,
 			State:  ev.ReviewState,
+			Path:   ev.Path,
+			Line:   ev.Line,
 		})
 	}
 

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -1,0 +1,337 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/agent"
+	"github.com/ahmadAlMezaal/nightshift/internal/github"
+	"github.com/ahmadAlMezaal/nightshift/internal/repo"
+	"github.com/ahmadAlMezaal/nightshift/internal/state"
+	"github.com/ahmadAlMezaal/nightshift/internal/watch"
+)
+
+// runWatcher is the PR-poll loop counterpart to the main Linear-poll loop.
+// Started by Run when cfg.AutoIteratePRs is true and the watcher initialised
+// without error.
+func (p *Pipeline) runWatcher(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	slog.Info("pr watcher starting",
+		"interval", p.cfg.PRPollInterval,
+		"max_iterations", p.cfg.MaxPRIterations,
+		"trusted_reviewers", p.cfg.TrustedReviewers,
+	)
+
+	ticker := time.NewTicker(p.cfg.PRPollInterval)
+	defer ticker.Stop()
+
+	// Initial scan after a brief delay so the Linear-startup output clears.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(5 * time.Second):
+	}
+	p.prPollOnce(ctx, wg)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.prPollOnce(ctx, wg)
+		}
+	}
+}
+
+// prPollOnce is one watcher tick: scan PRs, advance cursors for non-actionable
+// events, and dispatch iteratePR goroutines for everything that is actionable
+// (and not at the iteration cap).
+func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
+	scanCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	changes, err := p.watcher.Scan(scanCtx)
+	cancel()
+	if err != nil {
+		slog.Warn("pr poll: scan failed", "err", err)
+		return
+	}
+
+	slog.Info("pr poll", "prs_with_changes", len(changes))
+
+	for _, ch := range changes {
+		// Even with no actionable events (all-APPROVED / all-skipped),
+		// advance the cursor so we don't re-evaluate the same events on
+		// every poll.
+		if len(ch.Events) == 0 {
+			p.advanceCursor(ch)
+			continue
+		}
+
+		identifier := identifierFromBranch(ch.PR.HeadRefName)
+		if identifier == "" {
+			slog.Warn("pr poll: branch is not a Nightshift branch; skipping",
+				"branch", ch.PR.HeadRefName)
+			continue
+		}
+
+		cursor := p.store.Get(ch.PR.URL)
+		if cursor.Iterations >= p.cfg.MaxPRIterations {
+			slog.Info("pr at iteration cap — skipping",
+				"pr", ch.PR.URL, "iterations", cursor.Iterations, "cap", p.cfg.MaxPRIterations)
+			// Advance cursor anyway so the same skipped events don't
+			// keep getting "discovered" forever.
+			p.advanceCursor(ch)
+			continue
+		}
+
+		p.mu.Lock()
+		if _, dupe := p.active[identifier]; dupe {
+			p.mu.Unlock()
+			slog.Info("pr iteration skipped — ticket already in progress", "id", identifier)
+			continue
+		}
+		if len(p.active) >= p.cfg.MaxConcurrent {
+			p.mu.Unlock()
+			slog.Info("pr iteration deferred — at capacity", "id", identifier)
+			return // try again next tick
+		}
+		p.active[identifier] = struct{}{}
+		p.mu.Unlock()
+
+		wg.Add(1)
+		go func(ch watch.PRChanges, id string) {
+			defer wg.Done()
+			defer p.markDone(id)
+			p.iteratePR(ctx, ch, id)
+		}(ch, identifier)
+	}
+}
+
+// iteratePR is one re-engagement on an open PR. Resolves the repo, resumes
+// the existing remote branch, builds a fix prompt from the new feedback,
+// runs Claude, and pushes the follow-up commit.
+func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier string) {
+	logger := slog.With("id", identifier, "pr", ch.PR.URL)
+	logger.Info("re-engaging on PR feedback", "events", len(ch.Events))
+
+	// Heads-up Telegram (always — not gated by TELEGRAM_VERBOSE).
+	p.telegram.Send(ctx, fmt.Sprintf("🔄 *%s* — addressing review on PR #%d", identifier, ch.PR.Number))
+
+	project, err := p.matchPRtoProject(ch.PR.URL)
+	if err != nil {
+		logger.Error("could not match PR to a registered project", "err", err)
+		return
+	}
+
+	resolved, err := p.resolver.Resolve(ctx, project)
+	if err != nil {
+		logger.Error("repo resolve failed", "err", err)
+		return
+	}
+
+	wt, err := repo.ResumeWorktree(ctx, p.cfg.WorktreeBase, identifier, resolved.Path)
+	if err != nil {
+		logger.Error("resume worktree failed", "err", err)
+		return
+	}
+	defer repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, identifier)
+
+	// Fetch ticket context from Linear so the fix prompt has Title + Description.
+	// If Linear is unreachable, fall back to placeholders rather than aborting.
+	var title, description, issueID string
+	if issue, err := p.linear.GetIssueByIdentifier(ctx, identifier); err == nil {
+		title = issue.Title
+		description = issue.Description
+		issueID = issue.ID
+	} else {
+		logger.Warn("could not fetch Linear ticket — proceeding without context", "err", err)
+		title = identifier
+	}
+
+	items := make([]agent.FeedbackItem, 0, len(ch.Events))
+	for _, ev := range ch.Events {
+		items = append(items, agent.FeedbackItem{
+			Kind:   string(ev.Type),
+			Author: ev.Author.Login,
+			Body:   ev.Body,
+			URL:    ev.URL,
+			State:  ev.ReviewState,
+		})
+	}
+
+	prompt := agent.BuildFixPrompt(agent.FixPromptInput{
+		Identifier:  identifier,
+		Title:       title,
+		Description: description,
+		PRNumber:    ch.PR.Number,
+		PRURL:       ch.PR.URL,
+		Feedback:    items,
+	})
+
+	logFile := filepath.Join(p.cfg.LogDir, identifier+".log")
+	_ = agent.AttemptHeader(logFile)
+	offset := agent.OffsetBefore(logFile)
+
+	runErr := agent.Run(ctx, agent.RunOptions{
+		Workdir:       wt.Path,
+		Prompt:        prompt,
+		LogFile:       logFile,
+		Timeout:       p.cfg.AgentTimeout,
+		UseAgentTeams: p.cfg.UseAgentTeams,
+	})
+
+	// Don't increment iteration count on infrastructure-level failures
+	// (timeout / rate-limit) — those weren't really attempts on the feedback.
+	if errors.Is(runErr, agent.ErrTimedOut) {
+		logger.Warn("iteration timed out — will retry next poll", "timeout", p.cfg.AgentTimeout)
+		return
+	}
+
+	output := agent.ReadAfter(logFile, offset)
+	if agent.HasRateLimit(output) {
+		logger.Warn("rate limit detected during iteration")
+		p.flagRateLimit()
+		return
+	}
+	if runErr != nil {
+		logger.Error("claude run failed", "err", runErr)
+		return
+	}
+
+	if blocked := agent.BlockedLine(output); blocked != "" {
+		logger.Info("claude blocked on review feedback", "line", blocked)
+		if issueID != "" {
+			_ = p.linear.Comment(ctx, issueID, fmt.Sprintf(
+				"🚧 **Nightshift: blocked on PR feedback**\n\n> %s\n\nLeft the PR as-is. Reply to the PR with clarification, then move the ticket to **%s** to retry.",
+				blocked, p.cfg.TriggerState))
+		}
+		// Advance cursor + count attempt so we don't loop on the same feedback.
+		p.recordIteration(ch, identifier, ch.PR.Number, issueID)
+		return
+	}
+
+	// Apply changes (if any).
+	hasChanges, err := workingTreeChanged(ctx, wt.Path)
+	if err != nil {
+		logger.Error("git status failed", "err", err)
+		return
+	}
+	if hasChanges {
+		if err := runIn(ctx, wt.Path, "git", "add", "-A"); err != nil {
+			logger.Error("git add failed", "err", err)
+			return
+		}
+		commitMsg := fmt.Sprintf("fix: address review feedback on %s\n\nFollow-up commit by Nightshift addressing %d new feedback item(s).",
+			identifier, len(ch.Events))
+		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
+			logger.Error("git commit failed", "err", err)
+			return
+		}
+		if err := runIn(ctx, wt.Path, "git", "push", "origin", wt.Branch); err != nil {
+			logger.Error("git push failed", "err", err)
+			return
+		}
+		logger.Info("pushed follow-up commit", "branch", wt.Branch)
+	} else {
+		logger.Info("iteration produced no diff — feedback addressed without code edits, or Claude chose not to act")
+	}
+
+	p.recordIteration(ch, identifier, ch.PR.Number, issueID)
+}
+
+// recordIteration bumps the per-PR iteration counter, advances the comment +
+// review cursors, and fires the cap-hit notifications on the transition.
+func (p *Pipeline) recordIteration(ch watch.PRChanges, identifier string, prNumber int, issueID string) {
+	var iterations int
+	if err := p.store.Update(ch.PR.URL, func(r *state.PRState) {
+		if r.TicketID == "" {
+			r.TicketID = identifier
+		}
+		if ch.NewestComment.After(r.LastCommentAt) {
+			r.LastCommentAt = ch.NewestComment
+		}
+		if ch.NewestReview.After(r.LastReviewAt) {
+			r.LastReviewAt = ch.NewestReview
+		}
+		r.Iterations++
+		r.LastIteratedAt = time.Now()
+		iterations = r.Iterations
+	}); err != nil {
+		slog.Warn("pipeline: state update failed", "url", ch.PR.URL, "err", err)
+	}
+
+	if iterations >= p.cfg.MaxPRIterations {
+		p.telegram.Send(context.Background(), fmt.Sprintf(
+			"🛑 *%s* — PR #%d hit iteration cap (%d attempts). Needs human attention.",
+			identifier, prNumber, iterations))
+		if issueID != "" {
+			_ = p.linear.Comment(context.Background(), issueID, fmt.Sprintf(
+				"🛑 **Nightshift: PR iteration cap reached** (%d attempts on PR %s).\n\nNeeds a human to take a look — Nightshift won't re-engage on this PR again unless you reset the iteration count in `~/.nightshift-state.json` or close the PR.",
+				iterations, ch.PR.URL))
+		}
+	}
+}
+
+// advanceCursor moves the per-PR comment/review cursor forward without
+// incrementing the iteration counter — used when a poll finds only non-
+// actionable events (APPROVED reviews, skipped bot comments, etc.).
+func (p *Pipeline) advanceCursor(ch watch.PRChanges) {
+	if err := p.store.Update(ch.PR.URL, func(r *state.PRState) {
+		if ch.NewestComment.After(r.LastCommentAt) {
+			r.LastCommentAt = ch.NewestComment
+		}
+		if ch.NewestReview.After(r.LastReviewAt) {
+			r.LastReviewAt = ch.NewestReview
+		}
+	}); err != nil {
+		slog.Warn("pipeline: cursor advance failed", "url", ch.PR.URL, "err", err)
+	}
+}
+
+// matchPRtoProject finds the Linear project name in repos.json whose
+// configured URL points at the same owner/repo as the PR.
+func (p *Pipeline) matchPRtoProject(prURL string) (string, error) {
+	target, err := prRepoOwnerRepo(prURL)
+	if err != nil {
+		return "", err
+	}
+	if p.cfg.Registry == nil {
+		return "", fmt.Errorf("no registry configured; cannot match PR %s to a project", prURL)
+	}
+	for name, entry := range p.cfg.Registry.Repos {
+		if got, err := github.ExtractOwnerRepo(entry.URL); err == nil && got == target {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no registry entry matches %s (looking for %s)", prURL, target)
+}
+
+// prRepoOwnerRepo extracts owner/name from a PR URL like
+// https://github.com/owner/name/pull/N.
+func prRepoOwnerRepo(prURL string) (string, error) {
+	u, err := url.Parse(prURL)
+	if err != nil {
+		return "", fmt.Errorf("parse PR URL %q: %w", prURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("PR URL path too short: %q", u.Path)
+	}
+	return parts[0] + "/" + parts[1], nil
+}
+
+// identifierFromBranch turns "nightshift/eng-42" into "ENG-42". Returns ""
+// if the branch isn't a Nightshift branch.
+func identifierFromBranch(branch string) string {
+	if !strings.HasPrefix(branch, "nightshift/") {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimPrefix(branch, "nightshift/"))
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -257,6 +257,11 @@ func (p *Pipeline) banner() {
 	if p.telegram.Enabled {
 		notifyMode = "Telegram"
 	}
+	autoIterMode := "Disabled"
+	if p.watcher != nil {
+		autoIterMode = fmt.Sprintf("On (cap %d, poll %s)",
+			p.cfg.MaxPRIterations, p.cfg.PRPollInterval)
+	}
 
 	repoSummary := p.cfg.RepoPath
 	if p.cfg.Registry != nil {
@@ -274,6 +279,7 @@ func (p *Pipeline) banner() {
 	fmt.Printf("   Team:           %s\n", p.cfg.LinearTeamKey)
 	fmt.Printf("   Watching:       %q column\n", p.cfg.TriggerState)
 	fmt.Printf("   Review:         %s\n", reviewMode)
+	fmt.Printf("   Auto-iterate:   %s\n", autoIterMode)
 	fmt.Printf("   Max concurrent: %d\n", p.cfg.MaxConcurrent)
 	fmt.Printf("   Poll interval:  %s\n", p.cfg.PollInterval)
 	fmt.Printf("   Agent timeout:  %s\n", p.cfg.AgentTimeout)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -12,10 +12,13 @@ import (
 	"time"
 
 	"github.com/ahmadAlMezaal/nightshift/internal/config"
+	"github.com/ahmadAlMezaal/nightshift/internal/github"
 	"github.com/ahmadAlMezaal/nightshift/internal/linear"
 	"github.com/ahmadAlMezaal/nightshift/internal/notify"
 	"github.com/ahmadAlMezaal/nightshift/internal/repo"
 	"github.com/ahmadAlMezaal/nightshift/internal/review"
+	"github.com/ahmadAlMezaal/nightshift/internal/state"
+	"github.com/ahmadAlMezaal/nightshift/internal/watch"
 )
 
 // Pipeline holds the wiring shared by every ticket the agent processes.
@@ -26,6 +29,11 @@ type Pipeline struct {
 	telegram *notify.Telegram
 	review   *review.Gate
 	states   linear.StateIDs
+
+	// Auto-iterate plumbing — all nil when cfg.AutoIteratePRs is false.
+	store   *state.Store
+	gh      *github.Client
+	watcher *watch.Watcher
 
 	sessionStart time.Time
 
@@ -40,7 +48,7 @@ type Pipeline struct {
 
 // New constructs a Pipeline. It does not perform any I/O — call Run to start.
 func New(cfg *config.Config) *Pipeline {
-	return &Pipeline{
+	p := &Pipeline{
 		cfg:            cfg,
 		linear:         linear.New(cfg.LinearAPIKey),
 		resolver:       repo.FromConfig(cfg),
@@ -50,6 +58,29 @@ func New(cfg *config.Config) *Pipeline {
 		failedAttempts: map[string]int{},
 		sessionStart:   time.Now(),
 	}
+
+	// Auto-iterate is opt-in. When disabled, store/gh/watcher stay nil and
+	// the run loop never starts the PR-poller goroutine.
+	if cfg.AutoIteratePRs {
+		store, err := state.Open(cfg.StateFile)
+		if err != nil {
+			slog.Warn("auto-iterate: state store open failed; feature disabled",
+				"path", cfg.StateFile, "err", err)
+			return p
+		}
+		p.store = store
+		p.gh = github.New()
+
+		var repoURLs []string
+		if cfg.Registry != nil {
+			for _, name := range cfg.Registry.ProjectNames() {
+				repoURLs = append(repoURLs, cfg.Registry.Repos[name].URL)
+			}
+		}
+		p.watcher = watch.New(p.gh, store, repoURLs, cfg.TrustedReviewers)
+	}
+
+	return p
 }
 
 // Run blocks until ctx is canceled, the dispatch cap is hit, or a rate-limit
@@ -82,6 +113,14 @@ func (p *Pipeline) Run(ctx context.Context) error {
 
 	// One poll right away so we don't sit idle for the first interval.
 	p.pollOnce(ctx, &wg)
+
+	// PR watcher runs on its own ticker if auto-iterate is enabled. Lives
+	// inside this Run so it shares the WaitGroup — graceful shutdown waits
+	// for in-flight iterations the same way it waits for fresh dispatches.
+	if p.watcher != nil {
+		wg.Add(1)
+		go p.runWatcher(ctx, &wg)
+	}
 
 	for {
 		select {

--- a/internal/repo/worktree.go
+++ b/internal/repo/worktree.go
@@ -39,6 +39,32 @@ func CreateWorktree(ctx context.Context, base, identifier, repoPath, mainBranch 
 	return Worktree{Path: wt, Branch: branch}, nil
 }
 
+// ResumeWorktree creates a worktree from an EXISTING remote branch instead of
+// starting fresh from main. Used when Nightshift re-engages on an open PR to
+// address review comments or CI failures — prior commits stay intact and
+// follow-up work appears as additional commits on the same branch.
+//
+// Fails (rather than falling back to main) if origin/<branch> doesn't exist;
+// callers should use CreateWorktree for that case.
+func ResumeWorktree(ctx context.Context, base, identifier, repoPath string) (Worktree, error) {
+	branch := BranchName(identifier)
+	wt := filepath.Join(base, identifier)
+
+	if err := runIn(ctx, repoPath, "git", "fetch", "origin", branch, "--quiet"); err != nil {
+		return Worktree{}, fmt.Errorf("git fetch origin %s: %w", branch, err)
+	}
+
+	// Clear any stale local branch + worktree so the resume starts from a
+	// known-good remote tip.
+	_ = runIn(ctx, repoPath, "git", "branch", "-D", branch)
+	_ = runIn(ctx, repoPath, "git", "worktree", "remove", "--force", wt)
+
+	if err := runIn(ctx, repoPath, "git", "worktree", "add", "-b", branch, wt, "origin/"+branch); err != nil {
+		return Worktree{}, fmt.Errorf("git worktree add %s (resume): %w", wt, err)
+	}
+	return Worktree{Path: wt, Branch: branch}, nil
+}
+
 // CleanupWorktree removes the worktree for an identifier. We try the git
 // worktree machinery first (which also clears the admin entry), and fall back
 // to plain rm -rf if that fails — matching the bash predecessor.

--- a/internal/repo/worktree.go
+++ b/internal/repo/worktree.go
@@ -28,10 +28,13 @@ func CreateWorktree(ctx context.Context, base, identifier, repoPath, mainBranch 
 	branch := BranchName(identifier)
 	wt := filepath.Join(base, identifier)
 
-	// Best-effort: pull the latest main and clear any stale state.
+	// Best-effort: pull the latest main and clear any stale state. Remove the
+	// worktree BEFORE deleting the branch — git refuses to delete a branch
+	// that's still checked out in a worktree, which would leave the branch
+	// behind and make the `worktree add -b` below fail.
 	_ = runIn(ctx, repoPath, "git", "fetch", "origin", mainBranch, "--quiet")
-	_ = runIn(ctx, repoPath, "git", "branch", "-D", branch)
 	_ = runIn(ctx, repoPath, "git", "worktree", "remove", "--force", wt)
+	_ = runIn(ctx, repoPath, "git", "branch", "-D", branch)
 
 	if err := runIn(ctx, repoPath, "git", "worktree", "add", "-b", branch, wt, "origin/"+mainBranch); err != nil {
 		return Worktree{}, fmt.Errorf("git worktree add %s: %w", wt, err)
@@ -54,10 +57,11 @@ func ResumeWorktree(ctx context.Context, base, identifier, repoPath string) (Wor
 		return Worktree{}, fmt.Errorf("git fetch origin %s: %w", branch, err)
 	}
 
-	// Clear any stale local branch + worktree so the resume starts from a
-	// known-good remote tip.
-	_ = runIn(ctx, repoPath, "git", "branch", "-D", branch)
+	// Clear any stale worktree + local branch so the resume starts from a
+	// known-good remote tip. Worktree first: git won't delete a branch still
+	// checked out in a worktree, and a leftover branch fails `worktree add -b`.
 	_ = runIn(ctx, repoPath, "git", "worktree", "remove", "--force", wt)
+	_ = runIn(ctx, repoPath, "git", "branch", "-D", branch)
 
 	if err := runIn(ctx, repoPath, "git", "worktree", "add", "-b", branch, wt, "origin/"+branch); err != nil {
 		return Worktree{}, fmt.Errorf("git worktree add %s (resume): %w", wt, err)

--- a/internal/repo/worktree_test.go
+++ b/internal/repo/worktree_test.go
@@ -68,3 +68,113 @@ func TestCreateWorktree_BadRepoPath(t *testing.T) {
 		t.Fatal("expected CreateWorktree to fail on a bad repo path")
 	}
 }
+
+// TestResumeWorktree_PicksUpExistingBranchCommits creates a fresh worktree,
+// commits a "marker" file to the branch, pushes it, then runs ResumeWorktree
+// — the resumed worktree should carry the marker forward instead of being
+// recreated from main.
+func TestResumeWorktree_PicksUpExistingBranchCommits(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	mustGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, string(out))
+		}
+	}
+
+	mustGit("init", "-b", "main", "--quiet")
+	mustGit("config", "user.email", "t@t")
+	mustGit("config", "user.name", "T")
+	mustGit("config", "commit.gpgsign", "false")
+	mustGit("config", "receive.denyCurrentBranch", "ignore")
+	mustGit("remote", "add", "origin", repo)
+
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("init"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mustGit("add", "-A")
+	mustGit("commit", "-m", "init", "--quiet")
+	mustGit("fetch", "origin", "--quiet")
+
+	base := t.TempDir()
+	ctx := context.Background()
+
+	// Round 1 — fresh ticket: create worktree from main, add a commit on the
+	// branch, push.
+	wt1, err := CreateWorktree(ctx, base, "ENG-300", repo, "main")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	markerPath := filepath.Join(wt1.Path, "from-attempt-1.txt")
+	if err := os.WriteFile(markerPath, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runInWt := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wt1.Path
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v in worktree: %v\n%s", args, err, string(out))
+		}
+	}
+	runInWt("add", "-A")
+	runInWt("commit", "-m", "attempt-1", "--quiet")
+	runInWt("push", "-u", "origin", wt1.Branch, "--quiet")
+
+	// Tear it down between rounds — mirrors a real lifecycle where the
+	// initial worktree is cleaned up after the first PR was created.
+	CleanupWorktree(ctx, repo, base, "ENG-300")
+
+	// Round 2 — resume: should bring back the marker, NOT start fresh.
+	wt2, err := ResumeWorktree(ctx, base, "ENG-300", repo)
+	if err != nil {
+		t.Fatalf("ResumeWorktree: %v", err)
+	}
+	if wt2.Branch != "nightshift/eng-300" {
+		t.Errorf("branch: got %q", wt2.Branch)
+	}
+	if _, err := os.Stat(filepath.Join(wt2.Path, "from-attempt-1.txt")); err != nil {
+		t.Errorf("resumed worktree is missing the prior attempt's marker file: %v", err)
+	}
+
+	CleanupWorktree(ctx, repo, base, "ENG-300")
+}
+
+func TestResumeWorktree_FailsIfBranchNotOnRemote(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	mustGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, string(out))
+		}
+	}
+
+	mustGit("init", "-b", "main", "--quiet")
+	mustGit("config", "user.email", "t@t")
+	mustGit("config", "user.name", "T")
+	mustGit("config", "commit.gpgsign", "false")
+	mustGit("remote", "add", "origin", repo)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("init"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mustGit("add", "-A")
+	mustGit("commit", "-m", "init", "--quiet")
+	mustGit("fetch", "origin", "--quiet")
+
+	if _, err := ResumeWorktree(context.Background(), t.TempDir(), "ENG-NEVER-PUSHED", repo); err == nil {
+		t.Fatal("expected ResumeWorktree to fail when the branch isn't on origin")
+	}
+}

--- a/internal/repo/worktree_test.go
+++ b/internal/repo/worktree_test.go
@@ -147,6 +147,72 @@ func TestResumeWorktree_PicksUpExistingBranchCommits(t *testing.T) {
 	CleanupWorktree(ctx, repo, base, "ENG-300")
 }
 
+// TestResumeWorktree_OverStaleWorktree resumes while a previous worktree for
+// the same branch is STILL checked out (e.g. a crash skipped cleanup). git
+// refuses to delete a branch checked out in a worktree, so cleanup must remove
+// the worktree before deleting the branch — otherwise `worktree add -b` fails.
+func TestResumeWorktree_OverStaleWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	mustGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, string(out))
+		}
+	}
+
+	mustGit("init", "-b", "main", "--quiet")
+	mustGit("config", "user.email", "t@t")
+	mustGit("config", "user.name", "T")
+	mustGit("config", "commit.gpgsign", "false")
+	mustGit("config", "receive.denyCurrentBranch", "ignore")
+	mustGit("remote", "add", "origin", repo)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("init"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mustGit("add", "-A")
+	mustGit("commit", "-m", "init", "--quiet")
+	mustGit("fetch", "origin", "--quiet")
+
+	base := t.TempDir()
+	ctx := context.Background()
+
+	wt1, err := CreateWorktree(ctx, base, "ENG-400", repo, "main")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wt1.Path, "marker.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runInWt := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wt1.Path
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v in worktree: %v\n%s", args, err, string(out))
+		}
+	}
+	runInWt("add", "-A")
+	runInWt("commit", "-m", "attempt-1", "--quiet")
+	runInWt("push", "-u", "origin", wt1.Branch, "--quiet")
+
+	// Deliberately DO NOT clean up — the branch stays checked out in wt1.
+	wt2, err := ResumeWorktree(ctx, base, "ENG-400", repo)
+	if err != nil {
+		t.Fatalf("ResumeWorktree over a stale worktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt2.Path, "marker.txt")); err != nil {
+		t.Errorf("resumed worktree missing prior marker: %v", err)
+	}
+
+	CleanupWorktree(ctx, repo, base, "ENG-400")
+}
+
 func TestResumeWorktree_FailsIfBranchNotOnRemote(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -130,6 +130,9 @@ func Run(scriptDir string) error {
 	timeoutMin := w.askInt("Agent timeout (minutes)", existingEnv["AGENT_TIMEOUT_MINUTES"], int(config.DefaultAgentTimeout/time.Minute), 5)
 	fmt.Println()
 
+	// ── Optional: Auto-iterate on PR feedback ─────────────────────────────────
+	autoIterate, maxIter, prPoll, trusted := w.collectAutoIterate(existingEnv)
+
 	// ── Optional: Gemini review gate ───────────────────────────────────────────
 	geminiKey := ""
 	if existingEnv["GEMINI_API_KEY"] != "" {
@@ -182,6 +185,16 @@ func Run(scriptDir string) error {
 	fmt.Printf("  MAX_RETRIES           = %d\n", retries)
 	fmt.Printf("  AGENT_TIMEOUT_MINUTES = %d\n", timeoutMin)
 	fmt.Printf("  GEMINI_API_KEY        = %s\n", maskOrNone(geminiKey))
+	fmt.Printf("  AUTO_ITERATE_PRS      = %s\n", autoIterate)
+	if autoIterate == "true" {
+		fmt.Printf("  MAX_PR_ITERATIONS     = %d\n", maxIter)
+		fmt.Printf("  PR_POLL_INTERVAL      = %d\n", prPoll)
+		if trusted == "" {
+			fmt.Printf("  TRUSTED_REVIEWERS     = (humans only)\n")
+		} else {
+			fmt.Printf("  TRUSTED_REVIEWERS     = %s\n", trusted)
+		}
+	}
 	fmt.Printf("  TELEGRAM_ENABLED      = %s\n", tgEnabled)
 	if tgEnabled == "true" {
 		fmt.Printf("  TELEGRAM_BOT_TOKEN    = %s\n", mask(tgToken))
@@ -214,6 +227,10 @@ func Run(scriptDir string) error {
 		tgEnabled:   tgEnabled,
 		tgToken:     tgToken,
 		tgChat:      tgChat,
+		autoIterate: autoIterate,
+		maxIter:     strconv.Itoa(maxIter),
+		prPoll:      strconv.Itoa(prPoll),
+		trusted:     trusted,
 	}); err != nil {
 		return fmt.Errorf("write %s: %w", envFile, err)
 	}
@@ -434,6 +451,36 @@ func (w *wizard) printCLIStatus() {
 	}
 }
 
+// collectAutoIterate prompts for the auto-iterate-PR feature and its safety
+// knobs. Returns the values as strings (for the .env template) plus the
+// numeric forms used in the summary block.
+func (w *wizard) collectAutoIterate(existing map[string]string) (autoIterate string, maxIter int, prPoll int, trusted string) {
+	autoIterate = "false"
+	maxIter = config.DefaultMaxPRIterations
+	prPoll = int(config.DefaultPRPollInterval / time.Second)
+
+	wasEnabled := strings.EqualFold(existing["AUTO_ITERATE_PRS"], "true")
+	prompt := "Enable auto-iterate on PR review feedback?"
+	if wasEnabled {
+		prompt = "Auto-iterate on PR feedback is currently on. Keep it?"
+	}
+	if !w.confirm(prompt) {
+		return autoIterate, maxIter, prPoll, ""
+	}
+	autoIterate = "true"
+
+	maxIter = w.askInt("Max iterations per PR before stopping",
+		existing["MAX_PR_ITERATIONS"], config.DefaultMaxPRIterations, 1)
+	prPoll = w.askInt("PR poll interval (seconds)",
+		existing["PR_POLL_INTERVAL"], int(config.DefaultPRPollInterval/time.Second), 30)
+
+	fmt.Println("Trusted reviewers (comma-separated GitHub logins).")
+	fmt.Println("Leave blank to act on humans only — bots get logged but skipped.")
+	trusted = w.askEx("Trusted reviewers", askOpts{existing: existing["TRUSTED_REVIEWERS"]})
+
+	return autoIterate, maxIter, prPoll, trusted
+}
+
 func (w *wizard) collectRepos(defaultMainBranch string, existing *config.RepoRegistry) *config.RepoRegistry {
 	fmt.Println()
 	fmt.Println("─── Repos ───")
@@ -559,6 +606,7 @@ type envValues struct {
 	mainBranch, repoPath                         string
 	concurrency, dispatches, retries, timeoutMin string
 	geminiKey, tgEnabled, tgToken, tgChat        string
+	autoIterate, maxIter, prPoll, trusted        string
 }
 
 func writeEnvFile(path string, v envValues) error {
@@ -596,6 +644,16 @@ TELEGRAM_CHAT_ID="%s"
 GEMINI_API_KEY="%s"
 GEMINI_MODEL="gemini-2.5-pro"
 MAX_REVIEW_RETRIES="1"
+
+# Auto-iterate on PR review feedback (ENG-173). Opt-in. When true,
+# Nightshift periodically polls open PRs it created for new review
+# comments and re-engages Claude on the same branch.
+AUTO_ITERATE_PRS="%s"
+MAX_PR_ITERATIONS="%s"
+PR_POLL_INTERVAL="%s"
+# Comma-separated GitHub logins / bot names whose feedback Nightshift will
+# act on. Humans are always trusted; empty = humans only (bots ignored).
+TRUSTED_REVIEWERS="%s"
 `,
 		time.Now().Format(time.RFC3339),
 		v.linearKey, v.team, v.trigger, v.review,
@@ -604,6 +662,7 @@ MAX_REVIEW_RETRIES="1"
 		v.dispatches, v.retries, v.timeoutMin,
 		v.tgEnabled, v.tgToken, v.tgChat,
 		v.geminiKey,
+		v.autoIterate, v.maxIter, v.prPoll, v.trusted,
 	)
 	return os.WriteFile(path, []byte(body), 0o600)
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -118,9 +118,6 @@ func (s *Store) Update(prURL string, fn func(*PRState)) error {
 	if err != nil {
 		return fmt.Errorf("marshal state: %w", err)
 	}
-	// Keep the lock held through the write so concurrent Updates serialize
-	// their disk writes — otherwise an older snapshot could land on disk
-	// after a newer one and silently revert it.
 	return writeAtomic(s.path, data)
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -142,5 +142,9 @@ func writeAtomic(path string, data []byte) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, path)
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath) // don't leak the temp file on a failed rename
+		return err
+	}
+	return nil
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,146 @@
+// Package state persists Nightshift's view of the PRs it has created and how
+// far it has caught up on each — last-seen comment / review cursors and the
+// per-PR iteration counter. The watcher reads this on startup so a restart
+// doesn't re-react to comments that pre-date the cursor.
+//
+// Backed by a single JSON file at the path passed to Open. Concurrent-safe:
+// the store guards its in-memory map with a mutex and writes the file
+// atomically (write-temp, rename) on every update.
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// PRState is the per-PR record stored in the state file.
+type PRState struct {
+	// TicketID is the Linear identifier the PR was opened for (e.g. ENG-42).
+	// Used to route comments on Linear when re-engaging or capping.
+	TicketID string `json:"ticket_id,omitempty"`
+
+	// LastCommentAt is the createdAt of the most recent issue-conversation
+	// comment the watcher has already processed for this PR. Anything with
+	// a later timestamp is "new" and worth acting on. Tracking by timestamp
+	// rather than ID because `gh` returns GraphQL node IDs (strings without
+	// natural ordering), whereas timestamps sort cleanly.
+	LastCommentAt time.Time `json:"last_comment_at,omitempty"`
+
+	// LastReviewAt is the submittedAt of the most recent review already
+	// processed.
+	LastReviewAt time.Time `json:"last_review_at,omitempty"`
+
+	// Iterations counts how many times Nightshift has re-engaged on this
+	// PR. Capped by config.MaxPRIterations.
+	Iterations int `json:"iterations,omitempty"`
+
+	// LastIteratedAt is the timestamp of the most recent re-engage. Mostly
+	// for telemetry — also useful for spotting stuck iteration loops.
+	LastIteratedAt time.Time `json:"last_iterated_at,omitempty"`
+}
+
+type fileFormat struct {
+	PRs map[string]*PRState `json:"prs"`
+}
+
+// Store is a thread-safe, file-backed PR state.
+type Store struct {
+	mu   sync.Mutex
+	path string
+	data fileFormat
+}
+
+// Open loads the state file at path. A missing file is not an error — the
+// returned store starts empty and Save will create the file on first write.
+func Open(path string) (*Store, error) {
+	s := &Store{path: path, data: fileFormat{PRs: map[string]*PRState{}}}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(raw, &s.data); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if s.data.PRs == nil {
+		s.data.PRs = map[string]*PRState{}
+	}
+	return s, nil
+}
+
+// Get returns a copy of the record for prURL, or a zero-value PRState if the
+// PR isn't tracked yet.
+func (s *Store) Get(prURL string) PRState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r, ok := s.data.PRs[prURL]; ok && r != nil {
+		return *r
+	}
+	return PRState{}
+}
+
+// All returns a copy of every tracked PR keyed by URL.
+func (s *Store) All() map[string]PRState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]PRState, len(s.data.PRs))
+	for k, v := range s.data.PRs {
+		if v != nil {
+			out[k] = *v
+		}
+	}
+	return out
+}
+
+// Update mutates the record for prURL in place via fn and writes the file.
+// A nil fn is a no-op. fn is called while the store is locked; do not call
+// back into the Store from inside fn.
+func (s *Store) Update(prURL string, fn func(*PRState)) error {
+	if fn == nil {
+		return nil
+	}
+	s.mu.Lock()
+	r, ok := s.data.PRs[prURL]
+	if !ok || r == nil {
+		r = &PRState{}
+		s.data.PRs[prURL] = r
+	}
+	fn(r)
+	data, err := json.MarshalIndent(s.data, "", "  ")
+	s.mu.Unlock()
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+	return writeAtomic(s.path, data)
+}
+
+// writeAtomic writes to a sibling temp file then renames over the target.
+// On POSIX, rename(2) is atomic — a crash mid-write leaves the previous
+// state file intact instead of an empty/corrupt one.
+func writeAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -107,6 +107,7 @@ func (s *Store) Update(prURL string, fn func(*PRState)) error {
 		return nil
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	r, ok := s.data.PRs[prURL]
 	if !ok || r == nil {
 		r = &PRState{}
@@ -114,10 +115,12 @@ func (s *Store) Update(prURL string, fn func(*PRState)) error {
 	}
 	fn(r)
 	data, err := json.MarshalIndent(s.data, "", "  ")
-	s.mu.Unlock()
 	if err != nil {
 		return fmt.Errorf("marshal state: %w", err)
 	}
+	// Keep the lock held through the write so concurrent Updates serialize
+	// their disk writes — otherwise an older snapshot could land on disk
+	// after a newer one and silently revert it.
 	return writeAtomic(s.path, data)
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,97 @@
+package state
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestOpen_MissingFileStartsEmpty(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if len(s.All()) != 0 {
+		t.Errorf("expected empty store, got %v", s.All())
+	}
+}
+
+func TestUpdate_PersistsAcrossReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	commentTs := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	const prURL = "https://github.com/me/repo/pull/42"
+	if err := s.Update(prURL, func(r *PRState) {
+		r.TicketID = "ENG-42"
+		r.LastCommentAt = commentTs
+		r.Iterations = 1
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Reopen and verify the values came back.
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := s2.Get(prURL)
+	if got.TicketID != "ENG-42" {
+		t.Errorf("TicketID: got %q", got.TicketID)
+	}
+	if !got.LastCommentAt.Equal(commentTs) {
+		t.Errorf("LastCommentAt: got %v, want %v", got.LastCommentAt, commentTs)
+	}
+	if got.Iterations != 1 {
+		t.Errorf("Iterations: got %d", got.Iterations)
+	}
+}
+
+func TestUpdate_MultipleCallsAccumulate(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const prURL = "https://github.com/me/repo/pull/1"
+	for i := 0; i < 3; i++ {
+		if err := s.Update(prURL, func(r *PRState) {
+			r.Iterations++
+		}); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+	}
+
+	if got := s.Get(prURL).Iterations; got != 3 {
+		t.Errorf("Iterations: got %d, want 3", got)
+	}
+}
+
+func TestGet_UnknownPRReturnsZero(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := s.Get("https://nope")
+	if got != (PRState{}) {
+		t.Errorf("expected zero PRState, got %+v", got)
+	}
+}
+
+func TestWriteAtomic_LeavesNoTmpFileOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	s, _ := Open(path)
+	if err := s.Update("a", func(r *PRState) { r.TicketID = "ENG-1" }); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, _ := filepath.Glob(filepath.Join(dir, "*.tmp-*"))
+	if len(entries) != 0 {
+		t.Errorf("temp files left behind: %v", entries)
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -54,10 +54,10 @@ type PRChanges struct {
 // Watcher couples the gh client with the state store and the trusted-reviewer
 // allowlist.
 type Watcher struct {
-	gh        *github.Client
-	store     *state.Store
-	trusted   map[string]bool
-	repoURLs  []string
+	gh       *github.Client
+	store    *state.Store
+	trusted  map[string]bool
+	repoURLs []string
 }
 
 // New constructs a Watcher. trusted is the list of GitHub logins/bot names

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -1,0 +1,184 @@
+// Package watch polls Nightshift-authored PRs for actionable review feedback
+// and emits PRChanges describing what's new since the last poll. Combined
+// with the state.Store cursor, the watcher only ever surfaces events that
+// haven't been processed yet — restarts don't re-react to historical
+// comments.
+//
+// The watcher is intentionally side-effect-free: it doesn't dispatch Claude,
+// doesn't touch worktrees, doesn't post to Linear. It just classifies. The
+// pipeline layer drives the actual response.
+package watch
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/github"
+	"github.com/ahmadAlMezaal/nightshift/internal/state"
+)
+
+// EventType distinguishes comments from reviews so the prompt builder can
+// label them appropriately.
+type EventType string
+
+const (
+	EventComment EventType = "comment"
+	EventReview  EventType = "review"
+)
+
+// Event is one new piece of feedback on a PR — either a conversation comment
+// or a submitted review.
+type Event struct {
+	Type        EventType
+	Author      github.Actor
+	Body        string
+	URL         string
+	At          time.Time
+	ReviewState string // populated when Type == EventReview
+}
+
+// PRChanges packages everything the pipeline needs to act on one PR's worth
+// of new feedback. NewestComment / NewestReview are the cursors the caller
+// should write back into the state store *after* the iteration succeeds.
+type PRChanges struct {
+	PR            github.PR
+	Details       *github.Details
+	Events        []Event   // actionable (action!)
+	Skipped       []Event   // seen but filtered (log + ignore)
+	NewestComment time.Time // greatest CreatedAt across all comments
+	NewestReview  time.Time // greatest SubmittedAt across all reviews
+}
+
+// Watcher couples the gh client with the state store and the trusted-reviewer
+// allowlist.
+type Watcher struct {
+	gh        *github.Client
+	store     *state.Store
+	trusted   map[string]bool
+	repoURLs  []string
+}
+
+// New constructs a Watcher. trusted is the list of GitHub logins/bot names
+// whose feedback should be acted on; humans are always trusted, so trusted
+// only meaningfully restricts bots.
+func New(gh *github.Client, store *state.Store, repoURLs []string, trusted []string) *Watcher {
+	t := make(map[string]bool, len(trusted))
+	for _, login := range trusted {
+		if login = strings.TrimSpace(login); login != "" {
+			t[login] = true
+		}
+	}
+	return &Watcher{gh: gh, store: store, trusted: t, repoURLs: repoURLs}
+}
+
+// Scan lists all open Nightshift PRs and returns one PRChanges per PR with
+// at least one new event (actionable OR skipped). PRs with no changes since
+// the last cursor are omitted from the result so callers can short-circuit.
+func (w *Watcher) Scan(ctx context.Context) ([]PRChanges, error) {
+	prs, err := w.gh.ListNightshiftPRs(ctx, w.repoURLs)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []PRChanges
+	for _, pr := range prs {
+		details, err := w.gh.GetPR(ctx, pr.URL)
+		if err != nil {
+			slog.Warn("watch: get PR failed", "url", pr.URL, "err", err)
+			continue
+		}
+		if !details.IsOpen() {
+			continue
+		}
+
+		cursor := w.store.Get(pr.URL)
+		ch := w.diff(pr, details, cursor)
+		if len(ch.Events) > 0 || len(ch.Skipped) > 0 {
+			out = append(out, ch)
+		}
+	}
+	return out, nil
+}
+
+// diff produces a PRChanges for one PR by comparing comments+reviews against
+// the cursor in state. Events past the cursor get classified into actionable
+// or skipped; events at-or-before the cursor are silently ignored (already
+// handled in a prior poll).
+func (w *Watcher) diff(pr github.PR, d *github.Details, cursor state.PRState) PRChanges {
+	out := PRChanges{
+		PR:            pr,
+		Details:       d,
+		NewestComment: cursor.LastCommentAt,
+		NewestReview:  cursor.LastReviewAt,
+	}
+
+	for _, c := range d.Comments {
+		if !c.CreatedAt.After(cursor.LastCommentAt) {
+			continue
+		}
+		if c.CreatedAt.After(out.NewestComment) {
+			out.NewestComment = c.CreatedAt
+		}
+		ev := Event{
+			Type:   EventComment,
+			Author: c.Author,
+			Body:   c.Body,
+			URL:    c.URL,
+			At:     c.CreatedAt,
+		}
+		if w.actionable(ev) {
+			out.Events = append(out.Events, ev)
+		} else {
+			out.Skipped = append(out.Skipped, ev)
+		}
+	}
+
+	for _, r := range d.Reviews {
+		if !r.SubmittedAt.After(cursor.LastReviewAt) {
+			continue
+		}
+		if r.SubmittedAt.After(out.NewestReview) {
+			out.NewestReview = r.SubmittedAt
+		}
+
+		// Reviews that don't request a response: skip the prompt but still
+		// advance the cursor (no need to revisit them).
+		if r.State == "APPROVED" || r.State == "DISMISSED" {
+			continue
+		}
+		if r.State == "COMMENTED" && strings.TrimSpace(r.Body) == "" {
+			// Empty "just commented" reviews are wrappers around inline
+			// comments; nothing actionable at the review level.
+			continue
+		}
+
+		ev := Event{
+			Type:        EventReview,
+			Author:      r.Author,
+			Body:        r.Body,
+			At:          r.SubmittedAt,
+			ReviewState: r.State,
+		}
+		if w.actionable(ev) {
+			out.Events = append(out.Events, ev)
+		} else {
+			out.Skipped = append(out.Skipped, ev)
+		}
+	}
+
+	return out
+}
+
+// actionable decides whether an event should be acted on. Humans are always
+// trusted; bots are acted on only if their login appears in the trusted list.
+// This is the lesson from PR #50: a bot reviewer was confidently wrong about
+// our golangci-lint config, and blindly applying its suggestion would have
+// rewritten valid v2 syntax to broken v1.
+func (w *Watcher) actionable(ev Event) bool {
+	if !ev.Author.IsBot() {
+		return true
+	}
+	return w.trusted[ev.Author.Login]
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -95,12 +95,9 @@ func (w *Watcher) Scan(ctx context.Context) ([]PRChanges, error) {
 
 		cursor := w.store.Get(pr.URL)
 		ch := w.diff(pr, details, cursor)
-		// Surface the PR if there's anything to act on or log, OR if the
-		// cursor moved past purely non-actionable events (a new APPROVED
-		// review, an empty COMMENTED wrapper). The latter produces no Events
-		// or Skipped, but we still need to return it so the caller persists
-		// the advanced cursor — otherwise those events are re-fetched and
-		// re-diffed on every single poll.
+		// cursorMoved covers PRs whose only new events are non-actionable
+		// (APPROVED review, empty COMMENTED wrapper): no Events/Skipped, but
+		// still returned so the caller persists the advanced cursor.
 		cursorMoved := ch.NewestComment.After(cursor.LastCommentAt) ||
 			ch.NewestReview.After(cursor.LastReviewAt)
 		if len(ch.Events) > 0 || len(ch.Skipped) > 0 || cursorMoved {

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -66,9 +66,11 @@ type Watcher struct {
 // whose feedback should be acted on; humans are always trusted, so trusted
 // only meaningfully restricts bots.
 func New(gh *github.Client, store *state.Store, repoURLs []string, trusted []string) *Watcher {
+	// GitHub logins are case-insensitive; normalise to lower so a config
+	// entry like "Gemini-Code-Assist" still matches the API's casing.
 	t := make(map[string]bool, len(trusted))
 	for _, login := range trusted {
-		if login = strings.TrimSpace(login); login != "" {
+		if login = strings.ToLower(strings.TrimSpace(login)); login != "" {
 			t[login] = true
 		}
 	}
@@ -213,5 +215,5 @@ func (w *Watcher) actionable(ev Event) bool {
 	if !ev.Author.IsBot() {
 		return true
 	}
-	return w.trusted[ev.Author.Login]
+	return w.trusted[strings.ToLower(ev.Author.Login)]
 }

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -95,7 +95,15 @@ func (w *Watcher) Scan(ctx context.Context) ([]PRChanges, error) {
 
 		cursor := w.store.Get(pr.URL)
 		ch := w.diff(pr, details, cursor)
-		if len(ch.Events) > 0 || len(ch.Skipped) > 0 {
+		// Surface the PR if there's anything to act on or log, OR if the
+		// cursor moved past purely non-actionable events (a new APPROVED
+		// review, an empty COMMENTED wrapper). The latter produces no Events
+		// or Skipped, but we still need to return it so the caller persists
+		// the advanced cursor — otherwise those events are re-fetched and
+		// re-diffed on every single poll.
+		cursorMoved := ch.NewestComment.After(cursor.LastCommentAt) ||
+			ch.NewestReview.After(cursor.LastReviewAt)
+		if len(ch.Events) > 0 || len(ch.Skipped) > 0 || cursorMoved {
 			out = append(out, ch)
 		}
 	}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -37,6 +37,8 @@ type Event struct {
 	URL         string
 	At          time.Time
 	ReviewState string // populated when Type == EventReview
+	Path        string // file path, populated for inline review comments
+	Line        int    // line number, populated for inline review comments
 }
 
 // PRChanges packages everything the pipeline needs to act on one PR's worth
@@ -132,6 +134,32 @@ func (w *Watcher) diff(pr github.PR, d *github.Details, cursor state.PRState) PR
 			Body:   c.Body,
 			URL:    c.URL,
 			At:     c.CreatedAt,
+		}
+		if w.actionable(ev) {
+			out.Events = append(out.Events, ev)
+		} else {
+			out.Skipped = append(out.Skipped, ev)
+		}
+	}
+
+	// Inline review-thread comments share the comment cursor — they're
+	// "comments" too, and comment timestamps are globally ordered, so a new
+	// inline comment always sorts after anything seen in a prior poll.
+	for _, rc := range d.ReviewComments {
+		if !rc.CreatedAt.After(cursor.LastCommentAt) {
+			continue
+		}
+		if rc.CreatedAt.After(out.NewestComment) {
+			out.NewestComment = rc.CreatedAt
+		}
+		ev := Event{
+			Type:   EventComment,
+			Author: rc.Author,
+			Body:   rc.Body,
+			URL:    rc.URL,
+			At:     rc.CreatedAt,
+			Path:   rc.Path,
+			Line:   rc.Line,
 		}
 		if w.actionable(ev) {
 			out.Events = append(out.Events, ev)

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1,0 +1,164 @@
+package watch
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/github"
+	"github.com/ahmadAlMezaal/nightshift/internal/state"
+)
+
+// newTestWatcher returns a Watcher with no gh client (we don't exercise gh
+// here — diff is the unit we care about) and a fresh state store.
+func newTestWatcher(t *testing.T, trusted []string) *Watcher {
+	t.Helper()
+	store, err := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return New(nil, store, nil, trusted)
+}
+
+func TestDiff_NewCommentByHumanIsActionable(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1", Number: 1}
+	details := &github.Details{
+		State: "OPEN",
+		Comments: []github.Comment{{
+			ID:        "C1",
+			Author:    github.Actor{Login: "alice", Type: "User"},
+			Body:      "Please fix the typo",
+			CreatedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 1 {
+		t.Fatalf("expected 1 actionable event, got %d", len(ch.Events))
+	}
+	if ch.Events[0].Type != EventComment || ch.Events[0].Author.Login != "alice" {
+		t.Errorf("event: %+v", ch.Events[0])
+	}
+	if !ch.NewestComment.Equal(details.Comments[0].CreatedAt) {
+		t.Errorf("NewestComment cursor: got %v", ch.NewestComment)
+	}
+}
+
+func TestDiff_OldCommentIsIgnored(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	commentAt := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	details := &github.Details{
+		State: "OPEN",
+		Comments: []github.Comment{{
+			Author:    github.Actor{Login: "alice", Type: "User"},
+			Body:      "old comment",
+			CreatedAt: commentAt,
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{LastCommentAt: commentAt})
+	if len(ch.Events) != 0 {
+		t.Errorf("comments at-or-before cursor should be ignored, got %d events", len(ch.Events))
+	}
+}
+
+func TestDiff_UntrustedBotIsSkipped(t *testing.T) {
+	w := newTestWatcher(t, nil) // empty trust list = humans only
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State: "OPEN",
+		Comments: []github.Comment{{
+			Author:    github.Actor{Login: "gemini-code-assist", Type: "Bot"},
+			Body:      "Consider this suggestion",
+			CreatedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 0 {
+		t.Errorf("untrusted bot should be skipped, got %d actionable events", len(ch.Events))
+	}
+	if len(ch.Skipped) != 1 {
+		t.Errorf("expected 1 skipped event, got %d", len(ch.Skipped))
+	}
+}
+
+func TestDiff_TrustedBotIsActioned(t *testing.T) {
+	w := newTestWatcher(t, []string{"gemini-code-assist"})
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State: "OPEN",
+		Comments: []github.Comment{{
+			Author:    github.Actor{Login: "gemini-code-assist", Type: "Bot"},
+			Body:      "Consider this suggestion",
+			CreatedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 1 {
+		t.Errorf("trusted bot should be actioned, got %d events", len(ch.Events))
+	}
+}
+
+func TestDiff_ApprovedReviewIsIgnored(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State: "OPEN",
+		Reviews: []github.Review{{
+			Author:      github.Actor{Login: "alice", Type: "User"},
+			State:       "APPROVED",
+			Body:        "LGTM",
+			SubmittedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 0 {
+		t.Errorf("APPROVED reviews should not produce actionable events, got %d", len(ch.Events))
+	}
+}
+
+func TestDiff_ChangesRequestedReviewIsActionable(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State: "OPEN",
+		Reviews: []github.Review{{
+			Author:      github.Actor{Login: "alice", Type: "User"},
+			State:       "CHANGES_REQUESTED",
+			Body:        "needs work in X",
+			SubmittedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 1 {
+		t.Errorf("CHANGES_REQUESTED should be actioned, got %d events", len(ch.Events))
+	}
+	if ch.Events[0].ReviewState != "CHANGES_REQUESTED" {
+		t.Errorf("event ReviewState: got %q", ch.Events[0].ReviewState)
+	}
+}
+
+func TestDiff_EmptyCommentedReviewIsIgnored(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State: "OPEN",
+		Reviews: []github.Review{{
+			Author:      github.Actor{Login: "alice", Type: "User"},
+			State:       "COMMENTED",
+			Body:        "",
+			SubmittedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 0 {
+		t.Errorf("empty COMMENTED review (just a wrapper) should be ignored, got %d events", len(ch.Events))
+	}
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -45,6 +45,79 @@ func TestDiff_NewCommentByHumanIsActionable(t *testing.T) {
 	}
 }
 
+func TestDiff_InlineReviewCommentByHumanIsActionable(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1", Number: 1}
+	details := &github.Details{
+		State: "OPEN",
+		ReviewComments: []github.ReviewComment{{
+			Author:    github.Actor{Login: "alice", Type: "User"},
+			Body:      "keep the mutex held here",
+			CreatedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+			Path:      "internal/state/state.go",
+			Line:      122,
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 1 {
+		t.Fatalf("expected 1 actionable event, got %d", len(ch.Events))
+	}
+	ev := ch.Events[0]
+	if ev.Type != EventComment || ev.Path != "internal/state/state.go" || ev.Line != 122 {
+		t.Errorf("event: %+v", ev)
+	}
+	if !ch.NewestComment.Equal(details.ReviewComments[0].CreatedAt) {
+		t.Errorf("NewestComment cursor: got %v", ch.NewestComment)
+	}
+}
+
+func TestDiff_UntrustedBotInlineCommentIsSkipped(t *testing.T) {
+	w := newTestWatcher(t, nil) // humans only
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State: "OPEN",
+		ReviewComments: []github.ReviewComment{{
+			Author:    github.Actor{Login: "gemini-code-assist", Type: "Bot"},
+			Body:      "There is a critical race condition",
+			CreatedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+			Path:      "internal/state/state.go",
+			Line:      122,
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 0 {
+		t.Errorf("untrusted bot inline comment should be skipped, got %d events", len(ch.Events))
+	}
+	if len(ch.Skipped) != 1 {
+		t.Errorf("expected 1 skipped event, got %d", len(ch.Skipped))
+	}
+	// Cursor must still advance past the skipped comment.
+	if !ch.NewestComment.Equal(details.ReviewComments[0].CreatedAt) {
+		t.Errorf("NewestComment cursor should advance past skipped comment: got %v", ch.NewestComment)
+	}
+}
+
+func TestDiff_OldInlineReviewCommentIsIgnored(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	at := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	details := &github.Details{
+		State: "OPEN",
+		ReviewComments: []github.ReviewComment{{
+			Author:    github.Actor{Login: "alice", Type: "User"},
+			Body:      "old inline comment",
+			CreatedAt: at,
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{LastCommentAt: at})
+	if len(ch.Events) != 0 {
+		t.Errorf("inline comment at-or-before cursor should be ignored, got %d events", len(ch.Events))
+	}
+}
+
 func TestDiff_OldCommentIsIgnored(t *testing.T) {
 	w := newTestWatcher(t, nil)
 	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -176,6 +176,25 @@ func TestDiff_TrustedBotIsActioned(t *testing.T) {
 	}
 }
 
+func TestDiff_TrustedBotMatchIsCaseInsensitive(t *testing.T) {
+	// Config uses different casing than the API returns.
+	w := newTestWatcher(t, []string{"Gemini-Code-Assist"})
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State: "OPEN",
+		Comments: []github.Comment{{
+			Author:    github.Actor{Login: "gemini-code-assist", Type: "Bot"},
+			Body:      "suggestion",
+			CreatedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 1 {
+		t.Errorf("trusted bot should match regardless of login casing, got %d events", len(ch.Events))
+	}
+}
+
 func TestDiff_ApprovedReviewIsIgnored(t *testing.T) {
 	w := newTestWatcher(t, nil)
 	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}


### PR DESCRIPTION
## Summary

Closes [ENG-173](https://linear.app/amazz/issue/ENG-173/auto-iterate-on-pr-review-feedback). Nightshift no longer stops at "PR created" — it now optionally polls the PRs it opened, picks up new review feedback, and pushes a follow-up commit on the same branch.

Off by default. Set `AUTO_ITERATE_PRS=true` (or run `./nightshift setup`) to opt in.

## What lands

5 logical commits, ~1750 lines of code + tests across 6 new packages.

### `internal/repo.ResumeWorktree`

Counterpart to `CreateWorktree` that pulls the existing remote branch instead of recreating from `origin/main`. Prior commits stay intact; follow-up work just appends. Fails (rather than falling back to main) if `origin/<branch>` doesn't exist.

### `internal/state`

File-backed PR cursor store at `~/.nightshift-state.json` (path configurable via `STATE_FILE`). Tracks per-PR: ticket ID, last-seen comment cursor, last-seen review cursor, iteration count, last-iterated-at. Atomic writes (write-temp + rename) and mutex-guarded so the watcher and pipeline goroutines can share it.

Cursors are stored as timestamps, not GraphQL node IDs — naturally ordered, no parsing of opaque IDs.

### `internal/github`

Thin `gh` CLI wrapper:
- `ListNightshiftPRs` reduces each registry URL to `owner/name` (handles SSH + HTTPS + already-reduced forms), runs `gh pr list --author @me --state open`, filters for `nightshift/*` branches.
- `GetPR` returns a typed view of comments + reviews via `gh pr view --json …`.

### `internal/watch`

Side-effect-free classifier. `Scan()` returns one `PRChanges` per PR with new events since the cursor. Filtering rules:

- `APPROVED` / `DISMISSED` reviews never produce events (cursor still advances past them).
- `COMMENTED` reviews with empty bodies are inline-comment wrappers — skipped.
- `CHANGES_REQUESTED` + non-empty `COMMENTED` are actionable.
- Bot authors are skipped **unless their login is in `TRUSTED_REVIEWERS`**. Humans always actionable.

### `internal/agent.BuildFixPrompt`

Renders a fix prompt that instructs Claude to address **only** the listed feedback (no unrelated refactors), to flag wrong/inapplicable feedback explicitly, and to `BLOCKED:` rather than silently fail.

### `internal/pipeline` integration

`Pipeline.New` builds the store + gh client + watcher only when `AutoIteratePRs` is true. `Pipeline.Run` spawns `runWatcher` on the same `WaitGroup` so graceful shutdown waits for in-flight iterations.

Per tick:
1. Scan returns changes
2. Non-actionable PRs: advance cursor only
3. Actionable PRs: check iteration cap → resolve repo → `ResumeWorktree` → `GetIssueByIdentifier` for ticket context → `BuildFixPrompt` → run Claude → `git add` / commit / push
4. Bump iteration count + advance cursor. Cap-hit fires Telegram + Linear comment on the transition.

Timeouts / rate-limits do NOT count as iterations — those are infrastructure failures.

## Safety guards (all on by default)

| Guard | Why |
|---|---|
| `MAX_PR_ITERATIONS=3` per PR | Stops flake loops and stuck reviews from grinding API quota |
| `TRUSTED_REVIEWERS` defaults empty (humans only) | The reason: PR #50, where `gemini-code-assist` confidently misread the v2 lint config as v1 |
| State persistence | Restart-safe; no re-reacting to historical comments |
| Telegram heads-up on every re-engage | Always; not gated by `TELEGRAM_VERBOSE` |
| `Pipeline.active` dedupe | Same identifier can't be both freshly-dispatched and iterated concurrently |

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race ./...` — all 12 packages green; new tests cover Slug-like helpers (`ExtractOwnerRepo`), `state` round-trip & accumulate & temp-file hygiene, `watch.diff` for each rule (human comment, old comment ignored, untrusted bot, trusted bot, APPROVED, CHANGES_REQUESTED, empty COMMENTED), `agent.BuildFixPrompt` content, `ResumeWorktree` end-to-end with a real local-remote git repo
- [x] `golangci-lint run` v2.5.0 — `0 issues`
- [x] Wizard smoke-tested: enabling auto-iterate persists all four fields to `.env` and shows them in the summary
- [ ] On the Pi: pull, `make update`, run the wizard once to opt in, leave a fresh review comment on an open PR → confirm 🔄 Telegram heads-up + follow-up commit lands
- [ ] On the Pi: verify cap-hit behaviour by setting `MAX_PR_ITERATIONS=1` and watching the second comment skip with the Telegram "needs human attention" message

Linear: [ENG-173](https://linear.app/amazz/issue/ENG-173/auto-iterate-on-pr-review-feedback)

[ENG-174 (CI failure auto-iteration)](https://linear.app/amazz/issue/ENG-174/auto-iterate-on-ci-failures) is blocked on this one and will reuse the watcher + state + iteration cap + branch-reuse plumbing this PR lands.

https://claude.ai/code/session_01N8uh6QWm9uBw3u5nxSyC53

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8uh6QWm9uBw3u5nxSyC53)_