### PR TITLE
ENG-169: Nightshift Telegram commands — re-queue blocked ticket, status, kill run

### DIFF
--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -263,6 +263,52 @@ func (c *Client) RemoveLabel(ctx context.Context, issueID, labelID string) error
 	return nil
 }
 
+// AddLabel adds a single label to an issue. It fetches the issue's current
+// labels, appends the target if not already present, and writes the full set
+// back. No-ops if the issue already has the label.
+func (c *Client) AddLabel(ctx context.Context, issueID, labelID string) error {
+	fetchQ := `query($id: String!) {
+	  issue(id: $id) { labels { nodes { id } } }
+	}`
+	var fetchResp struct {
+		Issue struct {
+			Labels struct {
+				Nodes []struct {
+					ID string `json:"id"`
+				} `json:"nodes"`
+			} `json:"labels"`
+		} `json:"issue"`
+	}
+	if err := c.Do(ctx, fetchQ, map[string]any{"id": issueID}, &fetchResp); err != nil {
+		return fmt.Errorf("fetch labels for %s: %w", issueID, err)
+	}
+
+	ids := make([]string, 0, len(fetchResp.Issue.Labels.Nodes)+1)
+	for _, l := range fetchResp.Issue.Labels.Nodes {
+		if l.ID == labelID {
+			return nil // already labelled
+		}
+		ids = append(ids, l.ID)
+	}
+	ids = append(ids, labelID)
+
+	mutation := `mutation($id: String!, $labelIds: [String!]!) {
+	  issueUpdate(id: $id, input: { labelIds: $labelIds }) { success }
+	}`
+	var resp struct {
+		IssueUpdate struct {
+			Success bool `json:"success"`
+		} `json:"issueUpdate"`
+	}
+	if err := c.Do(ctx, mutation, map[string]any{"id": issueID, "labelIds": ids}, &resp); err != nil {
+		return err
+	}
+	if !resp.IssueUpdate.Success {
+		return fmt.Errorf("issueUpdate reported success=false adding label to %s", issueID)
+	}
+	return nil
+}
+
 // Ping verifies the API key works by fetching the authenticated viewer.
 // Returns the viewer's display name on success.
 func (c *Client) Ping(ctx context.Context) (string, error) {

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -227,7 +227,7 @@ func (c *Client) RemoveLabel(ctx context.Context, issueID, labelID string) error
 	  issue(id: $id) { labels { nodes { id } } }
 	}`
 	var fetchResp struct {
-		Issue struct {
+		Issue *struct {
 			Labels struct {
 				Nodes []struct {
 					ID string `json:"id"`
@@ -237,6 +237,9 @@ func (c *Client) RemoveLabel(ctx context.Context, issueID, labelID string) error
 	}
 	if err := c.Do(ctx, fetchQ, map[string]any{"id": issueID}, &fetchResp); err != nil {
 		return fmt.Errorf("fetch labels for %s: %w", issueID, err)
+	}
+	if fetchResp.Issue == nil {
+		return fmt.Errorf("issue %s not found", issueID)
 	}
 
 	var remaining []string
@@ -271,7 +274,7 @@ func (c *Client) AddLabel(ctx context.Context, issueID, labelID string) error {
 	  issue(id: $id) { labels { nodes { id } } }
 	}`
 	var fetchResp struct {
-		Issue struct {
+		Issue *struct {
 			Labels struct {
 				Nodes []struct {
 					ID string `json:"id"`
@@ -281,6 +284,9 @@ func (c *Client) AddLabel(ctx context.Context, issueID, labelID string) error {
 	}
 	if err := c.Do(ctx, fetchQ, map[string]any{"id": issueID}, &fetchResp); err != nil {
 		return fmt.Errorf("fetch labels for %s: %w", issueID, err)
+	}
+	if fetchResp.Issue == nil {
+		return fmt.Errorf("issue %s not found", issueID)
 	}
 
 	ids := make([]string, 0, len(fetchResp.Issue.Labels.Nodes)+1)

--- a/internal/pipeline/commands.go
+++ b/internal/pipeline/commands.go
@@ -1,0 +1,149 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/notify"
+	"github.com/ahmadAlMezaal/nightshift/internal/telegram"
+)
+
+// registerCommands wires the Telegram command handlers that require a running
+// pipeline (status, kill, requeue). Called from Run when Telegram is enabled.
+func (p *Pipeline) registerCommands(d *telegram.Dispatcher) {
+	d.Register("status", "Show active runs and session stats", p.handleStatus)
+	d.Register("kill", "Kill a running ticket (e.g. /kill ENG-42)", p.handleKill)
+	d.Register("requeue", "Re-queue a ticket with context (e.g. /requeue ENG-42 use Auth0)", p.handleRequeue)
+}
+
+// handleStatus replies with a snapshot of in-progress tickets, worker slot
+// usage, and session counters.
+func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
+	p.mu.Lock()
+	active := make([]string, 0, len(p.active))
+	for id := range p.active {
+		active = append(active, id)
+	}
+	succ := p.successCount
+	fail := p.failCount
+	dispatches := p.totalDispatches
+	maxD := p.cfg.MaxDispatches
+	maxC := p.cfg.MaxConcurrent
+	p.mu.Unlock()
+
+	sort.Strings(active)
+	uptime := time.Since(p.sessionStart).Round(time.Second)
+
+	var b strings.Builder
+	b.WriteString("*Nightshift Status*\n\n")
+
+	if len(active) == 0 {
+		fmt.Fprintf(&b, "*Active runs:* 0/%d (idle)\n", maxC)
+	} else {
+		fmt.Fprintf(&b, "*Active runs:* %d/%d\n", len(active), maxC)
+		for _, id := range active {
+			fmt.Fprintf(&b, "• %s\n", notify.EscapeMarkdown(id))
+		}
+	}
+
+	b.WriteString("\n*Session:*\n")
+	fmt.Fprintf(&b, "✅ %d PRs created\n", succ)
+	fmt.Fprintf(&b, "❌ %d failed\n", fail)
+	fmt.Fprintf(&b, "📦 %d/%d dispatches used\n", dispatches, maxD)
+	fmt.Fprintf(&b, "⏱ Uptime: %s\n", uptime)
+	return b.String()
+}
+
+// handleKill terminates the Claude run for a specific ticket.
+func (p *Pipeline) handleKill(_ context.Context, args string) string {
+	if args == "" {
+		return "Usage: /kill <ticket>\n\nExample: /kill ENG-42"
+	}
+	identifier := normalizeIdentifier(strings.Fields(args)[0], p.cfg.LinearTeamKey)
+	if identifier == "" {
+		return "Usage: /kill <ticket>\n\nExample: /kill ENG-42"
+	}
+
+	if err := p.KillRun(identifier); err != nil {
+		return fmt.Sprintf("Could not kill %s: %s",
+			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+	return fmt.Sprintf("🔪 Killed run for %s", notify.EscapeMarkdown(identifier))
+}
+
+// handleRequeue looks up a ticket on Linear, appends the caller's context as
+// a comment, and moves the ticket back to the trigger state/label so the next
+// poll picks it up.
+func (p *Pipeline) handleRequeue(ctx context.Context, args string) string {
+	parts := strings.SplitN(args, " ", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return "Usage: /requeue <ticket> <extra context>\n\nExample: /requeue ENG-42 use the Auth0 provider"
+	}
+
+	identifier := normalizeIdentifier(parts[0], p.cfg.LinearTeamKey)
+	if identifier == "" {
+		return "Usage: /requeue <ticket> <extra context>\n\nExample: /requeue ENG-42 use the Auth0 provider"
+	}
+
+	extraContext := ""
+	if len(parts) > 1 {
+		extraContext = strings.TrimSpace(parts[1])
+	}
+
+	// Look up the issue on Linear.
+	issue, err := p.linear.GetIssueByIdentifier(ctx, identifier)
+	if err != nil {
+		return fmt.Sprintf("Could not find ticket %s: %s",
+			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+
+	// Post the user's context as a comment.
+	if extraContext != "" {
+		comment := fmt.Sprintf("💬 **Requeued via Telegram**\n\n%s", extraContext)
+		if err := p.linear.Comment(ctx, issue.ID, comment); err != nil {
+			return fmt.Sprintf("Found %s but failed to post comment: %s",
+				notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+		}
+	}
+
+	// Move to trigger state/label so the next poll picks it up.
+	if p.cfg.TriggerMode == "label" && p.labelID != "" {
+		if err := p.linear.AddLabel(ctx, issue.ID, p.labelID); err != nil {
+			return fmt.Sprintf("Commented on %s but failed to add trigger label: %s",
+				notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+		}
+	} else if p.states.Trigger != "" {
+		if err := p.linear.SetState(ctx, issue.ID, p.states.Trigger); err != nil {
+			return fmt.Sprintf("Commented on %s but failed to move to trigger state: %s",
+				notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+		}
+	}
+
+	reply := fmt.Sprintf("✅ %s requeued", notify.EscapeMarkdown(identifier))
+	if extraContext != "" {
+		display := extraContext
+		if len(display) > 100 {
+			display = display[:100] + "..."
+		}
+		reply += fmt.Sprintf("\nContext added: %s", notify.EscapeMarkdown(display))
+	}
+	return reply
+}
+
+// normalizeIdentifier converts user input to the standard "ENG-42" format.
+// Accepts: "ENG-42", "eng-42", "42" (just the number — team key is prepended).
+func normalizeIdentifier(input, teamKey string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+	// If it's just a number, prepend the team key.
+	if _, err := strconv.Atoi(input); err == nil {
+		return strings.ToUpper(teamKey) + "-" + input
+	}
+	return strings.ToUpper(input)
+}

--- a/internal/pipeline/commands.go
+++ b/internal/pipeline/commands.go
@@ -60,10 +60,11 @@ func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
 
 // handleKill terminates the Claude run for a specific ticket.
 func (p *Pipeline) handleKill(_ context.Context, args string) string {
-	if args == "" {
+	fields := strings.Fields(args)
+	if len(fields) == 0 {
 		return "Usage: /kill <ticket>\n\nExample: /kill ENG-42"
 	}
-	identifier := normalizeIdentifier(strings.Fields(args)[0], p.cfg.LinearTeamKey)
+	identifier := normalizeIdentifier(fields[0], p.cfg.LinearTeamKey)
 	if identifier == "" {
 		return "Usage: /kill <ticket>\n\nExample: /kill ENG-42"
 	}

--- a/internal/pipeline/commands_test.go
+++ b/internal/pipeline/commands_test.go
@@ -1,0 +1,419 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/config"
+	"github.com/ahmadAlMezaal/nightshift/internal/linear"
+)
+
+func TestNormalizeIdentifier(t *testing.T) {
+	tests := []struct {
+		input, teamKey, want string
+	}{
+		{"ENG-42", "ENG", "ENG-42"},
+		{"eng-42", "ENG", "ENG-42"},
+		{"42", "ENG", "ENG-42"},
+		{"  ENG-42 ", "ENG", "ENG-42"},
+		{"42", "PROJ", "PROJ-42"},
+		{"proj-7", "PROJ", "PROJ-7"},
+		{"", "ENG", ""},
+		{"  ", "ENG", ""},
+	}
+	for _, tt := range tests {
+		got := normalizeIdentifier(tt.input, tt.teamKey)
+		if got != tt.want {
+			t.Errorf("normalizeIdentifier(%q, %q) = %q, want %q",
+				tt.input, tt.teamKey, got, tt.want)
+		}
+	}
+}
+
+func TestHandleStatus_Idle(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{
+			MaxConcurrent: 3,
+			MaxDispatches: 10,
+		},
+		active:       map[string]struct{}{},
+		sessionStart: time.Now().Add(-5 * time.Minute),
+	}
+	reply := p.handleStatus(context.Background(), "")
+	if !strings.Contains(reply, "0/3") {
+		t.Errorf("expected 0/3 in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "idle") {
+		t.Errorf("expected 'idle' in reply, got %q", reply)
+	}
+}
+
+func TestHandleStatus_Active(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{
+			MaxConcurrent: 3,
+			MaxDispatches: 10,
+		},
+		active: map[string]struct{}{
+			"ENG-42": {},
+			"ENG-44": {},
+		},
+		successCount:    2,
+		failCount:       1,
+		totalDispatches: 5,
+		sessionStart:    time.Now().Add(-1 * time.Hour),
+	}
+	reply := p.handleStatus(context.Background(), "")
+	if !strings.Contains(reply, "2/3") {
+		t.Errorf("expected 2/3 in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "ENG-42") {
+		t.Errorf("expected ENG-42 in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "ENG-44") {
+		t.Errorf("expected ENG-44 in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "2 PRs created") {
+		t.Errorf("expected success count in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "1 failed") {
+		t.Errorf("expected fail count in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "5/10") {
+		t.Errorf("expected dispatch count in reply, got %q", reply)
+	}
+}
+
+func TestHandleKill_NoArgs(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{LinearTeamKey: "ENG"},
+	}
+	reply := p.handleKill(context.Background(), "")
+	if !strings.Contains(reply, "Usage") {
+		t.Errorf("expected usage in reply, got %q", reply)
+	}
+}
+
+func TestHandleKill_NotActive(t *testing.T) {
+	p := &Pipeline{
+		cfg:     &config.Config{LinearTeamKey: "ENG"},
+		active:  map[string]struct{}{},
+		cancels: map[string]context.CancelFunc{},
+		killed:  map[string]struct{}{},
+	}
+	reply := p.handleKill(context.Background(), "ENG-42")
+	if !strings.Contains(reply, "no active run") {
+		t.Errorf("expected 'no active run' in reply, got %q", reply)
+	}
+}
+
+func TestHandleKill_Active(t *testing.T) {
+	ticketCtx, ticketCancel := context.WithCancel(context.Background())
+	defer ticketCancel()
+
+	p := &Pipeline{
+		cfg:     &config.Config{LinearTeamKey: "ENG"},
+		active:  map[string]struct{}{"ENG-42": {}},
+		cancels: map[string]context.CancelFunc{"ENG-42": ticketCancel},
+		killed:  map[string]struct{}{},
+	}
+	reply := p.handleKill(context.Background(), "ENG-42")
+	if !strings.Contains(reply, "Killed") {
+		t.Errorf("expected 'Killed' in reply, got %q", reply)
+	}
+	// Verify the context was cancelled.
+	select {
+	case <-ticketCtx.Done():
+		// expected
+	default:
+		t.Error("expected ticket context to be cancelled after kill")
+	}
+}
+
+func TestHandleKill_CaseInsensitive(t *testing.T) {
+	_, ticketCancel := context.WithCancel(context.Background())
+	defer ticketCancel()
+
+	p := &Pipeline{
+		cfg:     &config.Config{LinearTeamKey: "ENG"},
+		active:  map[string]struct{}{"ENG-42": {}},
+		cancels: map[string]context.CancelFunc{"ENG-42": ticketCancel},
+		killed:  map[string]struct{}{},
+	}
+	reply := p.handleKill(context.Background(), "eng-42")
+	if !strings.Contains(reply, "Killed") {
+		t.Errorf("expected 'Killed' in reply for case-insensitive input, got %q", reply)
+	}
+}
+
+func TestHandleKill_NumberOnly(t *testing.T) {
+	_, ticketCancel := context.WithCancel(context.Background())
+	defer ticketCancel()
+
+	p := &Pipeline{
+		cfg:     &config.Config{LinearTeamKey: "ENG"},
+		active:  map[string]struct{}{"ENG-42": {}},
+		cancels: map[string]context.CancelFunc{"ENG-42": ticketCancel},
+		killed:  map[string]struct{}{},
+	}
+	reply := p.handleKill(context.Background(), "42")
+	if !strings.Contains(reply, "Killed") {
+		t.Errorf("expected 'Killed' for number-only input, got %q", reply)
+	}
+}
+
+func TestHandleRequeue_NoArgs(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{LinearTeamKey: "ENG"},
+	}
+	reply := p.handleRequeue(context.Background(), "")
+	if !strings.Contains(reply, "Usage") {
+		t.Errorf("expected usage in reply, got %q", reply)
+	}
+}
+
+func TestHandleRequeue_TicketNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"issue": nil},
+		})
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg:    &config.Config{LinearTeamKey: "ENG"},
+		linear: client,
+	}
+	reply := p.handleRequeue(context.Background(), "ENG-99")
+	if !strings.Contains(reply, "Could not find") {
+		t.Errorf("expected 'Could not find' in reply, got %q", reply)
+	}
+}
+
+func TestHandleRequeue_StateMode(t *testing.T) {
+	var commented, stateChanged bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "issue(id:"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"id":         "uuid-42",
+						"identifier": "ENG-42",
+						"title":      "Fix login",
+						"url":        "https://linear.app/eng/issue/ENG-42",
+					},
+				},
+			})
+		case strings.Contains(req.Query, "commentCreate"):
+			commented = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"commentCreate": map[string]any{"success": true},
+				},
+			})
+		case strings.Contains(req.Query, "issueUpdate"):
+			stateChanged = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issueUpdate": map[string]any{"success": true},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			LinearTeamKey: "ENG",
+			TriggerMode:   "state",
+		},
+		linear: client,
+		states: linear.StateIDs{Trigger: "state-trigger-id"},
+	}
+
+	reply := p.handleRequeue(context.Background(), "ENG-42 use Auth0 instead of Cognito")
+	if !strings.Contains(reply, "requeued") {
+		t.Errorf("expected 'requeued' in reply, got %q", reply)
+	}
+	if !commented {
+		t.Error("expected a comment to be posted on Linear")
+	}
+	if !stateChanged {
+		t.Error("expected state to be changed on Linear")
+	}
+	if !strings.Contains(reply, "Auth0") {
+		t.Errorf("expected context snippet in reply, got %q", reply)
+	}
+}
+
+func TestHandleRequeue_LabelMode(t *testing.T) {
+	var addedLabel bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "issue(id:") && strings.Contains(req.Query, "labels"):
+			// AddLabel: fetch current labels
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"labels": map[string]any{
+							"nodes": []map[string]any{},
+						},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "issue(id:"):
+			// GetIssueByIdentifier
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"id":         "uuid-42",
+						"identifier": "ENG-42",
+						"title":      "Fix login",
+						"url":        "https://linear.app/eng/issue/ENG-42",
+					},
+				},
+			})
+		case strings.Contains(req.Query, "commentCreate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"commentCreate": map[string]any{"success": true},
+				},
+			})
+		case strings.Contains(req.Query, "issueUpdate"):
+			addedLabel = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issueUpdate": map[string]any{"success": true},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			LinearTeamKey: "ENG",
+			TriggerMode:   "label",
+			TriggerLabel:  "nightshift",
+		},
+		linear:  client,
+		labelID: "label-id-123",
+	}
+
+	reply := p.handleRequeue(context.Background(), "42 fix auth")
+	if !strings.Contains(reply, "requeued") {
+		t.Errorf("expected 'requeued' in reply, got %q", reply)
+	}
+	if !addedLabel {
+		t.Error("expected trigger label to be added in label mode")
+	}
+}
+
+func TestHandleRequeue_NoContext(t *testing.T) {
+	var commented bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "issue(id:"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"id":         "uuid-42",
+						"identifier": "ENG-42",
+						"title":      "Fix login",
+						"url":        "https://linear.app/eng/issue/ENG-42",
+					},
+				},
+			})
+		case strings.Contains(req.Query, "commentCreate"):
+			commented = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"commentCreate": map[string]any{"success": true},
+				},
+			})
+		case strings.Contains(req.Query, "issueUpdate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issueUpdate": map[string]any{"success": true},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			LinearTeamKey: "ENG",
+			TriggerMode:   "state",
+		},
+		linear: client,
+		states: linear.StateIDs{Trigger: "state-trigger-id"},
+	}
+
+	// Requeue without extra context — should skip comment.
+	reply := p.handleRequeue(context.Background(), "ENG-42")
+	if !strings.Contains(reply, "requeued") {
+		t.Errorf("expected 'requeued' in reply, got %q", reply)
+	}
+	if commented {
+		t.Error("expected no comment when no extra context is given")
+	}
+	if strings.Contains(reply, "Context added") {
+		t.Errorf("reply should not mention context when none given, got %q", reply)
+	}
+}
+
+func TestHandleStatus_UptimeFormat(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{
+			MaxConcurrent: 5,
+			MaxDispatches: 20,
+		},
+		active:       map[string]struct{}{},
+		sessionStart: time.Now().Add(-2*time.Hour - 30*time.Minute),
+	}
+	reply := p.handleStatus(context.Background(), "")
+	if !strings.Contains(reply, "Uptime") {
+		t.Errorf("expected uptime in reply, got %q", reply)
+	}
+}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -133,7 +133,9 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 			// advanced.
 			continue
 		}
