### PR TITLE
ENG-168: Inbound Telegram listener — two-way control channel for Nightshift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,14 @@ If a ticket's project has no registry entry, Nightshift falls back to `REPO_PATH
 
 | Package | Purpose |
 |---------|---------|
-| `cmd/nightshift` | Entry point + subcommand dispatch (`run` / `setup` / `cleanup` / `doctor` / `version`); startup banner; `--help` |
+| `cmd/nightshift` | Entry point + subcommand dispatch (`run` / `listener` / `setup` / `cleanup` / `doctor` / `version`); startup banner; `--help` |
 | `internal/config` | `.env` parser, `repos.json` loader, validated `Config`, `DefaultConfigDir` (`~/.nightshift/`) |
 | `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `FetchLabeledIssues`, `ResolveLabelID`, `RemoveLabel`, `SetState`, `Comment` |
 | `internal/repo` | Project → repo slug + registry; clone-on-demand; worktree create/cleanup; `BranchName`; `CreateWorktree` (from main) + `ResumeWorktree` (pull existing remote branch) |
 | `internal/agent` | Claude Code runner (`exec`) with timeout; implement-prompt builder; `BuildFixPrompt` (review feedback + failing-CI prompt); log_offset parsing |
 | `internal/review` | Optional Gemini second-model review gate |
 | `internal/notify` | Optional Telegram notifier (fire-and-forget) |
+| `internal/telegram` | Inbound Telegram listener: long-polling `getUpdates`, sender auth, command dispatcher; runs as `nightshift listener` subcommand |
 | `internal/github` | Thin `gh` CLI wrapper: `ListNightshiftPRs`, `GetPR` (comments + reviews + inline review comments via REST + `statusCheckRollup`), `CheckLogs` (failed-step logs via `gh run view`) |
 | `internal/state` | File-backed PR cursor store (`~/.nightshift-state.json`): per-PR comment/review timestamps + CI head-SHA + iteration count; atomic, mutex-guarded |
 | `internal/watch` | Side-effect-free classifier: diffs a PR's feedback + CI status against the cursor, applies trusted-reviewer rules, emits actionable events + `CIFailure` |

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BINARY := nightshift
 PKG    := ./cmd/nightshift
 
 .DEFAULT_GOAL := help
-.PHONY: help build test vet run setup cleanup build-pi update start stop restart status logs
+.PHONY: help build test vet run listener setup cleanup build-pi update start stop restart status logs start-listener stop-listener restart-listener status-listener logs-listener
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} \
@@ -29,6 +29,9 @@ vet: ## Run go vet
 
 run: build ## Build and start the poll loop in the foreground
 	./$(BINARY)
+
+listener: build ## Build and start the Telegram command listener
+	./$(BINARY) listener
 
 setup: build ## Build and run the interactive setup wizard
 	./$(BINARY) setup
@@ -67,3 +70,20 @@ status: ## Show service status
 
 logs: ## Tail live logs (Ctrl+C to stop)
 	journalctl --user-unit=nightshift.service -f
+
+# ── Telegram listener service management (run on the Pi) ─────────────────
+
+start-listener: ## Start the Telegram listener service
+	systemctl --user start nightshift-listener
+
+stop-listener: ## Stop the Telegram listener service
+	systemctl --user stop nightshift-listener
+
+restart-listener: ## Restart the Telegram listener service (does not rebuild)
+	systemctl --user restart nightshift-listener
+
+status-listener: ## Show listener service status
+	systemctl --user status nightshift-listener
+
+logs-listener: ## Tail live listener logs (Ctrl+C to stop)
+	journalctl --user-unit=nightshift-listener.service -f

--- a/cmd/nightshift/main.go
+++ b/cmd/nightshift/main.go
@@ -3,6 +3,7 @@
 // Subcommands:
 //
 //	nightshift            start the poll loop (default)
+//	nightshift listener   start the inbound Telegram listener
 //	nightshift setup      interactive .env + repos.json wizard
 //	nightshift cleanup    clean up stale branches and worktrees
 //	nightshift cleanup --force
@@ -27,6 +28,7 @@ import (
 	"github.com/ahmadAlMezaal/nightshift/internal/doctor"
 	"github.com/ahmadAlMezaal/nightshift/internal/pipeline"
 	"github.com/ahmadAlMezaal/nightshift/internal/setup"
+	"github.com/ahmadAlMezaal/nightshift/internal/telegram"
 )
 
 // version is the build version. Defaults to a dev marker for `go build`/`go
