### PR TITLE
Auto-iterate on CI failures (ENG-174)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,10 +92,11 @@ GEMINI_MODEL=gemini-2.5-pro
 # Set to 0 to create the PR immediately with Gemini's comments attached
 MAX_REVIEW_RETRIES=1
 
-# ── Auto-iterate on PR Review Feedback (optional) ─────────────────────────────
+# ── Auto-iterate on PR Feedback (optional) ───────────────────────────────────
 # When enabled, Nightshift periodically polls the open PRs it created. New
-# comments / reviews trigger Claude to address them on the SAME branch (so the
-# PR just gets a follow-up commit instead of being abandoned).
+# comments / reviews, OR a failing CI run, trigger Claude to address them on the
+# SAME branch (so the PR just gets a follow-up commit instead of being
+# abandoned). Review feedback and CI fixes share the MAX_PR_ITERATIONS budget.
 
 # Set to true to enable. Default off — single-shot behaviour stays unchanged.
 AUTO_ITERATE_PRS=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Nightshift
 
-Autonomous Linear-to-PR agent in Go. Polls Linear for tickets in a trigger state, dispatches Claude Code to implement them, creates PRs, and moves tickets to review. Optionally (`AUTO_ITERATE_PRS=true`) it also watches the PRs it opened and pushes follow-up commits in response to review feedback.
+Autonomous Linear-to-PR agent in Go. Polls Linear for tickets in a trigger state, dispatches Claude Code to implement them, creates PRs, and moves tickets to review. Optionally (`AUTO_ITERATE_PRS=true`) it also watches the PRs it opened and pushes follow-up commits in response to review feedback and CI failures.
 
 ## Architecture
 
@@ -17,18 +17,20 @@ Worktrees live at `~/.nightshift-worktrees/<IDENTIFIER>` so multiple tickets run
 When `AUTO_ITERATE_PRS=true`, a **second** poll loop runs alongside the Linear one:
 
 ```
-PR poll loop → github.ListNightshiftPRs → github.GetPR → watch.Scan (diff vs state cursor)
+PR poll loop → github.ListNightshiftPRs → github.GetPR (comments+reviews+statusCheckRollup)
+  → watch.Scan (diff vs state cursor: new feedback OR failing CI on a new head SHA)
   → pipeline.iteratePR (bounded, shares the worker pool + active-set)
-  → repo.ResumeWorktree → agent.BuildFixPrompt → agent.Run → commit/push (same branch)
-  → state.Update (advance cursor + bump iteration count)
+  → repo.ResumeWorktree → [github.CheckLogs for CI] → agent.BuildFixPrompt → agent.Run
+  → commit/push (same branch) → state.Update (advance comment/review/CI cursor + bump iteration count)
 ```
 
 - **Opt-in**, off by default. Both loops run on the same `WaitGroup` so shutdown drains in-flight iterations.
 - Only acts on PRs **Nightshift authored** — identified purely by the `nightshift/<id>` branch prefix (`repo.BranchName`). `CreateWorktree` and `ResumeWorktree` both use it; `watch`/`iterate` filter on it. **Keep creation and watching on the same prefix** or the watcher silently never finds its own PRs.
 - Feedback captured: conversation comments, review summaries (`CHANGES_REQUESTED` / non-empty `COMMENTED`), and inline review-thread comments (fetched separately via `gh api`, non-fatal on failure). `APPROVED`/`DISMISSED` and empty `COMMENTED` advance the cursor without acting.
