### PR TITLE
Fix: push Claude's work even when it self-commits (ENG-182)

### DIFF
--- a/internal/pipeline/git_test.go
+++ b/internal/pipeline/git_test.go
@@ -1,0 +1,99 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// gitRepoWithUpstream builds a temp repo with one commit on main and a
+// refs/remotes/origin/main tracking ref pointing at it (no real remote needed),
+// so branchAhead can be exercised against "origin/main".
+func gitRepoWithUpstream(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-b", "main", "--quiet")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "T")
+	run("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("a"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "c1", "--quiet")
+	run("update-ref", "refs/remotes/origin/main", "HEAD") // fake upstream at HEAD
+	return dir
+}
+
+func TestHasStagedChanges(t *testing.T) {
+	dir := gitRepoWithUpstream(t)
+	ctx := context.Background()
+	git := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Clean index.
+	if staged, err := hasStagedChanges(ctx, dir); err != nil || staged {
+		t.Fatalf("clean: staged=%v err=%v", staged, err)
+	}
+	// New staged file.
+	if err := os.WriteFile(filepath.Join(dir, "g.txt"), []byte("b"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	if staged, err := hasStagedChanges(ctx, dir); err != nil || !staged {
+		t.Fatalf("staged: staged=%v err=%v", staged, err)
+	}
+	// After commit, clean again.
+	git("commit", "-m", "c2", "--quiet")
+	if staged, err := hasStagedChanges(ctx, dir); err != nil || staged {
+		t.Fatalf("post-commit: staged=%v err=%v", staged, err)
+	}
+}
+
+func TestBranchAhead(t *testing.T) {
+	dir := gitRepoWithUpstream(t)
+	ctx := context.Background()
+	git := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// HEAD == origin/main → not ahead.
+	if ahead, err := branchAhead(ctx, dir, "origin/main"); err != nil || ahead {
+		t.Fatalf("level: ahead=%v err=%v", ahead, err)
+	}
+	// A new commit (the "Claude committed its own work" case) → ahead, even
+	// though the working tree is clean.
+	if err := os.WriteFile(filepath.Join(dir, "g.txt"), []byte("b"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-m", "claude-commit", "--quiet")
+	if ahead, err := branchAhead(ctx, dir, "origin/main"); err != nil || !ahead {
+		t.Fatalf("ahead: ahead=%v err=%v", ahead, err)
+	}
+	if changed, _ := workingTreeChanged(ctx, dir); changed {
+		t.Fatal("working tree should be clean after the commit (the bug scenario)")
+	}
+}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -251,19 +251,22 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		return
 	}
 
-	// Apply changes (if any).
-	hasChanges, err := workingTreeChanged(ctx, wt.Path)
-	if err != nil {
-		logger.Error("git status failed", "err", err)
+	// Push whatever the iteration produced. Claude may leave changes
+	// uncommitted OR commit them itself — so stage + commit anything pending,
+	// then push whenever the branch is ahead of its remote. Gating on a dirty
+	// worktree alone silently dropped Claude's own commits (ENG-182).
+	if err := runIn(ctx, wt.Path, "git", "add", "-A"); err != nil {
+		logger.Error("git add failed", "err", err)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 		return
 	}
-	if hasChanges {
-		if err := runIn(ctx, wt.Path, "git", "add", "-A"); err != nil {
-			logger.Error("git add failed", "err", err)
-			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
-			return
-		}
+	staged, err := hasStagedChanges(ctx, wt.Path)
+	if err != nil {
+		logger.Error("git diff --cached failed", "err", err)
+		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+		return
+	}
+	if staged {
 		commitMsg := fmt.Sprintf("fix: address PR feedback on %s\n\nFollow-up commit by Nightshift (%s).",
 			identifier, engagementSummary(ch))
 		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
@@ -271,6 +274,14 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 			return
 		}
+	}
+	ahead, err := branchAhead(ctx, wt.Path, "origin/"+wt.Branch)
+	if err != nil {
+		logger.Error("git rev-list failed", "err", err)
+		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+		return
+	}
+	if ahead {
 		if err := runIn(ctx, wt.Path, "git", "push", "origin", wt.Branch); err != nil {
 			logger.Error("git push failed", "err", err)
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -336,7 +336,7 @@ func workingTreeChanged(ctx context.Context, workdir string) (bool, error) {
 func hasStagedChanges(ctx context.Context, workdir string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--quiet")
 	cmd.Dir = workdir
-	err := cmd.Run()
+	out, err := cmd.CombinedOutput()
 	if err == nil {
 		return false, nil // exit 0: index clean
 	}
@@ -344,7 +344,7 @@ func hasStagedChanges(ctx context.Context, workdir string) (bool, error) {
 	if errors.As(err, &ee) && ee.ExitCode() == 1 {
 		return true, nil // exit 1: staged changes present
 	}
-	return false, err
+	return false, fmt.Errorf("git diff --cached: %w (%s)", err, strings.TrimSpace(string(out)))
 }
 
 // branchAhead reports whether HEAD has commits not present in upstream (e.g.
@@ -353,9 +353,9 @@ func hasStagedChanges(ctx context.Context, workdir string) (bool, error) {
 func branchAhead(ctx context.Context, workdir, upstream string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-list", "--count", upstream+"..HEAD")
 	cmd.Dir = workdir
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return false, fmt.Errorf("git rev-list %s..HEAD: %w", upstream, err)
+		return false, fmt.Errorf("git rev-list %s..HEAD: %w (%s)", upstream, err, strings.TrimSpace(string(out)))
 	}
 	n := strings.TrimSpace(string(out))
 	return n != "" && n != "0", nil

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -141,13 +141,23 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	}
 
 	// ── Any changes to commit? ───────────────────────────────────────────────
-	hasChanges, err := workingTreeChanged(ctx, wt.Path)
+	// Claude may leave edits uncommitted OR commit them itself, so "did it do
+	// anything" means a dirty worktree OR commits ahead of the base branch.
+	// Checking only the worktree would bounce a perfectly good self-committed
+	// implementation as "no changes made" (ENG-182).
+	dirty, err := workingTreeChanged(ctx, wt.Path)
 	if err != nil {
 		logger.Error("git status failed", "err", err)
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}
-	if !hasChanges {
+	committed, err := branchAhead(ctx, wt.Path, "origin/"+resolved.MainBranch)
+	if err != nil {
+		logger.Error("git rev-list failed", "err", err)
+		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
+		return
+	}
+	if !dirty && !committed {
 		logger.Warn("no changes made")
 		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
 			"💭 **Nightshift: No code changes made**\n\nClaude completed the session without modifying any files. This usually means the ticket description is too vague or needs more context.\n\nAdd more detail to the ticket description and move back to **%s** to retry.",
@@ -219,15 +229,27 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	}
 
 	// ── Commit and push ──────────────────────────────────────────────────────
+	// Commit only if there's staged work — if Claude already committed its own
+	// changes, the staged set is empty and a plain `git commit` would fail with
+	// "nothing to commit" and bounce a valid implementation (ENG-182).
 	commitMsg := fmt.Sprintf(
 		"feat: implement %s — %s\n\nImplemented by Nightshift using Claude Code\n\nLinear: %s",
 		id, issue.Title, issue.URL)
 
-	if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
-		logger.Error("git commit failed", "err", err)
-		p.linearBackToTrigger(ctx, issue.ID, "❌ **Nightshift: commit failed** — see Nightshift logs.")
+	staged, err := hasStagedChanges(ctx, wt.Path)
+	if err != nil {
+		logger.Error("git diff --cached failed", "err", err)
+		p.linearBackToTrigger(ctx, issue.ID, "❌ **Nightshift: commit check failed** — see Nightshift logs.")
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
+	}
+	if staged {
+		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
+			logger.Error("git commit failed", "err", err)
+			p.linearBackToTrigger(ctx, issue.ID, "❌ **Nightshift: commit failed** — see Nightshift logs.")
+			repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
+			return
+		}
 	}
 	if err := runIn(ctx, wt.Path, "git", "push", "-u", "origin", wt.Branch); err != nil {
 		logger.Error("git push failed", "err", err)
@@ -306,6 +328,37 @@ func workingTreeChanged(ctx context.Context, workdir string) (bool, error) {
 		return false, err
 	}
 	return len(bytes.TrimSpace(out)) > 0, nil
+}
+
+// hasStagedChanges reports whether the index has anything to commit. Used so we
+// only commit when there's staged work — Claude sometimes commits its own
+// changes, in which case a `git commit` would fail with "nothing to commit".
+func hasStagedChanges(ctx context.Context, workdir string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--quiet")
+	cmd.Dir = workdir
+	err := cmd.Run()
+	if err == nil {
+		return false, nil // exit 0: index clean
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) && ee.ExitCode() == 1 {
+		return true, nil // exit 1: staged changes present
+	}
+	return false, err
+}
+
+// branchAhead reports whether HEAD has commits not present in upstream (e.g.
+// origin/main, or origin/<branch>). This is how we detect work to push even
+// when Claude committed it itself, leaving a clean working tree.
+func branchAhead(ctx context.Context, workdir, upstream string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--count", upstream+"..HEAD")
+	cmd.Dir = workdir
+	out, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git rev-list %s..HEAD: %w", upstream, err)
+	}
+	n := strings.TrimSpace(string(out))
+	return n != "" && n != "0", nil
 }
 
 // gitDiff returns the staged diff (or the working-tree diff against HEAD if


### PR DESCRIPTION
## Summary

Fixes ENG-180… no — **ENG-182**, the bug that silently defeated auto-iterate on PR #65: Claude fixed the failing `gofmt` and committed it, but Nightshift never pushed the fix and then deleted the worktree.

Nightshift assumed Claude leaves edits **uncommitted** and that Nightshift does the `git add`/`commit`/`push`. When Claude commits its own work the worktree is clean, which broke **both** paths:

- **`iterate.go` (auto-iterate):** gated the push on a dirty worktree → clean tree → logged *"iteration produced no diff"*, **skipped the push**, advanced the CI cursor, and `CleanupWorktree` deleted the unpushed fix commit.
- **`process.go` (implement):** would bounce a valid implementation as *"no changes made"* (worktree check) and/or fail the unconditional `git commit` with *"nothing to commit"*.

## Fix

Both paths now: `git add -A` → commit **only if** there are staged changes → **push when the branch is ahead of its upstream** (`origin/<branch>` for iterate, `origin/<main>` for implement). Implement's "did Claude do anything" gate now also counts commits-ahead, not just a dirty tree.

New helpers: `hasStagedChanges` (`git diff --cached --quiet`) and `branchAhead` (`git rev-list --count <upstream>..HEAD`).

## Test plan
- [x] `TestHasStagedChanges` — clean / staged / post-commit
- [x] `TestBranchAhead` — level vs ahead-with-clean-worktree (the exact bug: commit present, worktree clean)
- [x] `go vet`, `gofmt`, golangci-lint v2.5.0 (0 issues), full `go test -race ./...`

## Notes
Found dogfooding ENG-141 (#65). Once merged, re-running ENG-141 through Nightshift should self-heal the `gofmt` failure and push it. Related: ENG-179 (dispatch resilience), ENG-181 (watch-loop observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)