### PR TITLE
ENG-179: Bug: deterministic dispatch failure burns the dispatch budget + shuts the agent down

### DIFF
--- a/internal/pipeline/dispatch_test.go
+++ b/internal/pipeline/dispatch_test.go
@@ -1,0 +1,76 @@
+package pipeline
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/repo"
+)
+
+func TestSkipPermanently_AddToSetAndRefundsDispatch(t *testing.T) {
+	p := &Pipeline{
+		skipped:        map[string]struct{}{},
+		active:         map[string]struct{}{},
+		failedAttempts: map[string]int{},
+	}
+	p.totalDispatches = 5
+
+	p.skipPermanently("ENG-100")
+
+	if _, ok := p.skipped["ENG-100"]; !ok {
+		t.Fatal("ENG-100 should be in the skipped set")
+	}
+	if p.totalDispatches != 4 {
+		t.Fatalf("totalDispatches: got %d, want 4 (should be refunded)", p.totalDispatches)
+	}
+
+	// Skipping again is idempotent but still decrements — the set prevents
+	// double-dispatch so this path shouldn't happen in practice.
+	p.skipPermanently("ENG-100")
+	if p.totalDispatches != 3 {
+		t.Fatalf("totalDispatches: got %d after second skip", p.totalDispatches)
+	}
+}
+
+func TestNonTransientError_Detectable(t *testing.T) {
+	inner := errors.New("no repo is mapped for project \"Foo\"")
+	nte := &repo.NonTransientError{Err: inner}
+
+	// errors.As should find it.
+	var target *repo.NonTransientError
+	if !errors.As(nte, &target) {
+		t.Fatal("errors.As should detect NonTransientError")
+	}
+	if target.Error() != inner.Error() {
+		t.Errorf("Error(): got %q, want %q", target.Error(), inner.Error())
+	}
+
+	// Unwrap should return the inner error.
+	if errors.Unwrap(nte) != inner {
+		t.Fatal("Unwrap should return the inner error")
+	}
+
+	// A plain error should NOT match.
+	plain := errors.New("transient clone failure")
+	if errors.As(plain, &target) {
+		t.Fatal("plain error should not match NonTransientError")
+	}
+}
+
+func TestBumpFailed_BoundsRetries(t *testing.T) {
+	p := &Pipeline{
+		skipped:        map[string]struct{}{},
+		active:         map[string]struct{}{},
+		failedAttempts: map[string]int{},
+	}
+
+	for i := 1; i <= 5; i++ {
+		got := p.bumpFailed("ENG-200")
+		if got != i {
+			t.Fatalf("bumpFailed attempt %d: got %d", i, got)
+		}
+	}
+	if p.failCount != 5 {
+		t.Fatalf("failCount: got %d, want 5", p.failCount)
+	}
+}

--- a/internal/pipeline/dispatch_test.go
+++ b/internal/pipeline/dispatch_test.go
@@ -24,11 +24,10 @@ func TestSkipPermanently_AddToSetAndRefundsDispatch(t *testing.T) {
 		t.Fatalf("totalDispatches: got %d, want 4 (should be refunded)", p.totalDispatches)
 	}
 
-	// Skipping again is idempotent but still decrements — the set prevents
-	// double-dispatch so this path shouldn't happen in practice.
+	// Skipping again should be idempotent and not decrement again.
 	p.skipPermanently("ENG-100")
