### PR TITLE
Release pipeline: prebuilt binaries via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+# Cut a release by pushing a semver tag:
+#   git tag v2.0.0 && git push origin v2.0.0
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the changelog can diff against the last tag
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: set this secret once a homebrew-tap repo exists to publish a formula.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ repos.json
 
 # macOS
 .DS_Store
+
+# GoReleaser output
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,67 @@
+# GoReleaser config — cross-compiles Nightshift and publishes a GitHub Release
+# with archives + checksums on every pushed `v*` tag. See .github/workflows/release.yml.
+#
+#   Local dry run:  goreleaser release --snapshot --clean
+#   Validate:       goreleaser check
+version: 2
+
+project_name: nightshift
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: nightshift
+    main: ./cmd/nightshift
+    binary: nightshift
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - "7"
+    ignore:
+      # No 32-bit arm builds for macOS.
+      - goos: darwin
+        goarch: arm
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot"
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+
+release:
+  github:
+    owner: ahmadAlMezaal
+    name: nightshift
+  draft: false
+  prerelease: auto
+
+# A Homebrew formula/cask can be published here later via `homebrew_casks`,
+# once an `ahmadAlMezaal/homebrew-tap` repo and a HOMEBREW_TAP_TOKEN secret
+# exist. `go install` + the release binaries already cover install for now.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,3 +96,7 @@ GOOS=linux GOARCH=arm GOARM=7 go build -o nightshift ./cmd/nightshift
 ```
 
 `go vet ./...` should be clean.
+
+## Releasing
+
+Releases are automated with GoReleaser (`.goreleaser.yaml`) via `.github/workflows/release.yml`, triggered by pushing a `v*` tag. It cross-compiles linux `amd64`/`arm64`/`armv7` + darwin `amd64`/`arm64`, archives them with checksums, and publishes a GitHub Release. `main.version` is a `var` (not const) so the tag is stamped in via `-ldflags "-X main.version=..."`. Validate config changes locally with `goreleaser check` and `goreleaser release --snapshot --clean --skip=publish`.

--- a/README.md
+++ b/README.md
@@ -52,13 +52,31 @@ gh auth login   # authenticate gh
 
 ---
 
+## Install
+
+Nightshift is a single static binary — pick whichever you prefer:
+
+```bash
+# A. Go toolchain (installs the latest tagged release to $GOPATH/bin)
+go install github.com/ahmadAlMezaal/nightshift/cmd/nightshift@latest
+
+# B. Prebuilt binary — no Go required
+#    Grab the archive for your OS/arch from the Releases page:
+#    https://github.com/ahmadAlMezaal/nightshift/releases
+#    (linux amd64/arm64/armv7, macOS amd64/arm64), then:
+tar -xzf nightshift_*_linux_arm64.tar.gz && sudo mv nightshift /usr/local/bin/
+
+# C. Build from source
+git clone https://github.com/ahmadAlMezaal/nightshift.git
+cd nightshift && go build -o nightshift ./cmd/nightshift
+```
+
+Run `nightshift version` to confirm the build.
+
 ## Setup
 
 ```bash
-# 1. Clone and build
-git clone https://github.com/ahmadAlMezaal/nightshift.git
-cd nightshift
-go build -o nightshift ./cmd/nightshift
+# 1. With nightshift on your PATH (or ./nightshift if built from source)
 
 # 2. Run the interactive setup wizard
 #    Prompts for Linear, optional Gemini/Telegram, and your repos —
@@ -73,19 +91,25 @@ That's it. Move tickets to your trigger state (default: "Next") and watch them b
 
 Prefer editing config by hand? Copy `.env.example` → `.env` and `repos.example.json` → `repos.json` instead of running the wizard.
 