+		ticketCtx, ticketCancel := context.WithCancel(ctx)
 		p.active[identifier] = struct{}{}
+		p.cancels[identifier] = ticketCancel
 		p.mu.Unlock()
 
 		slog.Info("pr poll detail",
@@ -147,7 +149,7 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 		go func(ch watch.PRChanges, id string) {
 			defer wg.Done()
 			defer p.markDone(id)
-			p.iteratePR(ctx, ch, id)
+			p.iteratePR(ticketCtx, ch, id)
 		}(ch, identifier)
 	}
 }
@@ -270,6 +272,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		Timeout:       p.cfg.AgentTimeout,
 		UseAgentTeams: p.cfg.UseAgentTeams,
 	})
+
+	// Killed via /kill — skip all error handling and let the defer clean up.
+	if p.isKilled(identifier) {
+		logger.Info("run killed by user")
+		return
+	}
 
 	// Don't increment iteration count on infrastructure-level failures
 	// (timeout / rate-limit) — those weren't really attempts on the feedback.

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -279,6 +279,14 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		return
 	}
 
+	// Context cancelled (graceful shutdown) — don't treat the cancellation as a
+	// real iteration: recording it would bump the PR's iteration count (and could
+	// fire the cap warning) on the way down. Mirrors the same guard in process().
+	if ctx.Err() != nil {
+		logger.Info("iteration cancelled (shutdown)", "reason", ctx.Err())
+		return
+	}
+
 	// Don't increment iteration count on infrastructure-level failures
 	// (timeout / rate-limit) — those weren't really attempts on the feedback.
 	if errors.Is(runErr, agent.ErrTimedOut) {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ahmadAlMezaal/nightshift/internal/repo"
 	"github.com/ahmadAlMezaal/nightshift/internal/review"
 	"github.com/ahmadAlMezaal/nightshift/internal/state"
+	"github.com/ahmadAlMezaal/nightshift/internal/telegram"
 	"github.com/ahmadAlMezaal/nightshift/internal/watch"
 )
 