-- Trusted-reviewer rule (`watch.actionable`): humans always actionable; bots only if their login is in `TRUSTED_REVIEWERS`.
-- Guards: per-PR `MAX_PR_ITERATIONS` cap (timeouts/rate-limits don't count), restart-safe cursor in `state`, `pipeline.active` dedupe so a ticket can't be freshly-dispatched and iterated at once.
-- Cursors are stored as **timestamps**, not opaque node IDs — naturally ordered. Conversation and inline comments share the comment cursor (comment timestamps are globally ordered).
+- **CI failures** are a second trigger feeding the same `iteratePR`: when every check on the head commit (`statusCheckRollup`) has completed and ≥1 failed, `watch.diff` sets `PRChanges.CIFailure`; `iteratePR` fetches failed-step logs (`gh run view --log-failed`, truncated, best-effort) and folds them into the same fix prompt. When both review feedback and CI are pending, one re-engagement handles both.
+- Trusted-reviewer rule (`watch.actionable`): humans always actionable; bots only if their login is in `TRUSTED_REVIEWERS`. (CI is not gated by this — it's not a person.)
+- Guards: per-PR `MAX_PR_ITERATIONS` cap, **shared** across review + CI re-engagements (timeouts/rate-limits don't count), restart-safe cursor in `state`, `pipeline.active` dedupe so a ticket can't be freshly-dispatched and iterated at once.
+- Cursors: comment/review are **timestamps** (naturally ordered; conversation + inline comments share the comment cursor). CI is keyed by **head commit SHA** (`LastCISHA`) — acted on once per commit, since a fix changes the SHA and makes a fresh failure eligible again.
 - Nightshift does **not** post back to the GitHub PR thread (no replies, no thread resolution); it pushes a follow-up commit and notifies via Telegram/Linear.
 
 ## Multi-repo
@@ -47,12 +49,12 @@ If a ticket's project has no registry entry, Nightshift falls back to `REPO_PATH
 | `internal/config` | `.env` parser, `repos.json` loader, validated `Config` |
 | `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `SetState`, `Comment` |
 | `internal/repo` | Project → repo slug + registry; clone-on-demand; worktree create/cleanup; `BranchName`; `CreateWorktree` (from main) + `ResumeWorktree` (pull existing remote branch) |
-| `internal/agent` | Claude Code runner (`exec`) with timeout; implement-prompt builder; `BuildFixPrompt` (review-feedback prompt); log_offset parsing |
+| `internal/agent` | Claude Code runner (`exec`) with timeout; implement-prompt builder; `BuildFixPrompt` (review feedback + failing-CI prompt); log_offset parsing |
 | `internal/review` | Optional Gemini second-model review gate |
 | `internal/notify` | Optional Telegram notifier (fire-and-forget) |
-| `internal/github` | Thin `gh` CLI wrapper: `ListNightshiftPRs`, `GetPR` (comments + reviews + inline review-thread comments via REST) |
-| `internal/state` | File-backed PR cursor store (`~/.nightshift-state.json`): per-PR comment/review cursors + iteration count; atomic, mutex-guarded |
-| `internal/watch` | Side-effect-free classifier: diffs a PR's feedback against the cursor, applies trusted-reviewer rules, emits actionable events |
+| `internal/github` | Thin `gh` CLI wrapper: `ListNightshiftPRs`, `GetPR` (comments + reviews + inline review comments via REST + `statusCheckRollup`), `CheckLogs` (failed-step logs via `gh run view`) |
+| `internal/state` | File-backed PR cursor store (`~/.nightshift-state.json`): per-PR comment/review timestamps + CI head-SHA + iteration count; atomic, mutex-guarded |
+| `internal/watch` | Side-effect-free classifier: diffs a PR's feedback + CI status against the cursor, applies trusted-reviewer rules, emits actionable events + `CIFailure` |
 | `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle (`process.go`); PR-watch loop + per-PR re-engagement (`iterate.go`) |
 | `internal/setup` | Interactive setup wizard (`./nightshift setup`) |
 | `internal/cleanup` | Cleanup subcommand: branches, worktrees, old logs |

--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ When a ticket comes in, Nightshift reads its project, finds the matching repo, a
 
 ---
 
-## Auto-iterate on PR review feedback (optional)
+## Auto-iterate on PR feedback (optional)
 
-By default Nightshift's job ends when the PR is created. Set `AUTO_ITERATE_PRS=true` and Nightshift will also poll the PRs it created — when new feedback lands, it re-engages Claude **on the same branch** and pushes a follow-up commit. The PR just updates; no new PR, no lost context.
+By default Nightshift's job ends when the PR is created. Set `AUTO_ITERATE_PRS=true` and Nightshift will also poll the PRs it created — when new feedback lands **or CI fails**, it re-engages Claude **on the same branch** and pushes a follow-up commit. The PR just updates; no new PR, no lost context.
 
-It picks up all three kinds of feedback: top-level conversation comments, submitted reviews (`CHANGES_REQUESTED` / non-empty `COMMENTED`), and **inline review-thread comments** attached to specific lines — the latter are passed to Claude with their `file:line` location so it knows exactly where each note applies.
+It picks up all three kinds of review feedback: top-level conversation comments, submitted reviews (`CHANGES_REQUESTED` / non-empty `COMMENTED`), and **inline review-thread comments** attached to specific lines — the latter are passed to Claude with their `file:line` location so it knows exactly where each note applies.
+
+It also watches **CI**: once every check on the head commit has completed and at least one failed, Nightshift fetches the failed-step logs and asks Claude to reproduce and fix them. CI is keyed by commit SHA, so it acts at most once per commit — pushing a fix that fails again counts as the next iteration (bounded by the cap). Review feedback and CI fixes share the same per-PR iteration budget and, when both are pending, are addressed in a single re-engagement.
 
 ```env
 AUTO_ITERATE_PRS=true
@@ -129,7 +131,7 @@ TRUSTED_REVIEWERS=               # CSV of bots/logins; empty = humans only
 **Safety guards built in:**
 - **Iteration cap.** After `MAX_PR_ITERATIONS` re-engagements on the same PR, Nightshift stops and pings you (Telegram + Linear comment). Prevents flake-loops and stuck reviews from grinding through your API quota.
 - **Trusted-reviewer allowlist.** Humans are always trusted. Bots are only acted on if their login is in `TRUSTED_REVIEWERS`. Default is empty = humans only — bot reviews are still seen and logged, but Nightshift won't act on them blindly. (The default exists because a bot reviewer once confidently misread a `golangci-lint` v2 config as v1; applying its "fix" would have broken CI.)
-- **Cursor persistence.** State at `~/.nightshift-state.json` tracks how far the watcher has caught up. Restarts don't re-react to historical comments.
+- **Cursor persistence.** State at `~/.nightshift-state.json` tracks how far the watcher has caught up (last comment/review timestamps + last CI commit SHA). Restarts don't re-react to historical comments or already-handled CI failures.
 - **Telegram heads-up** on each re-engage (always — not gated by `TELEGRAM_VERBOSE`).
 
 Disabled by default; set `AUTO_ITERATE_PRS=true` to opt in, or run the wizard.

--- a/internal/agent/fix_prompt.go
+++ b/internal/agent/fix_prompt.go
@@ -27,6 +27,17 @@ type FeedbackItem struct {
 	Line int
 }
 
+// CIItem is one failing CI check rendered into a fix prompt.
+type CIItem struct {
+	// Name is the check / workflow name (e.g. "build", "lint").
+	Name string
+	// URL links to the check run (optional).
+	URL string
+	// Logs is the truncated failed-step log tail (may be empty if the logs
+	// couldn't be fetched — Claude can still reproduce locally).
+	Logs string
+}
+
 // FixPromptInput is everything BuildFixPrompt needs to assemble a prompt the
 // implementing agent can act on without re-reading the PR.
 type FixPromptInput struct {
@@ -36,6 +47,7 @@ type FixPromptInput struct {
 	PRNumber    int
 	PRURL       string
 	Feedback    []FeedbackItem
+	CI          []CIItem
 }
 
 // BuildFixPrompt renders a fix prompt for Claude when reviewers (or bots in
@@ -49,27 +61,41 @@ func BuildFixPrompt(in FixPromptInput) string {
 		desc = "No description provided."
 	}
 
-	var feedback strings.Builder
-	for i, f := range in.Feedback {
-		header := fmt.Sprintf("### %d) %s by @%s", i+1, sectionLabel(f.Kind, f.State), f.Author)
-		feedback.WriteString(header)
-		feedback.WriteByte('\n')
-		if f.Path != "" {
-			if f.Line > 0 {
-				fmt.Fprintf(&feedback, "on `%s:%d`\n", f.Path, f.Line)
-			} else {
-				fmt.Fprintf(&feedback, "on `%s`\n", f.Path)
+	var sections strings.Builder
+	if len(in.Feedback) > 0 {
+		sections.WriteString("## Review feedback to address\n\n")
+		for i, f := range in.Feedback {
+			fmt.Fprintf(&sections, "### %d) %s by @%s\n", i+1, sectionLabel(f.Kind, f.State), f.Author)
+			if f.Path != "" {
+				if f.Line > 0 {
+					fmt.Fprintf(&sections, "on `%s:%d`\n", f.Path, f.Line)
+				} else {
+					fmt.Fprintf(&sections, "on `%s`\n", f.Path)
+				}
 			}
+			if f.URL != "" {
+				fmt.Fprintf(&sections, "(%s)\n", f.URL)
+			}
+			sections.WriteByte('\n')
+			sections.WriteString(strings.TrimSpace(f.Body))
+			sections.WriteString("\n\n")
 		}
-		if f.URL != "" {
-			fmt.Fprintf(&feedback, "(%s)\n", f.URL)
+	}
+	if len(in.CI) > 0 {
+		sections.WriteString("## Failing CI checks to fix\n\n")
+		for i, c := range in.CI {
+			fmt.Fprintf(&sections, "### %d) %s\n", i+1, c.Name)
+			if c.URL != "" {
+				fmt.Fprintf(&sections, "(%s)\n", c.URL)
+			}
+			if logs := strings.TrimSpace(c.Logs); logs != "" {
+				fmt.Fprintf(&sections, "\n```\n%s\n```\n", logs)
+			}
+			sections.WriteByte('\n')
 		}
-		feedback.WriteByte('\n')
-		feedback.WriteString(strings.TrimSpace(f.Body))
-		feedback.WriteString("\n\n")
 	}
 
-	return fmt.Sprintf(`A reviewer has left feedback on the PR you opened for this Linear ticket. Address it on the same branch — your changes will be pushed as a follow-up commit.
+	return fmt.Sprintf(`There is new activity on the PR you opened for this Linear ticket — review feedback and/or failing CI. Address it on the same branch; your changes will be pushed as a follow-up commit.
 
 ## Ticket: %s — %s
 %s
@@ -77,21 +103,19 @@ func BuildFixPrompt(in FixPromptInput) string {
 ## PR
 #%d — %s
 
-## Feedback to address
+%s## Rules
 
-%s
-## Rules
-
-- Address ONLY the feedback listed above. Do not refactor unrelated code or pick up new work.
+- Address ONLY the feedback and CI failures listed above. Do not refactor unrelated code or pick up new work.
+- If CI is failing, reproduce it locally (run the relevant tests / linter), fix the root cause, and re-run to confirm it passes.
 - If a piece of feedback is wrong or inapplicable, briefly say so and skip it — do not silently ignore it.
 - Run the test suite and the linter (`+"`golangci-lint run`"+`, if configured) after your changes; fix anything you broke.
-- If you cannot address a piece of feedback because more context is needed, say BLOCKED: <reason> and stop.
+- If you cannot proceed because more context is needed, say BLOCKED: <reason> and stop.
 - Do NOT create a new PR, push a new branch, or close the existing PR — Nightshift handles that.
 
 ## When done
 
-Summarise which pieces of feedback you addressed and how, and call out any you deliberately skipped (with the reason).
-`, in.Identifier, in.Title, desc, in.PRNumber, in.PRURL, feedback.String())
+Summarise what you addressed and how, and call out anything you deliberately skipped (with the reason).
+`, in.Identifier, in.Title, desc, in.PRNumber, in.PRURL, sections.String())
 }
 
 func sectionLabel(kind, state string) string {

--- a/internal/agent/fix_prompt_test.go
+++ b/internal/agent/fix_prompt_test.go
@@ -64,6 +64,30 @@ func TestBuildFixPrompt_RendersInlineCommentLocation(t *testing.T) {
 	}
 }
 
+func TestBuildFixPrompt_RendersCIFailures(t *testing.T) {
+	out := BuildFixPrompt(FixPromptInput{
+		Identifier: "ENG-50",
+		Title:      "Thing",
+		PRNumber:   7,
+		PRURL:      "https://github.com/me/repo/pull/7",
+		CI: []CIItem{{
+			Name: "test",
+			URL:  "https://github.com/me/repo/actions/runs/1",
+			Logs: "FAIL: TestThing\nexpected 2 got 3",
+		}},
+	})
+	for _, want := range []string{
+		"Failing CI checks to fix",
+		"test",
+		"expected 2 got 3",
+		"reproduce it locally",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("CI prompt missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
 func TestBuildFixPrompt_HandlesMissingDescription(t *testing.T) {
 	out := BuildFixPrompt(FixPromptInput{
 		Identifier: "ENG-1",

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -4,12 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
 	"os/exec"
 	"strings"
 )
+
+// ErrNotActionsRun is returned by CheckLogs when a check's details URL is not
+// a GitHub Actions run (e.g. CircleCI, Vercel). Callers can errors.Is on it to
+// skip such checks quietly rather than logging a failure.
+var ErrNotActionsRun = errors.New("not a GitHub Actions run")
 
 // Client is a `gh`-CLI wrapper. Stateless — safe to use concurrently.
 type Client struct{}
@@ -138,7 +144,7 @@ const maxCheckLogBytes = 6000
 func (c *Client) CheckLogs(ctx context.Context, ch Check) (string, error) {
 	owner, repo, runID, ok := parseActionsRunURL(ch.URL())
 	if !ok {
-		return "", fmt.Errorf("not a GitHub Actions run URL: %q", ch.URL())
+		return "", fmt.Errorf("%q: %w", ch.URL(), ErrNotActionsRun)
 	}
 	var stderr strings.Builder
 	cmd := exec.CommandContext(ctx, "gh", "run", "view", runID,
@@ -157,7 +163,13 @@ func tailString(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
-	return "...(truncated)\n" + s[len(s)-max:]
+	start := len(s) - max
+	// Don't slice mid-rune: skip past any UTF-8 continuation bytes (top two
+	// bits == 10) so the result stays valid UTF-8.
+	for start < len(s) && s[start]&0xC0 == 0x80 {
+		start++
+	}
+	return "...(truncated)\n" + s[start:]
 }
 
 // parseActionsRunURL extracts owner, repo and run ID from a GitHub Actions

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -67,7 +67,7 @@ func (c *Client) ListNightshiftPRs(ctx context.Context, repoURLs []string) ([]PR
 func (c *Client) GetPR(ctx context.Context, prURL string) (*Details, error) {
 	var stderr strings.Builder
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prURL,
-		"--json", "url,number,state,comments,reviews",
+		"--json", "url,number,state,headRefOid,comments,reviews,statusCheckRollup",
 	)
 	cmd.Stderr = &stderr
 	stdout, err := cmd.Output()
@@ -125,6 +125,58 @@ func decodeReviewComments(stdout []byte) ([]ReviewComment, error) {
 		comments = append(comments, page...)
 	}
 	return comments, nil
+}
+
+// maxCheckLogBytes caps how much of a failed check's log we feed back to
+// Claude — the tail almost always holds the actual error, and an unbounded
+// log would blow up the prompt.
+const maxCheckLogBytes = 6000
+
+// CheckLogs returns the failed-step logs for a check, truncated to the tail.
+// Only GitHub Actions runs are supported; other check kinds (whose details
+// URL isn't an Actions run) return an error the caller treats as best-effort.
+func (c *Client) CheckLogs(ctx context.Context, ch Check) (string, error) {
+	owner, repo, runID, ok := parseActionsRunURL(ch.URL())
+	if !ok {
+		return "", fmt.Errorf("not a GitHub Actions run URL: %q", ch.URL())
+	}
+	var stderr strings.Builder
+	cmd := exec.CommandContext(ctx, "gh", "run", "view", runID,
+		"--repo", owner+"/"+repo, "--log-failed")
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh run view %s: %w (%s)", runID, err, strings.TrimSpace(stderr.String()))
+	}
+	return tailString(string(stdout), maxCheckLogBytes), nil
+}
+
+// tailString returns the last max bytes of s, prefixed with a truncation
+// marker when it had to cut.
+func tailString(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return "...(truncated)\n" + s[len(s)-max:]
+}
+
+// parseActionsRunURL extracts owner, repo and run ID from a GitHub Actions
+// check details URL like
+// https://github.com/owner/repo/actions/runs/123/job/456.
+func parseActionsRunURL(raw string) (owner, repo, runID string, ok bool) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", "", "", false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	// owner / repo / actions / runs / <id> [...]
+	if len(parts) < 5 || parts[2] != "actions" || parts[3] != "runs" {
+		return "", "", "", false
+	}
+	if parts[0] == "" || parts[1] == "" || parts[4] == "" {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[4], true
 }
 
 // reviewCommentsAPIPath turns a PR URL into the REST path for its inline

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,6 +1,35 @@
 package github
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTailString_KeepsValidUTF8(t *testing.T) {
+	// A run of 3-byte runes (★ = e2 98 85) so a raw byte cut would land
+	// mid-rune for most max values.
+	s := strings.Repeat("★", 100)
+	for _, max := range []int{10, 50, 101, 299} {
+		out := tailString(s, max)
+		if !utf8.ValidString(out) {
+			t.Errorf("tailString(max=%d) produced invalid UTF-8: %q", max, out)
+		}
+	}
+	// Short input is returned untouched.
+	if got := tailString("hi", 100); got != "hi" {
+		t.Errorf("short input: got %q", got)
+	}
+}
+
+func TestCheckLogs_NonActionsReturnsSentinel(t *testing.T) {
+	_, err := New().CheckLogs(context.Background(), Check{DetailsURL: "https://circleci.com/gh/me/repo/123"})
+	if !errors.Is(err, ErrNotActionsRun) {
+		t.Errorf("expected ErrNotActionsRun, got %v", err)
+	}
+}
 
 func TestDecodeReviewComments(t *testing.T) {
 	// Single merged array (modern gh).

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -81,6 +81,52 @@ func TestReviewCommentsAPIPath(t *testing.T) {
 	}
 }
 
+func TestParseActionsRunURL(t *testing.T) {
+	cases := []struct {
+		in               string
+		owner, repo, run string
+		ok               bool
+	}{
+		{"https://github.com/me/auth/actions/runs/123/job/456", "me", "auth", "123", true},
+		{"https://github.com/me/auth/actions/runs/789", "me", "auth", "789", true},
+		{"https://github.com/me/auth/pull/12", "", "", "", false},
+		{"https://circleci.com/gh/me/auth/123", "", "", "", false},
+		{"", "", "", "", false},
+	}
+	for _, c := range cases {
+		o, r, run, ok := parseActionsRunURL(c.in)
+		if ok != c.ok || o != c.owner || r != c.repo || run != c.run {
+			t.Errorf("parseActionsRunURL(%q) = (%q,%q,%q,%v), want (%q,%q,%q,%v)",
+				c.in, o, r, run, ok, c.owner, c.repo, c.run, c.ok)
+		}
+	}
+}
+
+func TestCheckHelpers(t *testing.T) {
+	// Completed failing CheckRun.
+	fail := Check{Name: "build", Status: "COMPLETED", Conclusion: "FAILURE", DetailsURL: "u"}
+	if !fail.IsComplete() || !fail.IsFailure() || fail.CheckName() != "build" || fail.URL() != "u" {
+		t.Errorf("failing CheckRun: %+v", fail)
+	}
+	// In-progress check is not complete.
+	if (Check{Name: "x", Status: "IN_PROGRESS"}).IsComplete() {
+		t.Error("IN_PROGRESS should not be complete")
+	}
+	// Passing CheckRun.
+	if (Check{Status: "COMPLETED", Conclusion: "SUCCESS"}).IsFailure() {
+		t.Error("SUCCESS should not be a failure")
+	}
+	// Legacy StatusContext failure.
+	sc := Check{Context: "ci/legacy", State: "FAILURE", TargetURL: "t"}
+	if !sc.IsComplete() || !sc.IsFailure() || sc.CheckName() != "ci/legacy" || sc.URL() != "t" {
+		t.Errorf("StatusContext: %+v", sc)
+	}
+	// Pending StatusContext is not complete.
+	if (Check{Context: "x", State: "PENDING"}).IsComplete() {
+		t.Error("PENDING StatusContext should not be complete")
+	}
+}
+
 func TestActorIsBot(t *testing.T) {
 	if (Actor{Type: "Bot"}).IsBot() != true {
 		t.Error("Bot type should report IsBot true")

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -1,7 +1,7 @@
 // Package github wraps the `gh` CLI for the operations Nightshift's watcher
-// needs: listing PRs Nightshift authored, fetching their comments and reviews,
-// and (later) pulling check-run status. Stays thin — types mirror what `gh`
-// returns under --json, so decoding is JSON unmarshal straight onto these.
+// needs: listing PRs Nightshift authored, fetching their comments, reviews and
+// check-run status, and pulling failed-check logs. Stays thin — types mirror
+// what `gh` returns under --json, so decoding is JSON unmarshal onto these.
 package github
 
 import "time"
@@ -60,14 +60,73 @@ type ReviewComment struct {
 	Line      int       `json:"line"`
 }
 
+// Check is one entry in a PR's status-check rollup. `gh pr view --json
+// statusCheckRollup` returns a union of CheckRun (GitHub Actions etc.) and
+// StatusContext (legacy commit statuses); this struct captures both shapes —
+// the helpers below normalise across them.
+type Check struct {
+	Typename string `json:"__typename"`
+	// CheckRun fields.
+	Name         string `json:"name"`
+	Status       string `json:"status"`     // QUEUED | IN_PROGRESS | COMPLETED | PENDING
+	Conclusion   string `json:"conclusion"` // SUCCESS | FAILURE | TIMED_OUT | CANCELLED | ACTION_REQUIRED | NEUTRAL | SKIPPED | STARTUP_FAILURE
+	DetailsURL   string `json:"detailsUrl"`
+	WorkflowName string `json:"workflowName"`
+	// StatusContext fields.
+	Context   string `json:"context"`
+	State     string `json:"state"` // SUCCESS | FAILURE | ERROR | PENDING | EXPECTED
+	TargetURL string `json:"targetUrl"`
+}
+
+// CheckName is the display name regardless of check kind.
+func (c Check) CheckName() string {
+	if c.Name != "" {
+		return c.Name
+	}
+	return c.Context
+}
+
+// URL is the details/target link regardless of check kind.
+func (c Check) URL() string {
+	if c.DetailsURL != "" {
+		return c.DetailsURL
+	}
+	return c.TargetURL
+}
+
+// IsComplete reports whether the check has finished running (so its result is
+// final and worth acting on). Checks still in flight should be left alone.
+func (c Check) IsComplete() bool {
+	if c.Status != "" { // CheckRun
+		return c.Status == "COMPLETED"
+	}
+	// StatusContext has no status; PENDING/EXPECTED mean still in flight.
+	return c.State != "" && c.State != "PENDING" && c.State != "EXPECTED"
+}
+
+// IsFailure reports whether a completed check failed in a way worth fixing.
+func (c Check) IsFailure() bool {
+	switch c.Conclusion { // CheckRun
+	case "FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE":
+		return true
+	}
+	switch c.State { // StatusContext
+	case "FAILURE", "ERROR":
+		return true
+	}
+	return false
+}
+
 // Details is the full view of a PR Nightshift needs to decide whether to
 // re-engage and how. Mirrors the JSON shape `gh pr view --json ...` returns.
 type Details struct {
-	URL      string    `json:"url"`
-	Number   int       `json:"number"`
-	State    string    `json:"state"` // OPEN | CLOSED | MERGED
-	Comments []Comment `json:"comments"`
-	Reviews  []Review  `json:"reviews"`
+	URL               string    `json:"url"`
+	Number            int       `json:"number"`
+	State             string    `json:"state"` // OPEN | CLOSED | MERGED
+	HeadRefOid        string    `json:"headRefOid"`
+	Comments          []Comment `json:"comments"`
+	Reviews           []Review  `json:"reviews"`
+	StatusCheckRollup []Check   `json:"statusCheckRollup"`
 	// ReviewComments are inline review-thread comments, fetched separately
 	// from the REST API and merged in by GetPR (gh pr view omits them).
 	ReviewComments []ReviewComment `json:"-"`

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -66,10 +66,10 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 	slog.Info("pr poll", "prs_with_changes", len(changes))
 
 	for _, ch := range changes {
-		// Even with no actionable events (all-APPROVED / all-skipped),
-		// advance the cursor so we don't re-evaluate the same events on
-		// every poll.
-		if len(ch.Events) == 0 {
+		// Even with no actionable events (all-APPROVED / all-skipped) and no
+		// CI failure, advance the cursor so we don't re-evaluate the same
+		// events on every poll.
+		if len(ch.Events) == 0 && ch.CIFailure == nil {
 			p.advanceCursor(ch)
 			continue
 		}
@@ -122,10 +122,10 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 // runs Claude, and pushes the follow-up commit.
 func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier string) {
 	logger := slog.With("id", identifier, "pr", ch.PR.URL)
-	logger.Info("re-engaging on PR feedback", "events", len(ch.Events))
+	logger.Info("re-engaging on PR", "events", len(ch.Events), "ci_failed", ch.CIFailure != nil)
 
 	// Heads-up Telegram (always — not gated by TELEGRAM_VERBOSE).
-	p.telegram.Send(ctx, fmt.Sprintf("🔄 *%s* — addressing review on PR #%d", identifier, ch.PR.Number))
+	p.telegram.Send(ctx, fmt.Sprintf("🔄 *%s* — %s on PR #%d", identifier, engagementSummary(ch), ch.PR.Number))
 
 	// On every failure path below we record the iteration before returning.
 	// Otherwise the cursor never advances and the next poll re-discovers the
@@ -179,6 +179,21 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		})
 	}
 
+	// Fetch failed-step logs for any failing CI checks (best-effort — if the
+	// fetch fails, Claude can still reproduce the failure locally).
+	var ciItems []agent.CIItem
+	if ch.CIFailure != nil {
+		for _, chk := range ch.CIFailure.FailedChecks {
+			item := agent.CIItem{Name: chk.CheckName(), URL: chk.URL()}
+			if logs, err := p.gh.CheckLogs(ctx, chk); err == nil {
+				item.Logs = logs
+			} else {
+				logger.Warn("could not fetch CI logs — Claude will reproduce locally", "check", chk.CheckName(), "err", err)
+			}
+			ciItems = append(ciItems, item)
+		}
+	}
+
 	prompt := agent.BuildFixPrompt(agent.FixPromptInput{
 		Identifier:  identifier,
 		Title:       title,
@@ -186,6 +201,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		PRNumber:    ch.PR.Number,
 		PRURL:       ch.PR.URL,
 		Feedback:    items,
+		CI:          ciItems,
 	})
 
 	logFile := filepath.Join(p.cfg.LogDir, identifier+".log")
@@ -244,8 +260,8 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 			return
 		}
-		commitMsg := fmt.Sprintf("fix: address review feedback on %s\n\nFollow-up commit by Nightshift addressing %d new feedback item(s).",
-			identifier, len(ch.Events))
+		commitMsg := fmt.Sprintf("fix: address PR feedback on %s\n\nFollow-up commit by Nightshift (%s).",
+			identifier, engagementSummary(ch))
 		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
 			logger.Error("git commit failed", "err", err)
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
@@ -278,6 +294,9 @@ func (p *Pipeline) recordIteration(ctx context.Context, ch watch.PRChanges, iden
 		if ch.NewestReview.After(r.LastReviewAt) {
 			r.LastReviewAt = ch.NewestReview
 		}
+		if ch.CIFailure != nil && ch.CIFailure.SHA != "" {
+			r.LastCISHA = ch.CIFailure.SHA
+		}
 		r.Iterations++
 		r.LastIteratedAt = time.Now()
 		iterations = r.Iterations
@@ -308,8 +327,26 @@ func (p *Pipeline) advanceCursor(ch watch.PRChanges) {
 		if ch.NewestReview.After(r.LastReviewAt) {
 			r.LastReviewAt = ch.NewestReview
 		}
+		if ch.CIFailure != nil && ch.CIFailure.SHA != "" {
+			r.LastCISHA = ch.CIFailure.SHA
+		}
 	}); err != nil {
 		slog.Warn("pipeline: cursor advance failed", "url", ch.PR.URL, "err", err)
+	}
+}
+
+// engagementSummary is a short human description of why Nightshift is
+// re-engaging on a PR — used in the Telegram heads-up and the commit message.
+func engagementSummary(ch watch.PRChanges) string {
+	hasFeedback := len(ch.Events) > 0
+	hasCI := ch.CIFailure != nil
+	switch {
+	case hasFeedback && hasCI:
+		return "addressing review + CI"
+	case hasCI:
+		return "fixing CI"
+	default:
+		return "addressing review"
 	}
 }
 

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -187,6 +187,10 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			item := agent.CIItem{Name: chk.CheckName(), URL: chk.URL()}
 			if logs, err := p.gh.CheckLogs(ctx, chk); err == nil {
 				item.Logs = logs
+			} else if errors.Is(err, github.ErrNotActionsRun) {
+				// Expected for non-Actions checks (CircleCI, Vercel, …) — no
+				// logs to fetch; Claude reproduces locally. Not worth a warning.
+				logger.Debug("skipping log fetch for non-Actions check", "check", chk.CheckName())
 			} else {
 				logger.Warn("could not fetch CI logs — Claude will reproduce locally", "check", chk.CheckName(), "err", err)
 			}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -34,6 +34,12 @@ type PRState struct {
 	// processed.
 	LastReviewAt time.Time `json:"last_review_at,omitempty"`
 
+	// LastCISHA is the head commit SHA whose failing CI Nightshift has
+	// already re-engaged on. CI is keyed by SHA (not timestamp) so a failure
+	// is acted on once per commit; pushing a fix changes the SHA, making a
+	// fresh failure eligible again — bounded by Iterations.
+	LastCISHA string `json:"last_ci_sha,omitempty"`
+
 	// Iterations counts how many times Nightshift has re-engaged on this
 	// PR. Capped by config.MaxPRIterations.
 	Iterations int `json:"iterations,omitempty"`

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -28,6 +28,7 @@ func TestUpdate_PersistsAcrossReopen(t *testing.T) {
 	if err := s.Update(prURL, func(r *PRState) {
 		r.TicketID = "ENG-42"
 		r.LastCommentAt = commentTs
+		r.LastCISHA = "abc123"
 		r.Iterations = 1
 	}); err != nil {
 		t.Fatalf("Update: %v", err)
@@ -47,6 +48,9 @@ func TestUpdate_PersistsAcrossReopen(t *testing.T) {
 	}
 	if got.Iterations != 1 {
 		t.Errorf("Iterations: got %d", got.Iterations)
+	}
+	if got.LastCISHA != "abc123" {
+		t.Errorf("LastCISHA: got %q", got.LastCISHA)
 	}
 }
 

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -41,16 +41,24 @@ type Event struct {
 	Line        int    // line number, populated for inline review comments
 }
 
+// CIFailure describes a head commit whose CI has completed with at least one
+// failing check and which Nightshift hasn't re-engaged on yet.
+type CIFailure struct {
+	SHA          string         // head commit the failures belong to
+	FailedChecks []github.Check // only the failing checks
+}
+
 // PRChanges packages everything the pipeline needs to act on one PR's worth
 // of new feedback. NewestComment / NewestReview are the cursors the caller
 // should write back into the state store *after* the iteration succeeds.
 type PRChanges struct {
 	PR            github.PR
 	Details       *github.Details
-	Events        []Event   // actionable (action!)
-	Skipped       []Event   // seen but filtered (log + ignore)
-	NewestComment time.Time // greatest CreatedAt across all comments
-	NewestReview  time.Time // greatest SubmittedAt across all reviews
+	Events        []Event    // actionable (action!)
+	Skipped       []Event    // seen but filtered (log + ignore)
+	NewestComment time.Time  // greatest CreatedAt across all comments
+	NewestReview  time.Time  // greatest SubmittedAt across all reviews
+	CIFailure     *CIFailure // non-nil when the head commit's CI failed and is unhandled
 }
 
 // Watcher couples the gh client with the state store and the trusted-reviewer
@@ -104,7 +112,7 @@ func (w *Watcher) Scan(ctx context.Context) ([]PRChanges, error) {
 		// still returned so the caller persists the advanced cursor.
 		cursorMoved := ch.NewestComment.After(cursor.LastCommentAt) ||
 			ch.NewestReview.After(cursor.LastReviewAt)
-		if len(ch.Events) > 0 || len(ch.Skipped) > 0 || cursorMoved {
+		if len(ch.Events) > 0 || len(ch.Skipped) > 0 || cursorMoved || ch.CIFailure != nil {
 			out = append(out, ch)
 		}
 	}
@@ -203,7 +211,35 @@ func (w *Watcher) diff(pr github.PR, d *github.Details, cursor state.PRState) PR
 		}
 	}
 
+	// CI: act at most once per head commit. Keyed by SHA, not timestamp —
+	// pushing a fix changes the SHA, so a fresh failure becomes eligible
+	// again (bounded by the iteration cap).
+	if d.HeadRefOid != "" && d.HeadRefOid != cursor.LastCISHA {
+		if failed := failedChecks(d.StatusCheckRollup); len(failed) > 0 {
+			out.CIFailure = &CIFailure{SHA: d.HeadRefOid, FailedChecks: failed}
+		}
+	}
+
 	return out
+}
+
+// failedChecks returns the failing checks, but only once every check has
+// completed — while any check is still running we return nil so the watcher
+// waits for the full picture rather than reacting to a transient red.
+func failedChecks(checks []github.Check) []github.Check {
+	if len(checks) == 0 {
+		return nil
+	}
+	var failed []github.Check
+	for _, c := range checks {
+		if !c.IsComplete() {
+			return nil
+		}
+		if c.IsFailure() {
+			failed = append(failed, c)
+		}
+	}
+	return failed
 }
 
 // actionable decides whether an event should be acted on. Humans are always

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -118,6 +118,76 @@ func TestDiff_OldInlineReviewCommentIsIgnored(t *testing.T) {
 	}
 }
 
