### PR TITLE
ENG-184: Telegram notification when a PR iteration finishes

### DIFF
--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -288,8 +288,14 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			return
 		}
 		logger.Info("pushed follow-up commit", "branch", wt.Branch)
+		// Completion heads-up (always — mirrors the 🔄 start ping and the
+		// ✅ "PR ready" ping the main ticket flow sends on success).
+		p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — pushed follow-up to PR #%d (%s)",
+			identifier, ch.PR.Number, engagementSummary(ch)))
 	} else {
 		logger.Info("iteration produced no diff — feedback addressed without code edits, or Claude chose not to act")
+		p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — reviewed PR #%d, no code changes needed",
+			identifier, ch.PR.Number))
 	}
 
 	p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ahmadAlMezaal/nightshift/internal/agent"
 	"github.com/ahmadAlMezaal/nightshift/internal/github"
+	"github.com/ahmadAlMezaal/nightshift/internal/notify"
 	"github.com/ahmadAlMezaal/nightshift/internal/repo"
 	"github.com/ahmadAlMezaal/nightshift/internal/state"
 	"github.com/ahmadAlMezaal/nightshift/internal/watch"
@@ -125,7 +126,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	logger.Info("re-engaging on PR", "events", len(ch.Events), "ci_failed", ch.CIFailure != nil)
 
 	// Heads-up Telegram (always — not gated by TELEGRAM_VERBOSE).
-	p.telegram.Send(ctx, fmt.Sprintf("🔄 *%s* — %s on PR #%d", identifier, engagementSummary(ch), ch.PR.Number))
+	p.telegram.Send(ctx, fmt.Sprintf("🔄 *%s* — %s on PR #%d", notify.EscapeMarkdown(identifier), engagementSummary(ch), ch.PR.Number))
 
 	// On every failure path below we record the iteration before returning.
 	// Otherwise the cursor never advances and the next poll re-discovers the
@@ -291,11 +292,11 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		// Completion heads-up (always — mirrors the 🔄 start ping and the
 		// ✅ "PR ready" ping the main ticket flow sends on success).
 		p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — pushed follow-up to PR #%d (%s)",
-			identifier, ch.PR.Number, engagementSummary(ch)))
+			notify.EscapeMarkdown(identifier), ch.PR.Number, engagementSummary(ch)))
 	} else {
 		logger.Info("iteration produced no diff — feedback addressed without code edits, or Claude chose not to act")
 		p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — reviewed PR #%d, no code changes needed",
-			identifier, ch.PR.Number))
+			notify.EscapeMarkdown(identifier), ch.PR.Number))
 	}
 
 	p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
@@ -328,7 +329,7 @@ func (p *Pipeline) recordIteration(ctx context.Context, ch watch.PRChanges, iden
 	if iterations >= p.cfg.MaxPRIterations {
 		p.telegram.Send(ctx, fmt.Sprintf(
 			"🛑 *%s* — PR #%d hit iteration cap (%d attempts). Needs human attention.",
-			identifier, prNumber, iterations))
+			notify.EscapeMarkdown(identifier), prNumber, iterations))
 		if issueID != "" {
 			_ = p.linear.Comment(ctx, issueID, fmt.Sprintf(
 				"🛑 **Nightshift: PR iteration cap reached** (%d attempts on PR %s).\n\nNeeds a human to take a look — Nightshift won't re-engage on this PR again unless you reset the iteration count in `~/.nightshift-state.json` or close the PR.",


### PR DESCRIPTION
## ENG-184

**Linear:** https://linear.app/amazz/issue/ENG-184/auto-iterate-send-a-telegram-done-notification-after-addressing-pr

## Problem

The auto-iterate flow (`internal/pipeline/iterate.go`) sends a `🔄` Telegram heads-up when it *starts* addressing review feedback / CI, but never notifies when the work is **done**. The only other Telegram message in that flow is the iteration-cap alarm (`🛑`), so on a normal successful re-engagement you get "I'm starting…" then silence — the only success signal is a new commit appearing on the PR.

This is asymmetric with the main ticket flow (`process.go`), which sends a `✅ … PR ready` ping on success.

## Change

Add a completion notification on the two normal exit paths of `iteratePR`:

- **Pushed follow-up commit** → `✅ ENG-X — pushed follow-up to PR #N (addressing review + CI)`
- **No diff produced** → `✅ ENG-X — reviewed PR #N, no code changes needed`

`engagementSummary(ch)` already supplies the `addressing review + CI` / `fixing CI` / `addressing review` suffix. Telegram is fire-and-forget, so there are no signature or state changes.

Out of scope (noted in the ticket): per-error-path Telegram pings for transient failures — those still log and advance the cursor as before.

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- `gofmt -l` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)