@@ -41,9 +42,11 @@ type Pipeline struct {
 	sessionStart time.Time
 
 	mu                sync.Mutex
-	active            map[string]struct{} // identifiers in-flight
-	failedAttempts    map[string]int      // per-ticket retry counter
-	skipped           map[string]struct{} // non-transient failures — never re-dispatched
+	active            map[string]struct{}          // identifiers in-flight
+	cancels           map[string]context.CancelFunc // per-ticket cancel (for /kill)
+	killed            map[string]struct{}          // tickets killed via /kill
+	failedAttempts    map[string]int               // per-ticket retry counter
+	skipped           map[string]struct{}          // non-transient failures — never re-dispatched
 	totalDispatches   int
 	successCount      int
 	failCount         int
@@ -59,6 +62,8 @@ func New(cfg *config.Config) *Pipeline {
 		telegram:       notify.New(cfg.TelegramEnabled, cfg.TelegramBotToken, cfg.TelegramChatID),
 		review:         review.New(cfg.GeminiAPIKey, cfg.GeminiModel),
 		active:         map[string]struct{}{},
+		cancels:        map[string]context.CancelFunc{},
+		killed:         map[string]struct{}{},
 		failedAttempts: map[string]int{},
 		skipped:        map[string]struct{}{},
 		sessionStart:   time.Now(),
@@ -138,6 +143,22 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	}
 
 	var wg sync.WaitGroup
+
+	// Start the Telegram command listener alongside the poll loop if configured.
+	// The listener shares the WaitGroup so shutdown drains it like any other goroutine.
+	if p.cfg.TelegramEnabled && p.cfg.TelegramBotToken != "" && p.cfg.TelegramChatID != "" {
+		listener := telegram.New(p.cfg.TelegramBotToken, p.cfg.TelegramChatID)
+		p.registerCommands(listener.Dispatcher())
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := listener.Run(ctx); err != nil {
+				slog.Warn("telegram listener stopped", "err", err)
+			}
+		}()
+		slog.Info("telegram command listener started")
+	}
+
 	ticker := time.NewTicker(p.cfg.PollInterval)
 	defer ticker.Stop()
 