-### Cross-compile for the Raspberry Pi
+### Raspberry Pi
+
+Easiest: download the prebuilt **`linux_arm64`** (Pi 4 / 5, 64-bit OS) or **`linux_armv7`** (Pi 3 / 32-bit OS) archive from the [Releases page](https://github.com/ahmadAlMezaal/nightshift/releases) — no Go toolchain on the Pi needed.
+
+Prefer to cross-compile yourself:
 
 ```bash
-# Pi 4 / 5 (64-bit OS)
-GOOS=linux GOARCH=arm64 go build -o nightshift ./cmd/nightshift
-
-# Pi 3 or older / 32-bit OS
-GOOS=linux GOARCH=arm GOARM=7 go build -o nightshift ./cmd/nightshift
-
+GOOS=linux GOARCH=arm64 go build -o nightshift ./cmd/nightshift            # Pi 4 / 5
+GOOS=linux GOARCH=arm GOARM=7 go build -o nightshift ./cmd/nightshift      # Pi 3 / 32-bit
 scp nightshift pi@your-pi:/srv/nightshift/
 ```
 
-Then update your cron to point at the binary instead of the old shell script.
+### Cutting a release
+
+Releases are automated by [GoReleaser](https://goreleaser.com) (`.goreleaser.yaml` + `.github/workflows/release.yml`). Push a semver tag and a GitHub Release with cross-compiled archives + checksums is published automatically:
+
+```bash
+git tag v2.0.0 && git push origin v2.0.0
+```
 
 ---
 

--- a/cmd/nightshift/main.go
+++ b/cmd/nightshift/main.go
@@ -26,7 +26,9 @@ import (
 	"github.com/ahmadAlMezaal/nightshift/internal/setup"
 )
 
-const version = "2.0.0-dev"
+// version is the build version. Defaults to a dev marker for `go build`/`go
+// run`; release builds stamp the real tag via -ldflags "-X main.version=...".
+var version = "2.0.0-dev"
 
 func main() {
 	if err := realMain(); err != nil {


### PR DESCRIPTION
## Summary

Makes Nightshift installable **without building from source** — the "finalize for an open-source v1" gap. Pushing a semver tag now publishes a GitHub Release with cross-compiled archives + checksums, fully automated.

This is the salvageable, still-relevant core of the outdated ENG-105 (Docker/cloud-VPS framing predates the Go rewrite; prebuilt binaries are what actually matters now).

## What lands

- **`.goreleaser.yaml`** — build matrix (linux `amd64`/`arm64`/`armv7`, darwin `amd64`/`arm64`), `tar.gz` archives, `checksums.txt`, GitHub changelog, release config.
- **`.github/workflows/release.yml`** — on `v*` tag → `setup-go` → `goreleaser release --clean` (uses the auto `GITHUB_TOKEN`).
- **`main.version`** changed `const` → `var` so the tag is stamped via `-ldflags "-X main.version=..."`.
- **README** — new **Install** section (three paths: `go install`, prebuilt binary, build from source), a prebuilt-Pi note, and how to cut a release.
- **CLAUDE.md** — a Releasing section; **`.gitignore`** — `dist/`.

## Install paths this unlocks

```bash
go install github.com/ahmadAlMezaal/nightshift/cmd/nightshift@latest   # Go users
# or download a prebuilt archive from Releases — no Go toolchain needed
```

(A Homebrew tap can be added later via `homebrew_casks` once a `homebrew-tap` repo + token exist — noted in the config.)

## Test plan

- [x] All five targets cross-compile (`GOOS/GOARCH` matrix) with `-ldflags -s -w`
- [x] `go vet ./...` clean, `go test ./...` green
- [x] Version stamping verified: `go build -ldflags "-X main.version=v9.9.9-test"` → `nightshift v9.9.9-test`
- [x] `goreleaser check` passes (config valid, no deprecations)
- [x] `goreleaser release --snapshot --clean --skip=publish` produces all 5 archives + `checksums.txt`
- [ ] First real tag (`v2.0.0`) publishes the Release on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)