@@ -72,6 +74,9 @@ func realMain() error {
 	case "", "run":
 		printBanner()
 		return runPoll(scriptDir)
+	case "listener":
+		printBanner()
+		return runListener(scriptDir)
 	case "setup":
 		return runSetup(scriptDir)
 	case "cleanup":
@@ -111,6 +116,7 @@ func printUsage() {
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  run       Start the poll loop (default)")
+	fmt.Println("  listener  Start the inbound Telegram command listener")
 	fmt.Println("  setup     Interactive configuration wizard")
 	fmt.Println("  cleanup   Clean up stale branches and worktrees")
 	fmt.Println("  doctor    Preflight dependency and config checks")
@@ -151,6 +157,24 @@ func runPoll(scriptDir string) error {
 
 	slog.Info("nightshift starting", "version", version)
 	return pipeline.New(cfg).Run(ctx)
+}
+
+func runListener(scriptDir string) error {
+	cfg, err := config.Load(scriptDir)
+	if err != nil {
+		return err
+	}
+	if cfg.TelegramBotToken == "" || cfg.TelegramChatID == "" {
+		return fmt.Errorf("TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set in .env to run the listener")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	slog.Info("nightshift listener starting", "version", version)
+
+	listener := telegram.New(cfg.TelegramBotToken, cfg.TelegramChatID)
+	return listener.Run(ctx)
 }
 
 func runSetup(scriptDir string) error {

--- a/internal/telegram/dispatcher.go
+++ b/internal/telegram/dispatcher.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/ahmadAlMezaal/nightshift/internal/notify"
@@ -35,8 +36,11 @@ func NewDispatcher() *Dispatcher {
 
 // Register adds a command handler. The name should not include the leading
 // slash — it's stripped during dispatch. Registering the same name twice
-// overwrites the previous handler.
+// overwrites the previous handler. Leading slashes and surrounding whitespace
+// are stripped from name for robustness.
 func (d *Dispatcher) Register(name, description string, handler HandlerFunc) {
+	name = strings.TrimSpace(name)
+	name = strings.TrimPrefix(name, "/")
 	d.commands[strings.ToLower(name)] = command{
 		handler:     handler,
 		description: description,
@@ -77,10 +81,19 @@ func (d *Dispatcher) unknownReply(name string) string {
 }
 
 func (d *Dispatcher) helpHandler(_ context.Context, _ string) string {
+	names := make([]string, 0, len(d.commands))
+	for name := range d.commands {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	var b strings.Builder
 	b.WriteString("*Nightshift Commands*\n\n")
-	for name, cmd := range d.commands {
-		b.WriteString(fmt.Sprintf("/%s — %s\n", name, cmd.description))
+	for _, name := range names {
+		cmd := d.commands[name]
+		fmt.Fprintf(&b, "/%s — %s\n",
+			notify.EscapeMarkdown(name),
+			notify.EscapeMarkdown(cmd.description))
 	}
 	return b.String()
 }

--- a/internal/telegram/dispatcher.go
+++ b/internal/telegram/dispatcher.go
@@ -1,0 +1,90 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/notify"
+)
+
+// HandlerFunc processes a command and returns a reply message. An empty reply
+// means no message is sent back.
+type HandlerFunc func(ctx context.Context, args string) string
+
+// Dispatcher routes incoming text messages to registered command handlers.
+type Dispatcher struct {
+	commands map[string]command
+}
+
+type command struct {
+	handler     HandlerFunc
+	description string
+}
+
+// NewDispatcher creates a Dispatcher with the built-in /help and /ping
+// commands pre-registered.
+func NewDispatcher() *Dispatcher {
+	d := &Dispatcher{
+		commands: make(map[string]command),
+	}
+	d.Register("help", "List available commands", d.helpHandler)
+	d.Register("ping", "Check if the listener is alive", pingHandler)
+	return d
+}
+
+// Register adds a command handler. The name should not include the leading
+// slash — it's stripped during dispatch. Registering the same name twice
+// overwrites the previous handler.
+func (d *Dispatcher) Register(name, description string, handler HandlerFunc) {
+	d.commands[strings.ToLower(name)] = command{
+		handler:     handler,
+		description: description,
+	}
+}
+
+// Dispatch parses the message text, extracts the command keyword and args,
+// and routes to the matching handler. Returns the reply text (empty means
+// no reply).
+func (d *Dispatcher) Dispatch(ctx context.Context, text string) string {
+	// Strip leading slash if present (Telegram sends "/status" for commands).
+	text = strings.TrimPrefix(text, "/")
+
+	// Split into command + args.
+	parts := strings.SplitN(text, " ", 2)
+	name := strings.ToLower(parts[0])
+	args := ""
+	if len(parts) > 1 {
+		args = strings.TrimSpace(parts[1])
+	}
+
+	// Strip @botname suffix that Telegram appends in groups (e.g. "/ping@mybot").
+	if i := strings.Index(name, "@"); i > 0 {
+		name = name[:i]
+	}
+
+	cmd, ok := d.commands[name]
+	if !ok {
+		return d.unknownReply(name)
+	}
+	return cmd.handler(ctx, args)
+}
+
+// unknownReply returns a helpful message listing available commands.
+func (d *Dispatcher) unknownReply(name string) string {
+	return fmt.Sprintf("Unknown command: *%s*\n\nType /help to see available commands.",
+		notify.EscapeMarkdown(name))
+}
+
+func (d *Dispatcher) helpHandler(_ context.Context, _ string) string {
+	var b strings.Builder
+	b.WriteString("*Nightshift Commands*\n\n")
+	for name, cmd := range d.commands {
+		b.WriteString(fmt.Sprintf("/%s — %s\n", name, cmd.description))
+	}
+	return b.String()
+}
+
+func pingHandler(_ context.Context, _ string) string {
+	return "pong"
+}

--- a/internal/telegram/dispatcher_test.go
+++ b/internal/telegram/dispatcher_test.go
@@ -1,0 +1,89 @@
+package telegram
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestDispatch_KnownCommand(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Dispatch(context.Background(), "/ping")
+	if reply != "pong" {
+		t.Errorf("Dispatch(/ping) = %q, want %q", reply, "pong")
+	}
+}
+
+func TestDispatch_WithoutSlash(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Dispatch(context.Background(), "ping")
+	if reply != "pong" {
+		t.Errorf("Dispatch(ping) = %q, want %q", reply, "pong")
+	}
+}
+
+func TestDispatch_CaseInsensitive(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Dispatch(context.Background(), "/PING")
+	if reply != "pong" {
+		t.Errorf("Dispatch(/PING) = %q, want %q", reply, "pong")
+	}
+}
+
+func TestDispatch_WithArgs(t *testing.T) {
+	d := NewDispatcher()
+	var gotArgs string
+	d.Register("echo", "echo args", func(_ context.Context, args string) string {
+		gotArgs = args
+		return "ok"
+	})
+
+	reply := d.Dispatch(context.Background(), "/echo hello world")
+	if reply != "ok" {
+		t.Errorf("Dispatch reply = %q, want %q", reply, "ok")
+	}
+	if gotArgs != "hello world" {
+		t.Errorf("handler got args = %q, want %q", gotArgs, "hello world")
+	}
+}
+
+func TestDispatch_UnknownCommand(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Dispatch(context.Background(), "/foobar")
+	if !strings.Contains(reply, "Unknown command") {
+		t.Errorf("expected unknown command reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "foobar") {
+		t.Errorf("reply should mention the command name, got %q", reply)
+	}
+}
+
+func TestDispatch_HelpListsCommands(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Dispatch(context.Background(), "/help")
+	if !strings.Contains(reply, "/ping") {
+		t.Errorf("help should list /ping, got %q", reply)
+	}
+	if !strings.Contains(reply, "/help") {
+		t.Errorf("help should list /help, got %q", reply)
+	}
+}
+
+func TestDispatch_StripsBotMention(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Dispatch(context.Background(), "/ping@mybot")
+	if reply != "pong" {
+		t.Errorf("Dispatch(/ping@mybot) = %q, want %q", reply, "pong")
+	}
+}
+
+func TestDispatch_RegisterOverwrites(t *testing.T) {
+	d := NewDispatcher()
+	d.Register("ping", "custom ping", func(_ context.Context, _ string) string {
+		return "custom"
+	})
+	reply := d.Dispatch(context.Background(), "/ping")
+	if reply != "custom" {
+		t.Errorf("Dispatch(/ping) = %q after overwrite, want %q", reply, "custom")
+	}
+}

--- a/internal/telegram/listener.go
+++ b/internal/telegram/listener.go
@@ -40,10 +40,11 @@ type Listener struct {
 
 // New creates a Listener. The chatID is used for sender authorisation — only
 // messages from this chat are processed; everything else is silently ignored.
+// Leading/trailing whitespace is trimmed from chatID for robustness.
 func New(botToken, chatID string) *Listener {
 	return &Listener{
 		botToken:    botToken,
-		chatID:      chatID,
+		chatID:      strings.TrimSpace(chatID),
 		http:        &http.Client{Timeout: 45 * time.Second},
 		dispatcher:  NewDispatcher(),
 		pollTimeout: 30,

--- a/internal/telegram/listener.go
+++ b/internal/telegram/listener.go
@@ -1,0 +1,261 @@
+// Package telegram implements a long-polling listener for inbound Telegram
+// messages. It authenticates the sender against the configured chat ID,
+// parses commands, and routes them to registered handlers.
+//
+// This is the inbound counterpart to internal/notify (outbound). Both use the
+// same TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID from .env — same bot, now
+// bidirectional. Long-polling via getUpdates is the right fit for a Pi behind
+// a home network: no inbound ports, no tunnel, no TLS to manage.
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Listener long-polls the Telegram Bot API for inbound messages.
+type Listener struct {
+	botToken   string
+	chatID     string
+	http       *http.Client
+	dispatcher *Dispatcher
+
+	// pollTimeout is the long-poll timeout sent to Telegram's getUpdates.
+	// Telegram holds the connection open for this duration, then returns an
+	// empty result if no updates arrived. Separate from the HTTP client
+	// timeout (which must be longer to avoid premature cancellation).
+	pollTimeout int
+
+	// baseURL overrides the Telegram API base for testing. When empty, the
+	// production URL (https://api.telegram.org/bot<token>) is used.
+	baseURL string
+}
+
+// New creates a Listener. The chatID is used for sender authorisation — only
+// messages from this chat are processed; everything else is silently ignored.
+func New(botToken, chatID string) *Listener {
+	return &Listener{
+		botToken:    botToken,
+		chatID:      chatID,
+		http:        &http.Client{Timeout: 45 * time.Second},
+		dispatcher:  NewDispatcher(),
+		pollTimeout: 30,
+	}
+}
+
+// Dispatcher returns the command dispatcher so callers can register handlers.
+func (l *Listener) Dispatcher() *Dispatcher { return l.dispatcher }
+
+// Run blocks, polling Telegram for updates until ctx is cancelled. It
+// tracks the update offset so messages are never reprocessed, and retries
+// with exponential backoff on transient errors.
+func (l *Listener) Run(ctx context.Context) error {
+	slog.Info("telegram listener starting", "chat_id", l.chatID)
+
+	offset := 0
+	backoff := time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("telegram listener shutting down")
+			return nil
+		default:
+		}
+
+		updates, err := l.getUpdates(ctx, offset)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			slog.Warn("telegram getUpdates failed, retrying",
+				"err", err, "backoff", backoff)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(backoff):
+			}
+			backoff = nextBackoff(backoff)
+			continue
+		}
+
+		// Reset backoff on success.
+		backoff = time.Second
+
+		for _, u := range updates {
+			// Advance offset past this update so Telegram doesn't resend it.
+			if u.UpdateID >= offset {
+				offset = u.UpdateID + 1
+			}
+
+			l.handleUpdate(ctx, u)
+		}
+	}
+}
+
+// handleUpdate processes a single update. Unauthorised senders are silently
+// ignored. Recognised commands are dispatched; unknown ones get a helpful reply.
+func (l *Listener) handleUpdate(ctx context.Context, u Update) {
+	if u.Message == nil {
+		return
+	}
+	msg := u.Message
+
+	// Sender authorisation: hard-lock to the configured chat ID.
+	senderChatID := fmt.Sprintf("%d", msg.Chat.ID)
+	if senderChatID != l.chatID {
+		slog.Debug("ignoring message from unauthorised chat",
+			"chat_id", senderChatID)
+		return
+	}
+
+	text := strings.TrimSpace(msg.Text)
+	if text == "" {
+		return
+	}
+
+	sender := ""
+	if msg.From != nil {
+		sender = msg.From.Username
+	}
+	slog.Info("received message", "from", sender, "text", text)
+
+	reply := l.dispatcher.Dispatch(ctx, text)
+	if reply != "" {
+		l.sendReply(ctx, reply)
+	}
+}
+
+// sendReply sends a Markdown-formatted reply to the configured chat. Best-
+// effort — errors are logged but don't interrupt the poll loop.
+func (l *Listener) sendReply(ctx context.Context, text string) {
+	base := l.apiBase()
+	endpoint := base + "/sendMessage"
+
+	form := url.Values{
+		"chat_id":    {l.chatID},
+		"text":       {text},
+		"parse_mode": {"Markdown"},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		slog.Warn("failed to build reply request", "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := l.http.Do(req)
+	if err != nil {
+		slog.Warn("failed to send reply", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		slog.Warn("reply returned error", "status", resp.StatusCode, "body", string(body))
+	}
+}
+
+// apiBase returns the Bot API base URL, using the test override if set.
+func (l *Listener) apiBase() string {
+	if l.baseURL != "" {
+		return l.baseURL
+	}
+	return "https://api.telegram.org/bot" + l.botToken
+}
+
+// getUpdates calls the Telegram Bot API getUpdates endpoint with long-polling.
+func (l *Listener) getUpdates(ctx context.Context, offset int) ([]Update, error) {
+	endpoint := fmt.Sprintf("%s/getUpdates?offset=%d&timeout=%d",
+		l.apiBase(), offset, l.pollTimeout)
+	return l.fetchUpdates(ctx, endpoint)
+}
+
+// fetchUpdates does the actual HTTP GET and JSON decode.
+func (l *Listener) fetchUpdates(ctx context.Context, endpoint string) ([]Update, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := l.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("telegram returned %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result apiResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if !result.OK {
+		return nil, fmt.Errorf("telegram API error: %s", string(body))
+	}
+
+	return result.Result, nil
+}
+
+// nextBackoff doubles the backoff duration, capping at 60 seconds.
+func nextBackoff(d time.Duration) time.Duration {
+	d *= 2
+	if d > 60*time.Second {
+		d = 60 * time.Second
+	}
+	return d
+}
+
+// --- Telegram Bot API types ------------------------------------------------
+
+// apiResponse is the top-level envelope from getUpdates.
+type apiResponse struct {
+	OK     bool     `json:"ok"`
+	Result []Update `json:"result"`
+}
+
+// Update is a single update from the Telegram Bot API.
+type Update struct {
+	UpdateID int      `json:"update_id"`
+	Message  *Message `json:"message,omitempty"`
+}
+
+// Message is a Telegram message.
+type Message struct {
+	MessageID int    `json:"message_id"`
+	From      *User  `json:"from,omitempty"`
+	Chat      Chat   `json:"chat"`
+	Text      string `json:"text"`
+	Date      int    `json:"date"`
+}
+
+// User is a Telegram user.
+type User struct {
+	ID        int64  `json:"id"`
+	IsBot     bool   `json:"is_bot"`
+	FirstName string `json:"first_name"`
+	Username  string `json:"username"`
+}
+
+// Chat is a Telegram chat.
+type Chat struct {
+	ID   int64  `json:"id"`
+	Type string `json:"type"`
+}

--- a/internal/telegram/listener_test.go
+++ b/internal/telegram/listener_test.go
@@ -110,7 +110,7 @@ func TestListener_GetUpdatesParses(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -134,10 +134,13 @@ func TestListener_RunProcessesAndStops(t *testing.T) {
 	callCount := 0
 	var mu sync.Mutex
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/sendMessage") {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 			return
 		}
 		if !strings.Contains(r.URL.Path, "/getUpdates") {
@@ -161,19 +164,19 @@ func TestListener_RunProcessesAndStops(t *testing.T) {
 					From: &User{Username: "user"},
 				}},
 			}
+		} else {
+			// First update processed; cancel to stop the loop promptly.
+			cancel()
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
 	l := New("tok", "42")
 	l.pollTimeout = 0
 	l.baseURL = srv.URL + "/botTOK"
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
 
 	err := l.Run(ctx)
 	if err != nil {

--- a/internal/telegram/listener_test.go
+++ b/internal/telegram/listener_test.go
@@ -1,0 +1,206 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestListener_AuthRejectsWrongChat(t *testing.T) {
+	l := New("tok", "12345")
+	var dispatched bool
+	l.dispatcher.Register("test", "test", func(_ context.Context, _ string) string {
+		dispatched = true
+		return ""
+	})
+
+	u := Update{
+		UpdateID: 1,
+		Message: &Message{
+			Text: "/test",
+			Chat: Chat{ID: 99999}, // wrong chat ID
+			From: &User{Username: "attacker"},
+		},
+	}
+
+	l.handleUpdate(context.Background(), u)
+	if dispatched {
+		t.Error("handler should not be called for unauthorised chat")
+	}
+}
+
+func TestListener_AuthAcceptsCorrectChat(t *testing.T) {
+	l := New("tok", "12345")
+	var dispatched bool
+	l.dispatcher.Register("test", "test", func(_ context.Context, _ string) string {
+		dispatched = true
+		return ""
+	})
+
+	u := Update{
+		UpdateID: 1,
+		Message: &Message{
+			Text: "/test",
+			Chat: Chat{ID: 12345},
+			From: &User{Username: "owner"},
+		},
+	}
+
+	l.handleUpdate(context.Background(), u)
+	if !dispatched {
+		t.Error("handler should be called for authorised chat")
+	}
+}
+
+func TestListener_IgnoresEmptyText(t *testing.T) {
+	l := New("tok", "12345")
+	var dispatched bool
+	l.dispatcher.Register("test", "test", func(_ context.Context, _ string) string {
+		dispatched = true
+		return ""
+	})
+
+	u := Update{
+		UpdateID: 1,
+		Message: &Message{
+			Text: "   ",
+			Chat: Chat{ID: 12345},
+			From: &User{Username: "owner"},
+		},
+	}
+
+	l.handleUpdate(context.Background(), u)
+	if dispatched {
+		t.Error("handler should not be called for empty text")
+	}
+}
+
+func TestListener_IgnoresNilMessage(t *testing.T) {
+	l := New("tok", "12345")
+	// Should not panic.
+	l.handleUpdate(context.Background(), Update{UpdateID: 1, Message: nil})
+}
+
+func TestListener_GetUpdatesParses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/getUpdates") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		resp := apiResponse{
+			OK: true,
+			Result: []Update{
+				{UpdateID: 100, Message: &Message{
+					Text: "/ping",
+					Chat: Chat{ID: 42},
+					From: &User{Username: "user"},
+				}},
+				{UpdateID: 101, Message: &Message{
+					Text: "/help",
+					Chat: Chat{ID: 42},
+					From: &User{Username: "user"},
+				}},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	l := New("tok", "42")
+	l.pollTimeout = 0
+	l.baseURL = srv.URL + "/botTOK"
+
+	updates, err := l.getUpdates(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("getUpdates: %v", err)
+	}
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+	if updates[0].UpdateID != 100 || updates[1].UpdateID != 101 {
+		t.Errorf("unexpected update IDs: %d, %d", updates[0].UpdateID, updates[1].UpdateID)
+	}
+}
+
+func TestListener_RunProcessesAndStops(t *testing.T) {
+	callCount := 0
+	var mu sync.Mutex
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/sendMessage") {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+			return
+		}
+		if !strings.Contains(r.URL.Path, "/getUpdates") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		mu.Lock()
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		var resp apiResponse
+		resp.OK = true
+
+		if call == 1 {
+			resp.Result = []Update{
+				{UpdateID: 1, Message: &Message{
+					Text: "/ping",
+					Chat: Chat{ID: 42},
+					From: &User{Username: "user"},
+				}},
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	l := New("tok", "42")
+	l.pollTimeout = 0
+	l.baseURL = srv.URL + "/botTOK"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := l.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if callCount < 1 {
+		t.Error("expected at least one getUpdates call")
+	}
+}
+
+func TestNextBackoff(t *testing.T) {
+	cases := []struct {
+		in, want time.Duration
+	}{
+		{time.Second, 2 * time.Second},
+		{2 * time.Second, 4 * time.Second},
+		{30 * time.Second, 60 * time.Second},
+		{60 * time.Second, 60 * time.Second},  // cap
+		{120 * time.Second, 60 * time.Second}, // over cap
+	}
+	for _, c := range cases {
+		got := nextBackoff(c.in)
+		if got != c.want {
+			t.Errorf("nextBackoff(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/nightshift-listener.service
+++ b/nightshift-listener.service
@@ -1,0 +1,30 @@
+# Nightshift Telegram Listener — systemd user service
+#
+# Install:
+#   cp nightshift-listener.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now nightshift-listener
+#
+# Logs:
+#   journalctl --user-unit=nightshift-listener.service -f
+#
+# This service runs alongside the main nightshift.service. Both use the
+# same binary — this one invokes the "listener" subcommand.
+
+[Unit]
+Description=Nightshift Telegram Listener
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/nightshift/nightshift listener
+Restart=always
+RestartSec=10
+
+# Limit restart burst so a bad token doesn't hammer Telegram.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## ENG-168: Inbound Telegram listener — two-way control channel for Nightshift

**Linear:** https://linear.app/amazz/issue/ENG-168/inbound-telegram-listener-two-way-control-channel-for-nightshift

## What was implemented


- **`internal/telegram/dispatcher.go`** — Command parser/dispatcher skeleton:
  - Strips leading `/` and `@botname` suffixes
  - Case-insensitive command matching
  - Splits command from args (`/cmd arg1 arg2`)
  - Two built-in commands: `/help` (lists all commands) and `/ping` (liveness check → "pong")
  - Unknown commands get a helpful reply pointing to `/help`
  - `Register()` method for adding handlers (used by the separate command implementations ticket)

- **`internal/telegram/listener_test.go`** — Tests for:
  - Auth rejects wrong chat ID
  - Auth accepts correct chat ID
  - Ignores empty text and nil messages
  - `getUpdates` parsing via test HTTP server
  - Full `Run` loop processes and stops cleanly
  - Backoff capping logic

- **`internal/telegram/dispatcher_test.go`** — Tests for:
  - Known/unknown command dispatch
  - With/without leading slash
  - Case insensitivity
  - Args parsing
  - `@botname` stripping
  - Handler overwrite
  - Help output

- **`nightshift-listener.service`** — systemd user service template with restart policies

### Modified files

- **`cmd/nightshift/main.go`** — Added `listener` subcommand with `runListener()` that loads config, validates Telegram credentials, and starts the listener
- **`Makefile`** — Added `listener`, `start-listener`, `stop-listener`, `restart-listener`, `status-listener`, `logs-listener` targets
- **`CLAUDE.md`** — Updated package map with `internal/telegram` entry and `listener` subcommand

### Key decisions

- **Separate package** (`internal/telegram`) rather than adding to `internal/notify` — notify is outbound/fire-and-forget; the listener is a long-running inbound service with different concerns
- **No `notify.Telegram` dependency for replies** — the listener handles its own `sendMessage` calls so `baseURL` overriding works consistently for both reads and writes (testability)
- **`config.Load` without `Validate()`** — the listener doesn't need Linear, repos, or CLIs, just `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`; explicit check is simpler than adding a separate validation path
- **Reuses existing `.env` config** — same `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`, no new env vars needed

---

*Implemented by [Nightshift](https://github.com/ahmadAlMezaal/nightshift) 🌙 using Claude Code*