@@ -252,7 +273,9 @@ func (p *Pipeline) pollOnce(ctx context.Context, wg *sync.WaitGroup) {
 			slog.Debug("skipping (non-transient failure)", "id", issue.Identifier)
 			continue
 		}
+		ticketCtx, ticketCancel := context.WithCancel(ctx)
 		p.active[issue.Identifier] = struct{}{}
+		p.cancels[issue.Identifier] = ticketCancel
 		p.totalDispatches++
 		p.mu.Unlock()
 
@@ -264,7 +287,7 @@ func (p *Pipeline) pollOnce(ctx context.Context, wg *sync.WaitGroup) {
 		go func(iss linear.Issue) {
 			defer wg.Done()
 			defer p.markDone(iss.Identifier)
-			p.process(ctx, iss)
+			p.process(ticketCtx, iss)
 		}(issue)
 	}
 }
@@ -273,6 +296,38 @@ func (p *Pipeline) markDone(id string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	delete(p.active, id)
+	if cancel, ok := p.cancels[id]; ok {
+		cancel() // release context resources
+		delete(p.cancels, id)
+	}
+	delete(p.killed, id)
+}
+
+// isKilled reports whether a ticket was terminated via /kill. Used to skip
+// normal error handling (bump-failed, linearBackToTrigger) when the user
+// intentionally stopped a run.
+func (p *Pipeline) isKilled(id string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, ok := p.killed[id]
+	return ok
+}
+
+// KillRun cancels the context for an in-flight ticket, terminating any
+// running Claude process. The goroutine handles worktree cleanup on return.
+func (p *Pipeline) KillRun(identifier string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cancel, ok := p.cancels[identifier]
+	if !ok {
+		if _, active := p.active[identifier]; active {
+			return fmt.Errorf("%s is active but has no cancel handle", identifier)
+		}
+		return fmt.Errorf("no active run for %s", identifier)
+	}
+	p.killed[identifier] = struct{}{}
+	cancel()
+	return nil
 }
 
 func (p *Pipeline) bumpFailed(id string) int {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -42,11 +42,11 @@ type Pipeline struct {
 	sessionStart time.Time
 
 	mu                sync.Mutex
-	active            map[string]struct{}          // identifiers in-flight
+	active            map[string]struct{}           // identifiers in-flight
 	cancels           map[string]context.CancelFunc // per-ticket cancel (for /kill)
-	killed            map[string]struct{}          // tickets killed via /kill
-	failedAttempts    map[string]int               // per-ticket retry counter
-	skipped           map[string]struct{}          // non-transient failures — never re-dispatched
+	killed            map[string]struct{}           // tickets killed via /kill
+	failedAttempts    map[string]int                // per-ticket retry counter
+	skipped           map[string]struct{}           // non-transient failures — never re-dispatched
 	totalDispatches   int
 	successCount      int
 	failCount         int

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -107,6 +107,13 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 		UseAgentTeams: p.cfg.UseAgentTeams,
 	})
 