-	if p.totalDispatches != 3 {
-		t.Fatalf("totalDispatches: got %d after second skip", p.totalDispatches)
+	if p.totalDispatches != 4 {
+		t.Fatalf("totalDispatches: got %d after second skip, want 4 (should be idempotent)", p.totalDispatches)
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -43,6 +43,7 @@ type Pipeline struct {
 	mu                sync.Mutex
 	active            map[string]struct{} // identifiers in-flight
 	failedAttempts    map[string]int      // per-ticket retry counter
+	skipped           map[string]struct{} // non-transient failures — never re-dispatched
 	totalDispatches   int
 	successCount      int
 	failCount         int
@@ -59,6 +60,7 @@ func New(cfg *config.Config) *Pipeline {
 		review:         review.New(cfg.GeminiAPIKey, cfg.GeminiModel),
 		active:         map[string]struct{}{},
 		failedAttempts: map[string]int{},
+		skipped:        map[string]struct{}{},
 		sessionStart:   time.Now(),
 	}
 
@@ -245,6 +247,11 @@ func (p *Pipeline) pollOnce(ctx context.Context, wg *sync.WaitGroup) {
 				"attempts", p.failedAttempts[issue.Identifier])
 			continue
 		}
+		if _, skip := p.skipped[issue.Identifier]; skip {
+			p.mu.Unlock()
+			slog.Debug("skipping (non-transient failure)", "id", issue.Identifier)
+			continue
+		}
 		p.active[issue.Identifier] = struct{}{}
 		p.totalDispatches++
 		p.mu.Unlock()
@@ -280,6 +287,17 @@ func (p *Pipeline) bumpSuccess() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.successCount++
+}
+
+// skipPermanently marks a ticket as permanently skipped (non-transient failure
+// like a missing repos.json mapping). The ticket won't be re-dispatched on
+// future polls, and the dispatch it consumed is refunded so deterministic
+// config errors don't burn the dispatch budget or shut the agent down.
+func (p *Pipeline) skipPermanently(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.skipped[id] = struct{}{}
+	p.totalDispatches-- // refund — config errors shouldn't count
 }
 
 func (p *Pipeline) flagRateLimit() {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -293,11 +293,14 @@ func (p *Pipeline) bumpSuccess() {
 // like a missing repos.json mapping). The ticket won't be re-dispatched on
 // future polls, and the dispatch it consumed is refunded so deterministic
 // config errors don't burn the dispatch budget or shut the agent down.
+// Idempotent: calling multiple times for the same ID only refunds once.
 func (p *Pipeline) skipPermanently(id string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.skipped[id] = struct{}{}
-	p.totalDispatches-- // refund — config errors shouldn't count
+	if _, ok := p.skipped[id]; !ok {
+		p.skipped[id] = struct{}{}
+		p.totalDispatches-- // refund — config errors shouldn't count
+	}
 }
 
 func (p *Pipeline) flagRateLimit() {

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -40,9 +40,28 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	resolved, err := p.resolver.Resolve(ctx, issue.ProjectName())
 	if err != nil {
 		logger.Error("repo resolution failed", "err", err)
+
+		var nte *repo.NonTransientError
+		if errors.As(err, &nte) {
+			// Deterministic config error — will never succeed without
+			// human intervention. Skip on future polls and refund the
+			// dispatch so config mistakes don't burn the budget or shut
+			// the agent down. Only one comment + notification is posted.
+			p.skipPermanently(id)
+			if cerr := p.linear.Comment(ctx, issue.ID,
+				fmt.Sprintf("❌ **Nightshift: No repo for this ticket**\n\n%s\n\nMap this ticket's project in `repos.json` (or run `./nightshift setup`), then move it back to **%s**.",
+					err.Error(), p.cfg.TriggerState)); cerr != nil {
+				slog.Warn("linear Comment failed", "issue_id", issue.ID, "err", cerr)
+			}
+			p.telegram.Send(ctx, fmt.Sprintf("⚠️ *%s* — skipped (no repo mapping)", id))
+			return
+		}
+
+		// Transient failure — move back to trigger and retry (bounded).
+		attempts := p.bumpFailed(id)
 		p.linearBackToTrigger(ctx, issue.ID,
-			fmt.Sprintf("❌ **Nightshift: No repo for this ticket**\n\n%s\n\nMap this ticket's project in `repos.json` (or run `./nightshift setup`), then move it back to **%s**.",
-				err.Error(), p.cfg.TriggerState))
+			fmt.Sprintf("❌ **Nightshift: repo resolution failed** (attempt %d/%d)\n\n%s\n\nTicket moved back to **%s**. Will retry on next poll cycle.",
+				attempts, p.cfg.MaxRetries, err.Error(), p.cfg.TriggerState))
 		return
 	}
 	logger.Info("repo resolved", "path", resolved.Path, "main", resolved.MainBranch)

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -49,7 +49,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 			// the agent down. Only one comment + notification is posted.
 			p.skipPermanently(id)
 			if cerr := p.linear.Comment(ctx, issue.ID,
-				fmt.Sprintf("❌ **Nightshift: No repo for this ticket**\n\n%s\n\nMap this ticket's project in `repos.json` (or run `./nightshift setup`), then move it back to **%s**.",
+				fmt.Sprintf("❌ **Nightshift: No repo for this ticket**\n\n%s\n\nMap this ticket's project in `repos.json` (or run `./nightshift setup`), then restart Nightshift and move it back to **%s**.",
 					err.Error(), p.cfg.TriggerState)); cerr != nil {
 				slog.Warn("linear Comment failed", "issue_id", issue.ID, "err", cerr)
 			}
@@ -59,9 +59,15 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 		// Transient failure — move back to trigger and retry (bounded).
 		attempts := p.bumpFailed(id)
-		p.linearBackToTrigger(ctx, issue.ID,
-			fmt.Sprintf("❌ **Nightshift: repo resolution failed** (attempt %d/%d)\n\n%s\n\nTicket moved back to **%s**. Will retry on next poll cycle.",
-				attempts, p.cfg.MaxRetries, err.Error(), p.cfg.TriggerState))
+		var msg string
+		if attempts >= p.cfg.MaxRetries {
+			msg = fmt.Sprintf("❌ **Nightshift: repo resolution failed** (attempt %d/%d)\n\n%s\n\nMax retries reached. Ticket moved back to **%s** but will not be retried automatically.",
+				attempts, p.cfg.MaxRetries, err.Error(), p.cfg.TriggerState)
+		} else {
+			msg = fmt.Sprintf("❌ **Nightshift: repo resolution failed** (attempt %d/%d)\n\n%s\n\nTicket moved back to **%s**. Will retry on next poll cycle.",
+				attempts, p.cfg.MaxRetries, err.Error(), p.cfg.TriggerState)
+		}
+		p.linearBackToTrigger(ctx, issue.ID, msg)
 		return
 	}
 	logger.Info("repo resolved", "path", resolved.Path, "main", resolved.MainBranch)

--- a/internal/repo/resolve.go
+++ b/internal/repo/resolve.go
@@ -12,6 +12,18 @@ import (
 	"github.com/ahmadAlMezaal/nightshift/internal/config"
 )
 
+// NonTransientError signals a failure that is deterministic and cannot
+// resolve without human intervention — e.g. a missing repos.json mapping
+// or a ticket with no Linear project and no REPO_PATH fallback. The
+// pipeline uses this to skip the ticket on future polls instead of
+// retrying every cycle and burning the dispatch budget.
+type NonTransientError struct {
+	Err error
+}
+
+func (e *NonTransientError) Error() string { return e.Err.Error() }
+func (e *NonTransientError) Unwrap() error { return e.Err }
+
 // Resolved describes the local repository and base branch a ticket should
 // be implemented against.
 type Resolved struct {
@@ -74,12 +86,12 @@ func (r *Resolver) Resolve(ctx context.Context, project string) (Resolved, error
 	}
 
 	if project == "" {
-		return Resolved{}, errors.New(
-			"this ticket has no Linear project, and no REPO_PATH fallback is configured")
+		return Resolved{}, &NonTransientError{Err: errors.New(
+			"this ticket has no Linear project, and no REPO_PATH fallback is configured")}
 	}
-	return Resolved{}, fmt.Errorf(
+	return Resolved{}, &NonTransientError{Err: fmt.Errorf(
 		"no repo is mapped for the project %q in repos.json, and no REPO_PATH fallback is configured",
-		project)
+		project)}
 }
 
 // checkRemoteAccess runs `git ls-remote` to verify the host can reach the

--- a/internal/repo/resolve_test.go
+++ b/internal/repo/resolve_test.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -147,6 +148,58 @@ func TestResolve_NoMatchAndNoFallback(t *testing.T) {
 	_, err = r.Resolve(context.Background(), "")
 	if err == nil || !strings.Contains(err.Error(), "no Linear project") {
 		t.Fatalf("expected empty-project error, got %v", err)
+	}
+}
+
+func TestResolve_NoMatchReturnsNonTransient(t *testing.T) {
+	r := &Resolver{
+		Registry:   &config.RepoRegistry{Repos: map[string]config.RepoEntry{}},
+		ReposBase:  t.TempDir(),
+		MainBranch: "main",
+	}
+
+	// Unmapped project, no fallback → NonTransientError.
+	_, err := r.Resolve(context.Background(), "Missing Project")
+	if err == nil {
+		t.Fatal("expected error for unmapped project")
+	}
+	var nte *NonTransientError
+	if !errors.As(err, &nte) {
+		t.Fatalf("expected NonTransientError, got %T: %v", err, err)
+	}
+	if !strings.Contains(nte.Error(), "no repo is mapped") {
+		t.Errorf("unexpected message: %q", nte.Error())
+	}
+
+	// Empty project, no fallback → NonTransientError.
+	_, err = r.Resolve(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty project")
+	}
+	if !errors.As(err, &nte) {
+		t.Fatalf("expected NonTransientError, got %T: %v", err, err)
+	}
+	if !strings.Contains(nte.Error(), "no Linear project") {
+		t.Errorf("unexpected message: %q", nte.Error())
+	}
+}
+
+func TestResolve_FallbackToRepoPathIsNotNonTransient(t *testing.T) {
+	fallback := fakeGitRepo(t)
+	r := &Resolver{
+		Registry:   &config.RepoRegistry{Repos: map[string]config.RepoEntry{}},
+		ReposBase:  t.TempDir(),
+		RepoPath:   fallback,
+		MainBranch: "main",
+	}
+
+	// Unmapped project WITH a valid fallback → success, no error at all.
+	res, err := r.Resolve(context.Background(), "Unmapped Project")
+	if err != nil {
+		t.Fatalf("expected success with fallback, got %v", err)
+	}
+	if res.Path != fallback {
+		t.Errorf("Path: got %q, want %q", res.Path, fallback)
 	}
 }
 


### PR DESCRIPTION
## ENG-179: Bug: deterministic dispatch failure burns the dispatch budget + shuts the agent down

**Linear:** https://linear.app/amazz/issue/ENG-179/bug-deterministic-dispatch-failure-burns-the-dispatch-budget-shuts-the

## What was implemented

All tests pass and `go vet` is clean.

## Summary

### Problem
When a ticket's project had no `repos.json` mapping, `process()` called `linearBackToTrigger()` which moved the ticket back to the trigger state. The next poll re-fetched it, re-dispatched, and re-failed — an infinite loop that:
- Posted duplicate Linear comments + Telegram pings every ~30s
- Burned the dispatch budget (each failure counted as a dispatch)
- Tripped `MAX_DISPATCHES` and shut the agent down entirely

### What was implemented

**3 files modified, 1 file created:**

1. **`internal/repo/resolve.go`** — Added `NonTransientError` type that wraps deterministic config errors. The two cases where `Resolve` returns "no repo mapping" or "no Linear project" (with no fallback) now return `&NonTransientError{...}` instead of plain errors. Transient errors (clone failures, auth issues, etc.) remain as regular errors.

2. **`internal/pipeline/pipeline.go`** — Added:
   - `skipped map[string]struct{}` field to Pipeline for permanently-skipped ticket identifiers
   - `skipPermanently(id)` method that adds to `skipped` and decrements `totalDispatches` (refunding the dispatch)
   - Skip check in `pollOnce()` — tickets in the `skipped` set are silently skipped without dispatching

3. **`internal/pipeline/process.go`** — Updated the repo resolution error handler to distinguish non-transient from transient:
   - **Non-transient** (`NonTransientError`): calls `skipPermanently`, posts ONE Linear comment (without moving the ticket back to trigger), sends ONE Telegram notification, returns. The ticket is never re-dispatched.
   - **Transient** (all other errors): calls `bumpFailed` (bounded by `MaxRetries`), moves back to trigger state via `linearBackToTrigger`. This path was previously unbounded — now it's bounded by the existing retry mechanism.

4. **`internal/pipeline/dispatch_test.go`** (new) — Tests for `skipPermanently` (adds to set, refunds dispatch) and `NonTransientError` detection via `errors.As`.

5. **`internal/repo/resolve_test.go`** — Added tests verifying `NonTransientError` is returned for unmapped projects and empty projects, and that the fallback-to-`REPO_PATH` path does NOT return `NonTransientError`.

### Key design decisions

- **In-memory `skipped` set** rather than persisted state. On restart, the first poll will re-attempt (and re-skip) the ticket with one comment — acceptable tradeoff for simplicity. The critical fix is preventing the infinite loop within a session.
- **Dispatch refund** via `totalDispatches--` in `skipPermanently()` so config errors don't burn the budget.
- **Comment deduplication** is achieved naturally: the ticket is dispatched once, commented once, then skipped on all subsequent polls.
- **Transient repo failures** now call `bumpFailed()` so they're bounded by `MaxRetries`, preventing a persistent network issue from also burning the full budget.

---

*Implemented by [Nightshift](https://github.com/ahmadAlMezaal/nightshift) 🌙 using Claude Code*