+func TestDiff_CIFailureOnNewHeadCommit(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State:      "OPEN",
+		HeadRefOid: "abc123",
+		StatusCheckRollup: []github.Check{
+			{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE", DetailsURL: "u"},
+		},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if ch.CIFailure == nil {
+		t.Fatal("expected a CI failure")
+	}
+	if ch.CIFailure.SHA != "abc123" {
+		t.Errorf("SHA: got %q", ch.CIFailure.SHA)
+	}
+	if len(ch.CIFailure.FailedChecks) != 1 || ch.CIFailure.FailedChecks[0].CheckName() != "test" {
+		t.Errorf("failed checks: %+v", ch.CIFailure.FailedChecks)
+	}
+}
+
+func TestDiff_CIFailureAlreadyHandledForSHA(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State:             "OPEN",
+		HeadRefOid:        "abc123",
+		StatusCheckRollup: []github.Check{{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE"}},
+	}
+	// Cursor already at this SHA — must not re-fire.
+	ch := w.diff(pr, details, state.PRState{LastCISHA: "abc123"})
+	if ch.CIFailure != nil {
+		t.Error("CI failure for an already-handled SHA should not re-fire")
+	}
+}
+
+func TestDiff_CIStillRunningIsIgnored(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State:      "OPEN",
+		HeadRefOid: "abc123",
+		StatusCheckRollup: []github.Check{
+			{Name: "build", Status: "COMPLETED", Conclusion: "FAILURE"},
+			{Name: "test", Status: "IN_PROGRESS"}, // still running
+		},
+	}
+	ch := w.diff(pr, details, state.PRState{})
+	if ch.CIFailure != nil {
+		t.Error("should wait until all checks complete before acting on CI")
+	}
+}
+
+func TestDiff_CIAllGreenIsNoFailure(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
+	details := &github.Details{
+		State:             "OPEN",
+		HeadRefOid:        "abc123",
+		StatusCheckRollup: []github.Check{{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"}},
+	}
+	ch := w.diff(pr, details, state.PRState{})
+	if ch.CIFailure != nil {
+		t.Error("all-green CI should not produce a failure")
+	}
+}
+
 func TestDiff_OldCommentIsIgnored(t *testing.T) {
 	w := newTestWatcher(t, nil)
 	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}


### PR DESCRIPTION
## Summary

Closes ENG-174. Nightshift's auto-iterate loop now reacts to **failing CI**, not just review feedback — when a PR it created has a failed CI run, it fetches the failed-step logs and re-engages Claude on the same branch to reproduce and fix.

Builds directly on ENG-173 (#55), reusing its watcher / state / iteration-cap / branch-reuse plumbing. Per the design decisions: **no new flag** (folded into `AUTO_ITERATE_PRS`) and a **shared** `MAX_PR_ITERATIONS` budget across review + CI re-engagements.

## How it works

- `GetPR` now also pulls `headRefOid` + `statusCheckRollup`. `watch.diff` sets `PRChanges.CIFailure` only when **every** check on the head commit has completed and ≥1 failed — it waits while anything is still running, so it never reacts to a transient red.
- CI is keyed by **head commit SHA** (`state.PRState.LastCISHA`), so a failure is acted on **once per commit**. Pushing a fix changes the SHA, making a fresh failure eligible again — bounded by the iteration cap.
- `iteratePR` fetches truncated failed-step logs (`gh run view --log-failed`, best-effort — Claude can still reproduce locally if it fails) and folds them into the same fix prompt. When review feedback **and** CI are both pending, one re-engagement addresses both.
- CI is **not** gated by `TRUSTED_REVIEWERS` (it's not a person).

## Test plan

- [x] `go vet ./...`, `gofmt`, `go build ./...` clean
- [x] `go test -race ./...` green — new tests: `Check` helpers + `parseActionsRunURL`, CI detection (new SHA / already-handled / still-running / all-green), CI prompt rendering, `LastCISHA` round-trip
- [ ] On the Pi: open a PR with a deliberately failing test → confirm 🔄 "fixing CI" heads-up + a follow-up commit that makes CI green
- [ ] Verify a flaky/persistent failure stops at `MAX_PR_ITERATIONS` rather than looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)