+	// ── Killed via /kill ────────────────────────────────────────────────────
+	if p.isKilled(id) {
+		logger.Info("run killed by user")
+		repo.CleanupWorktree(context.Background(), resolved.Path, p.cfg.WorktreeBase, id)
+		return
+	}
+
 	// ── Timeout ──────────────────────────────────────────────────────────────
 	if errors.Is(runErr, agent.ErrTimedOut) {
 		logger.Warn("timed out", "timeout", p.cfg.AgentTimeout)

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -114,6 +114,13 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 		return
 	}
 
+	// ── Context cancelled (graceful shutdown) ────────────────────────────────
+	if ctx.Err() != nil {
+		logger.Info("run cancelled (shutdown)", "reason", ctx.Err())
+		repo.CleanupWorktree(context.Background(), resolved.Path, p.cfg.WorktreeBase, id)
+		return
+	}
+
 	// ── Timeout ──────────────────────────────────────────────────────────────
 	if errors.Is(runErr, agent.ErrTimedOut) {
 		logger.Warn("timed out", "timeout", p.cfg.AgentTimeout)


### PR DESCRIPTION
## ENG-169: Nightshift Telegram commands — re-queue blocked ticket, status, kill run

**Linear:** https://linear.app/amazz/issue/ENG-169/nightshift-telegram-commands-re-queue-blocked-ticket-status-kill-run

## What was implemented

All tests pass, `go vet` is clean, build compiles. Here's a summary of what was implemented:

## Summary

### New files
- **`internal/pipeline/commands.go`** — Three Telegram command handlers registered on the pipeline's dispatcher:
  - `/requeue <ticket> <context>` — Looks up the ticket on Linear, posts the user's context as a comment, and moves it back to the trigger state (state mode) or re-adds the trigger label (label mode).
  - `/status` — Returns an accurate snapshot: active tickets, worker slots in use vs max, PRs created/failed, dispatches used, and uptime.
  - `/kill <ticket>` — Cancels the per-ticket context (killing the in-flight Claude process), marks the ticket as intentionally killed so it skips error handling (no `bumpFailed`, no `linearBackToTrigger`), and lets the goroutine clean up the worktree.
  - `normalizeIdentifier()` — Tolerates `ENG-42`, `eng-42`, and bare `42` (prepends team key).

- **`internal/pipeline/commands_test.go`** — 14 tests covering identifier normalization, status output (idle/active), kill (no args, not active, active, case-insensitive, number-only), and requeue (no args, ticket not found, state mode, label mode, no context).

### Modified files
- **`internal/pipeline/pipeline.go`** — Added `cancels` (per-ticket `CancelFunc`) and `killed` maps to Pipeline; `markDone()` cleans them up; `isKilled()` and `KillRun()` methods; `Run()` starts a Telegram command listener alongside the poll loop when Telegram is enabled.
- **`internal/pipeline/process.go`** — `pollOnce()` creates per-ticket cancellable contexts stored in `cancels`; `process()` checks `isKilled` after `agent.Run()` and exits cleanly (with `context.Background()` for worktree cleanup) if the run was killed.
- **`internal/pipeline/iterate.go`** — Same per-ticket context pattern for PR re-engagement goroutines; `iteratePR()` checks `isKilled` after `agent.Run()`.
- **`internal/linear/operations.go`** — Added `AddLabel()` (fetch current labels, append if not already present, write back), the counterpart to the existing `RemoveLabel()`.

### Key design decisions
1. **Inline listener**: The Telegram listener starts inside `Pipeline.Run()` (same process, same WaitGroup) rather than requiring a separate `nightshift listener` process. This gives commands direct access to pipeline state without IPC.
2. **Per-ticket cancellation**: Each dispatched goroutine gets its own `context.WithCancel`, stored in a `cancels` map keyed by identifier. `/kill` cancels the context (which SIGKILLs the Claude process via `exec.CommandContext`), and a `killed` set prevents the goroutine from bumping the failed counter or moving the ticket back to trigger.
3. **Label mode requeue**: In label mode, `/requeue` re-adds the trigger label (via the new `AddLabel` method) instead of setting a state, matching how Nightshift discovers tickets in label mode.

---

*Implemented by [Nightshift](https://github.com/ahmadAlMezaal/nightshift) 🌙 using Claude Code*