### PR TITLE
ENG-181: Observability: log what the PR-watch loop is acting on each poll

### DIFF
--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -376,6 +376,7 @@ func (p *Pipeline) recordIteration(ctx context.Context, ch watch.PRChanges, iden
 		lastCISHA = r.LastCISHA
 	}); err != nil {
 		slog.Warn("pipeline: state update failed", "url", ch.PR.URL, "err", err)
+		return
 	}
 
 	slog.Info("cursor advanced",

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -66,15 +66,28 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 	slog.Info("pr poll", "prs_with_changes", len(changes))
 
 	for _, ch := range changes {
+		identifier := identifierFromBranch(ch.PR.HeadRefName)
+		newComments, newReviews := countEvents(ch.Events)
+		ciFailed := ch.CIFailure != nil
+
 		// Even with no actionable events (all-APPROVED / all-skipped) and no
 		// CI failure, advance the cursor so we don't re-evaluate the same
 		// events on every poll.
-		if len(ch.Events) == 0 && ch.CIFailure == nil {
+		if len(ch.Events) == 0 && !ciFailed {
+			reason := "none"
+			if len(ch.Skipped) > 0 {
+				reason = "untrusted-bot"
+			}
+			slog.Info("pr poll detail",
+				"pr", ch.PR.Number, "id", identifier,
+				"new_comments", newComments, "new_reviews", newReviews,
+				"ci_failed", ciFailed,
+				"action", "skip", "reason", reason,
+			)
 			p.advanceCursor(ch)
 			continue
 		}
 
-		identifier := identifierFromBranch(ch.PR.HeadRefName)
 		if identifier == "" {
 			slog.Warn("pr poll: branch is not a Nightshift branch; skipping",
 				"branch", ch.PR.HeadRefName)
@@ -83,8 +96,12 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 
 		cursor := p.store.Get(ch.PR.URL)
 		if cursor.Iterations >= p.cfg.MaxPRIterations {
-			slog.Info("pr at iteration cap — skipping",
-				"pr", ch.PR.URL, "iterations", cursor.Iterations, "cap", p.cfg.MaxPRIterations)
+			slog.Info("pr poll detail",
+				"pr", ch.PR.Number, "id", identifier,
+				"new_comments", newComments, "new_reviews", newReviews,
+				"ci_failed", ciFailed,
+				"action", "skip", "reason", "cap",
+			)
 			// Advance cursor anyway so the same skipped events don't
 			// keep getting "discovered" forever.
 			p.advanceCursor(ch)
@@ -94,12 +111,22 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 		p.mu.Lock()
 		if _, dupe := p.active[identifier]; dupe {
 			p.mu.Unlock()
-			slog.Info("pr iteration skipped — ticket already in progress", "id", identifier)
+			slog.Info("pr poll detail",
+				"pr", ch.PR.Number, "id", identifier,
+				"new_comments", newComments, "new_reviews", newReviews,
+				"ci_failed", ciFailed,
+				"action", "skip", "reason", "in-progress",
+			)
 			continue
 		}
 		if len(p.active) >= p.cfg.MaxConcurrent {
 			p.mu.Unlock()
-			slog.Info("pr iteration deferred — at capacity", "id", identifier)
+			slog.Info("pr poll detail",
+				"pr", ch.PR.Number, "id", identifier,
+				"new_comments", newComments, "new_reviews", newReviews,
+				"ci_failed", ciFailed,
+				"action", "skip", "reason", "at-capacity",
+			)
 			// continue, not return: this PR waits for the next tick, but
 			// later non-actionable PRs in this batch still need their cursors
 			// advanced.
@@ -108,6 +135,13 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 		p.active[identifier] = struct{}{}
 		p.mu.Unlock()
 
+		slog.Info("pr poll detail",
+			"pr", ch.PR.Number, "id", identifier,
+			"new_comments", newComments, "new_reviews", newReviews,
+			"ci_failed", ciFailed,
+			"action", "iterate",
+		)
+
 		wg.Add(1)
 		go func(ch watch.PRChanges, id string) {
 			defer wg.Done()
@@ -115,6 +149,19 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 			p.iteratePR(ctx, ch, id)
 		}(ch, identifier)
 	}
+}
+
+// countEvents tallies actionable events by type for structured logging.
+func countEvents(events []watch.Event) (comments, reviews int) {
+	for _, ev := range events {
+		switch ev.Type {
+		case watch.EventComment:
+			comments++
+		case watch.EventReview:
+			reviews++
+		}
+	}
+	return
 }
 
 // iteratePR is one re-engagement on an open PR. Resolves the repo, resumes
@@ -152,6 +199,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
 		return
 	}
+	logger.Info("resume worktree", "path", wt.Path)
 	defer repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, identifier)
 
 	// Fetch ticket context from Linear so the fix prompt has Title + Description.
@@ -212,6 +260,8 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	_ = agent.AttemptHeader(logFile)
 	offset := agent.OffsetBefore(logFile)
 
+	logger.Info("running claude")
+
 	runErr := agent.Run(ctx, agent.RunOptions{
 		Workdir:       wt.Path,
 		Prompt:        prompt,
@@ -240,7 +290,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	}
 
 	if blocked := agent.BlockedLine(output); blocked != "" {
-		logger.Info("claude blocked on review feedback", "line", blocked)
+		logger.Info("blocked", "reason", blocked)
 		if issueID != "" {
 			_ = p.linear.Comment(ctx, issueID, fmt.Sprintf(
 				"🚧 **Nightshift: blocked on PR feedback**\n\n> %s\n\nLeft the PR as-is. Reply to the PR with clarification, then move the ticket to **%s** to retry.",
@@ -287,9 +337,10 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 			return
 		}
-		logger.Info("pushed follow-up commit", "branch", wt.Branch)
+		sha := gitHeadShort(ctx, wt.Path)
+		logger.Info("pushed follow-up commit", "sha", sha, "branch", wt.Branch)
 	} else {
-		logger.Info("iteration produced no diff — feedback addressed without code edits, or Claude chose not to act")
+		logger.Info("no diff produced")
 	}
 
 	p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
@@ -298,7 +349,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 // recordIteration bumps the per-PR iteration counter, advances the comment +
 // review cursors, and fires the cap-hit notifications on the transition.
 func (p *Pipeline) recordIteration(ctx context.Context, ch watch.PRChanges, identifier string, prNumber int, issueID string) {
-	var iterations int
+	var (
+		iterations  int
+		lastComment time.Time
+		lastReview  time.Time
+		lastCISHA   string
+	)
 	if err := p.store.Update(ch.PR.URL, func(r *state.PRState) {
 		if r.TicketID == "" {
 			r.TicketID = identifier
@@ -315,9 +371,19 @@ func (p *Pipeline) recordIteration(ctx context.Context, ch watch.PRChanges, iden
 		r.Iterations++
 		r.LastIteratedAt = time.Now()
 		iterations = r.Iterations
+		lastComment = r.LastCommentAt
+		lastReview = r.LastReviewAt
+		lastCISHA = r.LastCISHA
 	}); err != nil {
 		slog.Warn("pipeline: state update failed", "url", ch.PR.URL, "err", err)
 	}
+
+	slog.Info("cursor advanced",
+		"id", identifier, "pr", prNumber,
+		"last_comment", lastComment, "last_review", lastReview,
+		"last_ci_sha", lastCISHA,
+		"iterations", fmt.Sprintf("%d/%d", iterations, p.cfg.MaxPRIterations),
+	)
 
 	if iterations >= p.cfg.MaxPRIterations {
 		p.telegram.Send(ctx, fmt.Sprintf(

--- a/internal/pipeline/iterate_test.go
+++ b/internal/pipeline/iterate_test.go
@@ -1,0 +1,98 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/watch"
+)
+
+func TestCountEvents_MixedTypes(t *testing.T) {
+	events := []watch.Event{
+		{Type: watch.EventComment},
+		{Type: watch.EventReview},
+		{Type: watch.EventComment},
+		{Type: watch.EventComment},
+		{Type: watch.EventReview},
+	}
+	comments, reviews := countEvents(events)
+	if comments != 3 {
+		t.Errorf("comments: got %d, want 3", comments)
+	}
+	if reviews != 2 {
+		t.Errorf("reviews: got %d, want 2", reviews)
+	}
+}
+
+func TestCountEvents_Empty(t *testing.T) {
+	comments, reviews := countEvents(nil)
+	if comments != 0 || reviews != 0 {
+		t.Errorf("empty: got comments=%d reviews=%d", comments, reviews)
+	}
+}
+
+func TestCountEvents_CommentsOnly(t *testing.T) {
+	events := []watch.Event{
+		{Type: watch.EventComment},
+		{Type: watch.EventComment},
+	}
+	comments, reviews := countEvents(events)
+	if comments != 2 {
+		t.Errorf("comments: got %d, want 2", comments)
+	}
+	if reviews != 0 {
+		t.Errorf("reviews: got %d, want 0", reviews)
+	}
+}
+
+func TestCountEvents_ReviewsOnly(t *testing.T) {
+	events := []watch.Event{
+		{Type: watch.EventReview},
+	}
+	comments, reviews := countEvents(events)
+	if comments != 0 {
+		t.Errorf("comments: got %d, want 0", comments)
+	}
+	if reviews != 1 {
+		t.Errorf("reviews: got %d, want 1", reviews)
+	}
+}
+
+func TestGitHeadShort(t *testing.T) {
+	dir := gitRepoWithUpstream(t) // from git_test.go
+	ctx := context.Background()
+	sha := gitHeadShort(ctx, dir)
+	if sha == "" {
+		t.Fatal("expected non-empty SHA")
+	}
+	if len(sha) < 7 {
+		t.Errorf("SHA too short: %q", sha)
+	}
+}
+
+func TestGitHeadShort_InvalidDir(t *testing.T) {
+	ctx := context.Background()
+	sha := gitHeadShort(ctx, t.TempDir())
+	if sha != "" {
+		t.Errorf("expected empty SHA for non-git dir, got %q", sha)
+	}
+}
+
+func TestIdentifierFromBranch(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   string
+	}{
+		{"nightshift/eng-42", "ENG-42"},
+		{"nightshift/eng-181", "ENG-181"},
+		{"main", ""},
+		{"feature/something", ""},
+		{"nightshift/", ""},
+	}
+	for _, tt := range tests {
+		got := identifierFromBranch(tt.branch)
+		if got != tt.want {
+			t.Errorf("identifierFromBranch(%q) = %q, want %q", tt.branch, got, tt.want)
+		}
+	}
+}

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -401,6 +401,17 @@ func ghCreatePR(ctx context.Context, repoPath, title, body, base, head string) (
 	return strings.TrimSpace(string(out)), nil
 }
 
+// gitHeadShort returns the abbreviated HEAD commit SHA, or "" on error.
+func gitHeadShort(ctx context.Context, workdir string) string {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--short", "HEAD")
+	cmd.Dir = workdir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func runIn(ctx context.Context, dir, name string, args ...string) error {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir


### PR DESCRIPTION
## ENG-181: Observability: log what the PR-watch loop is acting on each poll

**Linear:** https://linear.app/amazz/issue/ENG-181/observability-log-what-the-pr-watch-loop-is-acting-on-each-poll

## What was implemented

All tests pass, `go vet` is clean, and the build succeeds. Here's a summary of what was implemented:

## Summary

### Changes made

**`internal/pipeline/iterate.go`** — Main observability improvements:

1. **Per-PR poll detail logging** (`prPollOnce`): Each PR with changes now emits a structured `"pr poll detail"` log line with: PR number, ticket ID, `new_comments`/`new_reviews` counts, `ci_failed` status, `action` (iterate/skip), and `reason` (none/untrusted-bot/cap/in-progress/at-capacity). Replaces the previous inconsistent individual skip messages.

2. **Iteration milestone logging** (`iteratePR`):
   - `"resume worktree"` — logged after successful worktree resume with path
   - `"running claude"` — logged before agent execution begins
   - `"pushed follow-up commit"` — now includes `sha` field (via new `gitHeadShort` helper)
   - `"no diff produced"` — shortened from the verbose original message
   - `"blocked"` — uses `reason` key instead of `line` for clarity

3. **Cursor update logging** (`recordIteration`): After every iteration, emits `"cursor advanced"` with `last_comment`, `last_review`, `last_ci_sha`, and `iterations` (formatted as `N/CAP`).

4. **`countEvents` helper**: Tallies actionable events by type (comment vs review) for the poll detail log.

**`internal/pipeline/process.go`**:
- Added `gitHeadShort` helper that runs `git rev-parse --short HEAD` to get the abbreviated commit SHA.

**`internal/pipeline/iterate_test.go`** (new):
- Tests for `countEvents` (mixed types, empty, comments-only, reviews-only)
- Tests for `gitHeadShort` (valid repo, non-git dir)
- Tests for `identifierFromBranch`

### Design decisions

- Used `"pr poll detail"` as the slog message (not just `"pr"`) for greppability — distinct from the existing `"pr poll"` heartbeat.
- The `reason` field on skip distinguishes `"untrusted-bot"` (events exist but all from untrusted bots) from `"none"` (only cursor-advancing, non-actionable events like APPROVED reviews).
- Cursor logging lives inside `recordIteration` so it's emitted on every terminal path (pushed, no-diff, blocked, failed) without needing changes at each call site.
- All new logging is INFO level and structured slog kv — no secrets or tokens are logged.

---

*Implemented by [Nightshift](https://github.com/ahmadAlMezaal/nightshift) 🌙 using Claude Code*