### PR TITLE
ENG-189: Telegram Linear read commands — /tickets, /ticket, /search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ If a ticket's project has no registry entry, Nightshift falls back to `REPO_PATH
 |---------|---------|
 | `cmd/nightshift` | Entry point + subcommand dispatch (`run` / `setup` / `cleanup` / `doctor` / `version`); startup banner; `--help` |
 | `internal/config` | `.env` parser, `repos.json` loader, validated `Config`, `DefaultConfigDir` (`~/.nightshift/`) |
-| `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `FetchLabeledIssues`, `ResolveLabelID`, `RemoveLabel`, `SetState`, `Comment` |
+| `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `FetchLabeledIssues`, `ResolveLabelID`, `RemoveLabel`, `SetState`, `Comment`; read queries for Telegram — `ProjectIssueCounts`, `ListProjectIssues`, `SearchIssues`, `GetIssueByIdentifier` |
 | `internal/repo` | Project → repo slug + registry; clone-on-demand; worktree create/cleanup; `BranchName`; `CreateWorktree` (from main) + `ResumeWorktree` (pull existing remote branch) |
 | `internal/agent` | Claude Code runner (`exec`) with timeout; implement-prompt builder; `BuildFixPrompt` (review feedback + failing-CI prompt); log_offset parsing |
 | `internal/review` | Optional Gemini second-model review gate |
@@ -61,7 +61,7 @@ If a ticket's project has no registry entry, Nightshift falls back to `REPO_PATH
 | `internal/github` | Thin `gh` CLI wrapper: `ListNightshiftPRs`, `GetPR` (comments + reviews + inline review comments via REST + `statusCheckRollup`), `CheckLogs` (failed-step logs via `gh run view`) |
 | `internal/state` | File-backed PR cursor store (`~/.nightshift-state.json`): per-PR comment/review timestamps + CI head-SHA + iteration count; atomic, mutex-guarded |
 | `internal/watch` | Side-effect-free classifier: diffs a PR's feedback + CI status against the cursor, applies trusted-reviewer rules, emits actionable events + `CIFailure` |
-| `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle (`process.go`); PR-watch loop + per-PR re-engagement (`iterate.go`) |
+| `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle (`process.go`); PR-watch loop + per-PR re-engagement (`iterate.go`); Telegram command handlers — `/status`, `/tickets`, `/ticket`, `/search`, `/kill`, `/requeue` (`commands.go`) |
 | `internal/setup` | Interactive setup wizard (`./nightshift setup`) |
 | `internal/cleanup` | Cleanup subcommand: branches, worktrees, old logs |
 | `internal/doctor` | Preflight checks: CLIs on PATH, `gh auth`, Linear API key, repos.json |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ If a ticket's project has no registry entry, Nightshift falls back to `REPO_PATH
 | `internal/github` | Thin `gh` CLI wrapper: `ListNightshiftPRs`, `GetPR` (comments + reviews + inline review comments via REST + `statusCheckRollup`), `CheckLogs` (failed-step logs via `gh run view`) |
 | `internal/state` | File-backed PR cursor store (`~/.nightshift-state.json`): per-PR comment/review timestamps + CI head-SHA + iteration count; atomic, mutex-guarded |
 | `internal/watch` | Side-effect-free classifier: diffs a PR's feedback + CI status against the cursor, applies trusted-reviewer rules, emits actionable events + `CIFailure` |
-| `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle (`process.go`); PR-watch loop + per-PR re-engagement (`iterate.go`); Telegram command handlers — `/status`, `/tickets`, `/ticket`, `/search`, `/kill`, `/requeue` (`commands.go`) |
+| `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle (`process.go`); PR-watch loop + per-PR re-engagement (`iterate.go`); Telegram command handlers — `/status`, `/tickets`, `/ticket`, `/search-tickets` (alias `/find`), `/kill`, `/requeue` (`commands.go`) |
 | `internal/setup` | Interactive setup wizard (`./nightshift setup`) |
 | `internal/cleanup` | Cleanup subcommand: branches, worktrees, old logs |
 | `internal/doctor` | Preflight checks: CLIs on PATH, `gh auth`, Linear API key, repos.json |

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -100,6 +100,276 @@ func TestFetchTriggerIssues_ParsesProject(t *testing.T) {
 	}
 }
 
+func TestProjectIssueCounts_AggregatesAndOrders(t *testing.T) {
+	// Issues arrive in arbitrary state order; the result must be grouped per
+	// state and sorted by board position (Backlog=0 → In Review=3).
+	state := func(name, typ string, pos float64) map[string]any {
+		return map[string]any{"state": map[string]any{"name": name, "type": typ, "position": pos}}
+	}
+	resp := map[string]any{
+		"data": map[string]any{
+			"issues": map[string]any{
+				"nodes": []map[string]any{
+					state("In Review", "started", 3),
+					state("Backlog", "backlog", 0),
+					state("Backlog", "backlog", 0),
+					state("Next", "unstarted", 1),
+					state("In Review", "started", 3),
+					state("Next", "unstarted", 1),
+					state("Next", "unstarted", 1),
+				},
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+			},
+		},
+	}
+
+	client := fakeServer(t, struct {
+		authHeader string
+		query      string
+		variables  map[string]any
+	}{
+		authHeader: "test-key",
+		query:      "project: { name: { eq: $project } }",
+		variables:  map[string]any{"project": "Nightshift"},
+	}, resp)
+
+	counts, err := client.ProjectIssueCounts(context.Background(), "Nightshift")
+	if err != nil {
+		t.Fatalf("ProjectIssueCounts: %v", err)
+	}
+	want := []StateCount{
+		{State: "Backlog", Type: "backlog", Position: 0, Count: 2},
+		{State: "Next", Type: "unstarted", Position: 1, Count: 3},
+		{State: "In Review", Type: "started", Position: 3, Count: 2},
+	}
+	if len(counts) != len(want) {
+		t.Fatalf("counts: got %d states, want %d (%+v)", len(counts), len(want), counts)
+	}
+	for i, w := range want {
+		if counts[i].State != w.State || counts[i].Count != w.Count {
+			t.Errorf("counts[%d]: got %+v, want %+v", i, counts[i], w)
+		}
+	}
+}
+
+func TestProjectIssueCounts_EmptyProject(t *testing.T) {
+	client := fakeServer(t, struct {
+		authHeader string
+		query      string
+		variables  map[string]any
+	}{
+		authHeader: "test-key",
+		query:      "issues(filter:",
+		variables:  map[string]any{"project": "Ghost"},
+	}, map[string]any{
+		"data": map[string]any{
+			"issues": map[string]any{
+				"nodes":    []map[string]any{},
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+			},
+		},
+	})
+
+	counts, err := client.ProjectIssueCounts(context.Background(), "Ghost")
+	if err != nil {
+		t.Fatalf("ProjectIssueCounts: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Errorf("expected no states for empty project, got %+v", counts)
+	}
+}
+
+func TestProjectIssueCounts_Paginates(t *testing.T) {
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got struct {
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &got)
+		page++
+		if page == 1 {
+			if _, ok := got.Variables["after"]; ok {
+				t.Errorf("first page should not send an after cursor, got %v", got.Variables["after"])
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issues": map[string]any{
+						"nodes": []map[string]any{
+							{"state": map[string]any{"name": "Next", "type": "unstarted", "position": 1.0}},
+						},
+						"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "CURSOR1"},
+					},
+				},
+			})
+			return
+		}
+		if got.Variables["after"] != "CURSOR1" {
+			t.Errorf("second page after: got %v, want CURSOR1", got.Variables["after"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"issues": map[string]any{
+					"nodes": []map[string]any{
+						{"state": map[string]any{"name": "Next", "type": "unstarted", "position": 1.0}},
+					},
+					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &Client{APIKey: "k", Endpoint: srv.URL, HTTP: srv.Client()}
+	counts, err := client.ProjectIssueCounts(context.Background(), "Nightshift")
+	if err != nil {
+		t.Fatalf("ProjectIssueCounts: %v", err)
+	}
+	if page != 2 {
+		t.Errorf("expected 2 pages fetched, got %d", page)
+	}
+	if len(counts) != 1 || counts[0].Count != 2 {
+		t.Errorf("expected Next=2 across both pages, got %+v", counts)
+	}
+}
+
+func TestListProjectIssues_FiltersByState(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &got)
+		gotQuery = got.Query
+		if got.Variables["project"] != "Nightshift" {
+			t.Errorf("project var: got %v", got.Variables["project"])
+		}
+		if got.Variables["state"] != "Next" {
+			t.Errorf("state var: got %v", got.Variables["state"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"issues": map[string]any{
+					"nodes": []map[string]any{
+						{
+							"id": "i1", "identifier": "ENG-7", "title": "Wire it up",
+							"url":   "https://linear.app/x/issue/ENG-7",
+							"state": map[string]any{"name": "Next", "type": "unstarted"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &Client{APIKey: "k", Endpoint: srv.URL, HTTP: srv.Client()}
+	issues, err := client.ListProjectIssues(context.Background(), "Nightshift", "Next", 25)
+	if err != nil {
+		t.Fatalf("ListProjectIssues: %v", err)
+	}
+	if !strings.Contains(gotQuery, "state: { name: { eq: $state } }") {
+		t.Errorf("query should filter by state when given, got: %s", gotQuery)
+	}
+	if len(issues) != 1 || issues[0].Identifier != "ENG-7" {
+		t.Fatalf("issues: %+v", issues)
+	}
+	if issues[0].StateName() != "Next" {
+		t.Errorf("state: got %q", issues[0].StateName())
+	}
+}
+
+func TestListProjectIssues_NoStateOmitsFilter(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &got)
+		gotQuery = got.Query
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"issues": map[string]any{"nodes": []map[string]any{}}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &Client{APIKey: "k", Endpoint: srv.URL, HTTP: srv.Client()}
+	if _, err := client.ListProjectIssues(context.Background(), "Nightshift", "", 25); err != nil {
+		t.Fatalf("ListProjectIssues: %v", err)
+	}
+	if strings.Contains(gotQuery, "$state") {
+		t.Errorf("query should not declare $state when no state given, got: %s", gotQuery)
+	}
+}
+
+func TestSearchIssues_MatchesTitleOrDescription(t *testing.T) {
+	client := fakeServer(t, struct {
+		authHeader string
+		query      string
+		variables  map[string]any
+	}{
+		authHeader: "test-key",
+		query:      "containsIgnoreCase: $q",
+		variables:  map[string]any{"q": "auth"},
+	}, map[string]any{
+		"data": map[string]any{
+			"issues": map[string]any{
+				"nodes": []map[string]any{
+					{
+						"id": "s1", "identifier": "ENG-9", "title": "Auth flow",
+						"url":   "https://linear.app/x/issue/ENG-9",
+						"state": map[string]any{"name": "Backlog", "type": "backlog"},
+					},
+				},
+			},
+		},
+	})
+
+	issues, err := client.SearchIssues(context.Background(), "auth", 15)
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Identifier != "ENG-9" {
+		t.Fatalf("issues: %+v", issues)
+	}
+}
+
+func TestGetIssueByIdentifier_LoadsStateAndAssignee(t *testing.T) {
+	client := fakeServer(t, struct {
+		authHeader string
+		query      string
+		variables  map[string]any
+	}{
+		authHeader: "test-key",
+		query:      "assignee { name }",
+		variables:  map[string]any{"id": "ENG-42"},
+	}, map[string]any{
+		"data": map[string]any{
+			"issue": map[string]any{
+				"id": "u42", "identifier": "ENG-42", "title": "Fix login",
+				"url":      "https://linear.app/x/issue/ENG-42",
+				"project":  map[string]any{"name": "Nightshift"},
+				"state":    map[string]any{"name": "In Review", "type": "started"},
+				"assignee": map[string]any{"name": "Ada Lovelace"},
+			},
+		},
+	})
+
+	issue, err := client.GetIssueByIdentifier(context.Background(), "ENG-42")
+	if err != nil {
+		t.Fatalf("GetIssueByIdentifier: %v", err)
+	}
+	if issue.StateName() != "In Review" {
+		t.Errorf("state: got %q", issue.StateName())
+	}
+	if issue.AssigneeName() != "Ada Lovelace" {
+		t.Errorf("assignee: got %q", issue.AssigneeName())
+	}
+}
+
 func TestPing_ReturnsViewerName(t *testing.T) {
 	client := fakeServer(t, struct {
 		authHeader string

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -3,6 +3,7 @@ package linear
 import (
 	"context"
 	"fmt"
+	"sort"
 )
 
 // StateIDs holds the resolved workflow-state IDs Nightshift moves tickets
@@ -101,6 +102,98 @@ func (c *Client) FetchTriggerIssues(ctx context.Context, stateName string) ([]Is
 	return out, nil
 }
 
+// StateCount is the number of issues sitting in one workflow state for a
+// project, with the state's type ("backlog", "started", "completed", …) and
+// board position so callers can render the states in workflow order.
+type StateCount struct {
+	State    string
+	Type     string
+	Position float64
+	Count    int
+}
+
+// ProjectIssueCounts returns, for the named Linear project, how many issues sit
+// in each workflow state — ordered by board position (Backlog → Done). It pages
+// through every issue in the project. An unknown project, or one with no
+// issues, yields an empty slice and no error.
+func (c *Client) ProjectIssueCounts(ctx context.Context, projectName string) ([]StateCount, error) {
+	query := `query($project: String!, $after: String) {
+	  issues(filter: { project: { name: { eq: $project } } }, first: 250, after: $after) {
+	    nodes { state { name type position } }
+	    pageInfo { hasNextPage endCursor }
+	  }
+	}`
+
+	type agg struct {
+		typ      string
+		position float64
+		count    int
+	}
+	byState := map[string]*agg{}
+
+	after := ""
+	for {
+		var resp struct {
+			Issues struct {
+				Nodes []struct {
+					State *struct {
+						Name     string  `json:"name"`
+						Type     string  `json:"type"`
+						Position float64 `json:"position"`
+					} `json:"state"`
+				} `json:"nodes"`
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+			} `json:"issues"`
+		}
+
+		vars := map[string]any{"project": projectName}
+		if after != "" {
+			vars["after"] = after
+		}
+		if err := c.Do(ctx, query, vars, &resp); err != nil {
+			return nil, err
+		}
+
+		for _, n := range resp.Issues.Nodes {
+			if n.State == nil {
+				continue
+			}
+			a := byState[n.State.Name]
+			if a == nil {
+				a = &agg{typ: n.State.Type, position: n.State.Position}
+				byState[n.State.Name] = a
+			}
+			a.count++
+		}
+
+		if !resp.Issues.PageInfo.HasNextPage || resp.Issues.PageInfo.EndCursor == "" {
+			break
+		}
+		after = resp.Issues.PageInfo.EndCursor
+	}
+
+	out := make([]StateCount, 0, len(byState))
+	for name, a := range byState {
+		out = append(out, StateCount{State: name, Type: a.typ, Position: a.position, Count: a.count})
+	}
+	sortStateCounts(out)
+	return out, nil
+}
+
+// sortStateCounts orders states by board position (ascending), falling back to
+// state name so the output is deterministic when positions collide.
+func sortStateCounts(s []StateCount) {
+	sort.SliceStable(s, func(i, j int) bool {
+		if s[i].Position != s[j].Position {
+			return s[i].Position < s[j].Position
+		}
+		return s[i].State < s[j].State
+	})
+}
+
 // SetState moves an issue to the given workflow state ID.
 func (c *Client) SetState(ctx context.Context, issueID, stateID string) error {
 	mutation := `mutation($id: String!, $stateId: String!) {
@@ -146,7 +239,7 @@ func (c *Client) Comment(ctx context.Context, issueID, body string) error {
 // to UUIDs for the `issue(id:)` argument.
 func (c *Client) GetIssueByIdentifier(ctx context.Context, identifier string) (Issue, error) {
 	query := `query($id: String!) {
-	  issue(id: $id) { id identifier title description url project { name } }
+	  issue(id: $id) { id identifier title description url project { name } state { name type } assignee { name } }
 	}`
 
 	var resp struct {
@@ -159,6 +252,64 @@ func (c *Client) GetIssueByIdentifier(ctx context.Context, identifier string) (I
 		return Issue{}, fmt.Errorf("linear returned no issue for identifier %q", identifier)
 	}
 	return *resp.Issue, nil
+}
+
+// ListProjectIssues returns up to limit issues in the named project, most
+// recently updated first, optionally restricted to a single workflow state.
+// stateName is matched exactly (case-sensitive, as Linear stores it); an empty
+// stateName lists every state.
+func (c *Client) ListProjectIssues(ctx context.Context, projectName, stateName string, limit int) ([]Issue, error) {
+	if limit <= 0 {
+		limit = 25
+	}
+
+	filter := "project: { name: { eq: $project } }"
+	varDecl := "$project: String!, $limit: Int!"
+	vars := map[string]any{"project": projectName, "limit": limit}
+	if stateName != "" {
+		filter += ", state: { name: { eq: $state } }"
+		varDecl += ", $state: String!"
+		vars["state"] = stateName
+	}
+
+	query := fmt.Sprintf(`query(%s) {
+	  issues(filter: { %s }, orderBy: updatedAt, first: $limit) {
+	    nodes { id identifier title url project { name } state { name type } }
+	  }
+	}`, varDecl, filter)
+
+	var resp struct {
+		Issues struct {
+			Nodes []Issue `json:"nodes"`
+		} `json:"issues"`
+	}
+	if err := c.Do(ctx, query, vars, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Issues.Nodes, nil
+}
+
+// SearchIssues returns up to limit issues whose title or description contains
+// the given term (case-insensitive), most recently updated first.
+func (c *Client) SearchIssues(ctx context.Context, term string, limit int) ([]Issue, error) {
+	if limit <= 0 {
+		limit = 15
+	}
+	query := `query($q: String!, $limit: Int!) {
+	  issues(filter: { or: [ { title: { containsIgnoreCase: $q } }, { description: { containsIgnoreCase: $q } } ] }, orderBy: updatedAt, first: $limit) {
+	    nodes { id identifier title url project { name } state { name type } }
+	  }
+	}`
+
+	var resp struct {
+		Issues struct {
+			Nodes []Issue `json:"nodes"`
+		} `json:"issues"`
+	}
+	if err := c.Do(ctx, query, map[string]any{"q": term, "limit": limit}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Issues.Nodes, nil
 }
 
 // FetchLabeledIssues returns every issue carrying the named label, across all

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -9,14 +9,30 @@ type Project struct {
 	Name string `json:"name"`
 }
 
-// Issue is the subset of a Linear issue Nightshift acts on.
+// WorkflowState is the column a ticket sits in (e.g. "Next", "In Review") and
+// its type ("backlog", "started", "completed", …).
+type WorkflowState struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// User is the subset of a Linear user Nightshift surfaces (the assignee).
+type User struct {
+	Name string `json:"name"`
+}
+
+// Issue is the subset of a Linear issue Nightshift acts on. State and Assignee
+// are only populated by the read queries that request them (e.g.
+// GetIssueByIdentifier); they are nil otherwise.
 type Issue struct {
-	ID          string   `json:"id"`
-	Identifier  string   `json:"identifier"`
-	Title       string   `json:"title"`
-	Description string   `json:"description"`
-	URL         string   `json:"url"`
-	Project     *Project `json:"project,omitempty"`
+	ID          string         `json:"id"`
+	Identifier  string         `json:"identifier"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	URL         string         `json:"url"`
+	Project     *Project       `json:"project,omitempty"`
+	State       *WorkflowState `json:"state,omitempty"`
+	Assignee    *User          `json:"assignee,omitempty"`
 }
 
 // ProjectName returns the issue's project name, or "" if the ticket has no
@@ -26,4 +42,20 @@ func (i Issue) ProjectName() string {
 		return ""
 	}
 	return i.Project.Name
+}
+
+// StateName returns the issue's workflow-state name, or "" if not loaded.
+func (i Issue) StateName() string {
+	if i.State == nil {
+		return ""
+	}
+	return i.State.Name
+}
+
+// AssigneeName returns the issue's assignee name, or "" if unassigned/not loaded.
+func (i Issue) AssigneeName() string {
+	if i.Assignee == nil {
+		return ""
+	}
+	return i.Assignee.Name
 }

--- a/internal/pipeline/commands.go
+++ b/internal/pipeline/commands.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ahmadAlMezaal/nightshift/internal/notify"
@@ -18,7 +19,8 @@ func (p *Pipeline) registerCommands(d *telegram.Dispatcher) {
 	d.Register("status", "Show active runs and session stats", p.handleStatus)
 	d.Register("tickets", "Linear ticket counts by state, or list a state (e.g. /tickets Nightshift Next)", p.handleTickets)
 	d.Register("ticket", "Show a ticket's details (e.g. /ticket ENG-42)", p.handleTicket)
-	d.Register("search", "Search Linear tickets by text (e.g. /search auth login)", p.handleSearch)
+	d.Register("search-tickets", "Search Linear tickets by text (e.g. /search-tickets auth login)", p.handleSearch)
+	d.Register("find", "Alias for /search-tickets", p.handleSearch)
 	d.Register("kill", "Kill a running ticket (e.g. /kill ENG-42)", p.handleKill)
 	d.Register("requeue", "Re-queue a ticket with context (e.g. /requeue ENG-42 use Auth0)", p.handleRequeue)
 }
@@ -75,13 +77,31 @@ func (p *Pipeline) handleTickets(ctx context.Context, args string) string {
 		if len(names) == 0 {
 			return "No projects registered in repos.json.\n\nUsage: /tickets <project> [state]"
 		}
+
+		// Each project is an independent paginated query — fan them out so the
+		// reply latency is the slowest single project, not their sum. Goroutines
+		// write to distinct slice indices (no shared-state race), preserving the
+		// sorted project order.
+		results := make([]string, len(names))
+		var wg sync.WaitGroup
+		for i, name := range names {
+			wg.Add(1)
+			go func(idx int, project string) {
+				defer wg.Done()
+				var pb strings.Builder
+				p.writeProjectCounts(ctx, &pb, project)
+				results[idx] = pb.String()
+			}(i, name)
+		}
+		wg.Wait()
+
 		var b strings.Builder
 		b.WriteString("*Linear tickets by project*\n\n")
-		for i, name := range names {
+		for i, text := range results {
 			if i > 0 {
 				b.WriteString("\n")
 			}
-			p.writeProjectCounts(ctx, &b, name)
+			b.WriteString(text)
 		}
 		return b.String()
 	}
@@ -177,7 +197,7 @@ func (p *Pipeline) handleTicket(ctx context.Context, args string) string {
 func (p *Pipeline) handleSearch(ctx context.Context, args string) string {
 	term := strings.TrimSpace(args)
 	if term == "" {
-		return "Usage: /search <terms>\n\nExample: /search auth login"
+		return "Usage: /search-tickets <terms>\n\nExample: /search-tickets auth login"
 	}
 
 	issues, err := p.linear.SearchIssues(ctx, term, 15)

--- a/internal/pipeline/commands.go
+++ b/internal/pipeline/commands.go
@@ -16,6 +16,9 @@ import (
 // pipeline (status, kill, requeue). Called from Run when Telegram is enabled.
 func (p *Pipeline) registerCommands(d *telegram.Dispatcher) {
 	d.Register("status", "Show active runs and session stats", p.handleStatus)
+	d.Register("tickets", "Linear ticket counts by state, or list a state (e.g. /tickets Nightshift Next)", p.handleTickets)
+	d.Register("ticket", "Show a ticket's details (e.g. /ticket ENG-42)", p.handleTicket)
+	d.Register("search", "Search Linear tickets by text (e.g. /search auth login)", p.handleSearch)
 	d.Register("kill", "Kill a running ticket (e.g. /kill ENG-42)", p.handleKill)
 	d.Register("requeue", "Re-queue a ticket with context (e.g. /requeue ENG-42 use Auth0)", p.handleRequeue)
 }
@@ -56,6 +59,182 @@ func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
 	fmt.Fprintf(&b, "📦 %d/%d dispatches used\n", dispatches, maxD)
 	fmt.Fprintf(&b, "⏱ Uptime: %s\n", uptime)
 	return b.String()
+}
+
+// handleTickets reports Linear ticket counts grouped by workflow state, or —
+// when a trailing state is given — lists the tickets in that state.
+//
+//	/tickets                     counts for every project in repos.json
+//	/tickets <project>           counts per state for one project
+//	/tickets <project> <state>   list the tickets in that state
+func (p *Pipeline) handleTickets(ctx context.Context, args string) string {
+	args = strings.TrimSpace(args)
+
+	if args == "" {
+		names := p.cfg.Registry.ProjectNames()
+		if len(names) == 0 {
+			return "No projects registered in repos.json.\n\nUsage: /tickets <project> [state]"
+		}
+		var b strings.Builder
+		b.WriteString("*Linear tickets by project*\n\n")
+		for i, name := range names {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			p.writeProjectCounts(ctx, &b, name)
+		}
+		return b.String()
+	}
+
+	project, state := p.splitProjectState(args)
+	if state != "" {
+		return p.listTickets(ctx, project, state)
+	}
+
+	var b strings.Builder
+	b.WriteString("*Linear tickets*\n\n")
+	p.writeProjectCounts(ctx, &b, project)
+	return b.String()
+}
+
+// splitProjectState separates a "/tickets" argument into a project name and an
+// optional trailing state. It matches the longest registered project name that
+// is a case-insensitive prefix of args; the remainder (if any) is the state.
+// With no registry match the whole string is treated as the project name (so
+// counts still work for projects not in repos.json).
+func (p *Pipeline) splitProjectState(args string) (project, state string) {
+	lower := strings.ToLower(args)
+	best := ""
+	for _, name := range p.cfg.Registry.ProjectNames() {
+		ln := strings.ToLower(name)
+		if (lower == ln || strings.HasPrefix(lower, ln+" ")) && len(name) > len(best) {
+			best = name
+		}
+	}
+	if best == "" {
+		return args, ""
+	}
+	return best, strings.TrimSpace(args[len(best):])
+}
+
+// listTickets lists the tickets in one project filtered to a single state.
+func (p *Pipeline) listTickets(ctx context.Context, project, state string) string {
+	issues, err := p.linear.ListProjectIssues(ctx, project, state, 25)
+	if err != nil {
+		return fmt.Sprintf("Could not list %s tickets: %s",
+			notify.EscapeMarkdown(project), notify.EscapeMarkdown(err.Error()))
+	}
+	if len(issues) == 0 {
+		return fmt.Sprintf("No *%s* tickets in *%s* (check the state name).",
+			notify.EscapeMarkdown(state), notify.EscapeMarkdown(project))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "*%s* — %s (%d)\n",
+		notify.EscapeMarkdown(project), notify.EscapeMarkdown(state), len(issues))
+	for _, is := range issues {
+		fmt.Fprintf(&b, "• %s %s\n",
+			notify.EscapeMarkdown(is.Identifier), notify.EscapeMarkdown(is.Title))
+	}
+	return b.String()
+}
+
+// handleTicket shows a single ticket's details, looked up by identifier.
+func (p *Pipeline) handleTicket(ctx context.Context, args string) string {
+	id := normalizeIdentifier(strings.TrimSpace(args), p.cfg.LinearTeamKey)
+	if id == "" {
+		return "Usage: /ticket <id>\n\nExample: /ticket ENG-42"
+	}
+
+	issue, err := p.linear.GetIssueByIdentifier(ctx, id)
+	if err != nil {
+		return fmt.Sprintf("Could not find ticket %s: %s",
+			notify.EscapeMarkdown(id), notify.EscapeMarkdown(err.Error()))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "*%s* — %s\n",
+		notify.EscapeMarkdown(issue.Identifier), notify.EscapeMarkdown(issue.Title))
+	if s := issue.StateName(); s != "" {
+		fmt.Fprintf(&b, "State: %s\n", notify.EscapeMarkdown(s))
+	}
+	if pr := issue.ProjectName(); pr != "" {
+		fmt.Fprintf(&b, "Project: %s\n", notify.EscapeMarkdown(pr))
+	}
+	if a := issue.AssigneeName(); a != "" {
+		fmt.Fprintf(&b, "Assignee: %s\n", notify.EscapeMarkdown(a))
+	}
+	if issue.URL != "" {
+		fmt.Fprintf(&b, "%s\n", notify.EscapeMarkdown(issue.URL))
+	}
+	if d := snippet(issue.Description, 280); d != "" {
+		fmt.Fprintf(&b, "\n%s\n", notify.EscapeMarkdown(d))
+	}
+	return b.String()
+}
+
+// handleSearch lists tickets whose title/description match the given text.
+func (p *Pipeline) handleSearch(ctx context.Context, args string) string {
+	term := strings.TrimSpace(args)
+	if term == "" {
+		return "Usage: /search <terms>\n\nExample: /search auth login"
+	}
+
+	issues, err := p.linear.SearchIssues(ctx, term, 15)
+	if err != nil {
+		return fmt.Sprintf("Search failed: %s", notify.EscapeMarkdown(err.Error()))
+	}
+	if len(issues) == 0 {
+		return fmt.Sprintf("No tickets match *%s*.", notify.EscapeMarkdown(term))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "*Search:* %s (%d)\n", notify.EscapeMarkdown(term), len(issues))
+	for _, is := range issues {
+		if s := is.StateName(); s != "" {
+			fmt.Fprintf(&b, "• %s [%s] %s\n",
+				notify.EscapeMarkdown(is.Identifier), notify.EscapeMarkdown(s),
+				notify.EscapeMarkdown(is.Title))
+		} else {
+			fmt.Fprintf(&b, "• %s %s\n",
+				notify.EscapeMarkdown(is.Identifier), notify.EscapeMarkdown(is.Title))
+		}
+	}
+	return b.String()
+}
+
+// snippet trims s and truncates it to at most maxRunes runes, appending an
+// ellipsis when it had to cut.
+func snippet(s string, maxRunes int) string {
+	s = strings.TrimSpace(s)
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	return strings.TrimSpace(string(r[:maxRunes])) + "…"
+}
+
+// writeProjectCounts renders one project's per-state ticket counts into b.
+func (p *Pipeline) writeProjectCounts(ctx context.Context, b *strings.Builder, project string) {
+	counts, err := p.linear.ProjectIssueCounts(ctx, project)
+	if err != nil {
+		fmt.Fprintf(b, "*%s* — error: %s\n",
+			notify.EscapeMarkdown(project), notify.EscapeMarkdown(err.Error()))
+		return
+	}
+	if len(counts) == 0 {
+		fmt.Fprintf(b, "*%s* — no tickets found\n", notify.EscapeMarkdown(project))
+		return
+	}
+
+	total := 0
+	for _, c := range counts {
+		total += c.Count
+	}
+	fmt.Fprintf(b, "*%s* — %d total\n", notify.EscapeMarkdown(project), total)
+	for _, c := range counts {
+		fmt.Fprintf(b, "• %s: %d\n", notify.EscapeMarkdown(c.State), c.Count)
+	}
 }
 
 // handleKill terminates the Claude run for a specific ticket.

--- a/internal/pipeline/commands_test.go
+++ b/internal/pipeline/commands_test.go
@@ -403,6 +403,256 @@ func TestHandleRequeue_NoContext(t *testing.T) {
 	}
 }
 
+// ticketCountServer returns a Linear server that answers the ProjectIssueCounts
+// query with two states (Backlog x2, Next x1) and records the requested project.
+func ticketCountServer(t *testing.T, gotProject *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if gotProject != nil {
+			if p, ok := req.Variables["project"].(string); ok {
+				*gotProject = p
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"issues": map[string]any{
+					"nodes": []map[string]any{
+						{"state": map[string]any{"name": "Backlog", "type": "backlog", "position": 0.0}},
+						{"state": map[string]any{"name": "Backlog", "type": "backlog", "position": 0.0}},
+						{"state": map[string]any{"name": "Next", "type": "unstarted", "position": 1.0}},
+					},
+					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				},
+			},
+		})
+	}))
+	return srv
+}
+
+func TestHandleTickets_NamedProject(t *testing.T) {
+	var gotProject string
+	srv := ticketCountServer(t, &gotProject)
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{cfg: &config.Config{}, linear: client}
+	reply := p.handleTickets(context.Background(), "Nightshift")
+
+	if gotProject != "Nightshift" {
+		t.Errorf("queried project: got %q, want %q", gotProject, "Nightshift")
+	}
+	if !strings.Contains(reply, "Nightshift") {
+		t.Errorf("expected project name in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "3 total") {
+		t.Errorf("expected '3 total' in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "Backlog: 2") {
+		t.Errorf("expected 'Backlog: 2' in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "Next: 1") {
+		t.Errorf("expected 'Next: 1' in reply, got %q", reply)
+	}
+}
+
+func TestHandleTickets_AllRegisteredProjects(t *testing.T) {
+	srv := ticketCountServer(t, nil)
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			Registry: &config.RepoRegistry{
+				Repos: map[string]config.RepoEntry{
+					"Nightshift": {URL: "git@github.com:x/nightshift.git"},
+				},
+			},
+		},
+		linear: client,
+	}
+	reply := p.handleTickets(context.Background(), "")
+	if !strings.Contains(reply, "by project") {
+		t.Errorf("expected 'by project' header, got %q", reply)
+	}
+	if !strings.Contains(reply, "Nightshift") {
+		t.Errorf("expected registered project in reply, got %q", reply)
+	}
+}
+
+func TestHandleTickets_NoProjectsRegistered(t *testing.T) {
+	p := &Pipeline{cfg: &config.Config{}} // Registry is nil
+	reply := p.handleTickets(context.Background(), "")
+	if !strings.Contains(reply, "No projects registered") {
+		t.Errorf("expected 'No projects registered' in reply, got %q", reply)
+	}
+}
+
+func TestSplitProjectState(t *testing.T) {
+	p := &Pipeline{cfg: &config.Config{
+		Registry: &config.RepoRegistry{
+			Repos: map[string]config.RepoEntry{
+				"Nightshift":   {URL: "x"},
+				"Auth Service": {URL: "y"},
+			},
+		},
+	}}
+	tests := []struct {
+		args, wantProject, wantState string
+	}{
+		{"Nightshift", "Nightshift", ""},
+		{"Nightshift Next", "Nightshift", "Next"},
+		{"Nightshift In Review", "Nightshift", "In Review"},
+		{"nightshift next", "Nightshift", "next"},     // case-insensitive project match
+		{"Auth Service Done", "Auth Service", "Done"}, // multi-word project name
+		{"Unknown Project", "Unknown Project", ""},    // not in registry → whole string is project
+	}
+	for _, tt := range tests {
+		gotProject, gotState := p.splitProjectState(tt.args)
+		if gotProject != tt.wantProject || gotState != tt.wantState {
+			t.Errorf("splitProjectState(%q) = (%q, %q), want (%q, %q)",
+				tt.args, gotProject, gotState, tt.wantProject, tt.wantState)
+		}
+	}
+}
+
+func TestHandleTickets_ListMode(t *testing.T) {
+	var gotState string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if s, ok := req.Variables["state"].(string); ok {
+			gotState = s
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"issues": map[string]any{
+					"nodes": []map[string]any{
+						{"id": "i1", "identifier": "ENG-7", "title": "Wire it up",
+							"state": map[string]any{"name": "Next", "type": "unstarted"}},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			Registry: &config.RepoRegistry{
+				Repos: map[string]config.RepoEntry{"Nightshift": {URL: "x"}},
+			},
+		},
+		linear: client,
+	}
+	reply := p.handleTickets(context.Background(), "Nightshift Next")
+	if gotState != "Next" {
+		t.Errorf("expected state filter 'Next', got %q", gotState)
+	}
+	if !strings.Contains(reply, "ENG-7") || !strings.Contains(reply, "Wire it up") {
+		t.Errorf("expected listed ticket in reply, got %q", reply)
+	}
+}
+
+func TestHandleTicket(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"issue": map[string]any{
+					"id": "u42", "identifier": "ENG-42", "title": "Fix login",
+					"description": "Some details about the login bug.",
+					"url":         "https://linear.app/eng/issue/ENG-42",
+					"project":     map[string]any{"name": "Nightshift"},
+					"state":       map[string]any{"name": "In Review", "type": "started"},
+					"assignee":    map[string]any{"name": "Ada Lovelace"},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{cfg: &config.Config{LinearTeamKey: "ENG"}, linear: client}
+	reply := p.handleTicket(context.Background(), "42") // number-only → ENG-42
+	for _, want := range []string{"ENG-42", "Fix login", "In Review", "Nightshift", "Ada Lovelace"} {
+		if !strings.Contains(reply, want) {
+			t.Errorf("expected %q in reply, got %q", want, reply)
+		}
+	}
+}
+
+func TestHandleTicket_NoArgs(t *testing.T) {
+	p := &Pipeline{cfg: &config.Config{LinearTeamKey: "ENG"}}
+	if reply := p.handleTicket(context.Background(), ""); !strings.Contains(reply, "Usage") {
+		t.Errorf("expected usage, got %q", reply)
+	}
+}
+
+func TestHandleSearch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"issues": map[string]any{
+					"nodes": []map[string]any{
+						{"id": "s1", "identifier": "ENG-9", "title": "Auth flow",
+							"state": map[string]any{"name": "Backlog", "type": "backlog"}},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{cfg: &config.Config{}, linear: client}
+	reply := p.handleSearch(context.Background(), "auth")
+	if !strings.Contains(reply, "ENG-9") || !strings.Contains(reply, "Backlog") {
+		t.Errorf("expected search result in reply, got %q", reply)
+	}
+}
+
+func TestHandleSearch_NoArgs(t *testing.T) {
+	p := &Pipeline{cfg: &config.Config{}}
+	if reply := p.handleSearch(context.Background(), ""); !strings.Contains(reply, "Usage") {
+		t.Errorf("expected usage, got %q", reply)
+	}
+}
+
+func TestSnippet(t *testing.T) {
+	if got := snippet("  short  ", 280); got != "short" {
+		t.Errorf("snippet trim: got %q", got)
+	}
+	long := strings.Repeat("a", 300)
+	got := snippet(long, 280)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis on truncation, got %q", got)
+	}
+	if len([]rune(got)) != 281 { // 280 runes + ellipsis
+		t.Errorf("expected 280 runes + ellipsis, got %d runes", len([]rune(got)))
+	}
+}
+
 func TestHandleStatus_UptimeFormat(t *testing.T) {
 	p := &Pipeline{
 		cfg: &config.Config{

--- a/internal/pipeline/commands_test.go
+++ b/internal/pipeline/commands_test.go
@@ -474,18 +474,22 @@ func TestHandleTickets_AllRegisteredProjects(t *testing.T) {
 		cfg: &config.Config{
 			Registry: &config.RepoRegistry{
 				Repos: map[string]config.RepoEntry{
-					"Nightshift": {URL: "git@github.com:x/nightshift.git"},
+					"Nightshift":   {URL: "git@github.com:x/nightshift.git"},
+					"Auth Service": {URL: "git@github.com:x/auth.git"},
 				},
 			},
 		},
 		linear: client,
 	}
+	// Two projects exercise the concurrent fan-out (run under -race).
 	reply := p.handleTickets(context.Background(), "")
 	if !strings.Contains(reply, "by project") {
 		t.Errorf("expected 'by project' header, got %q", reply)
 	}
-	if !strings.Contains(reply, "Nightshift") {
-		t.Errorf("expected registered project in reply, got %q", reply)
+	for _, want := range []string{"Nightshift", "Auth Service"} {
+		if !strings.Contains(reply, want) {
+			t.Errorf("expected %q in reply, got %q", want, reply)
+		}
 	}
 }
 


### PR DESCRIPTION
## Why

The inbound Telegram channel (ENG-168/ENG-169) can act on tickets (`/kill`, `/requeue`) and report runtime state (`/status`), but there was **no way to read Linear** from chat — no ticket counts, no way to pull up a specific ticket, no search. You had to open the Linear app. This closes that gap, making Telegram a full read+control surface for Nightshift.

Implements ENG-189: https://linear.app/amazz/issue/ENG-189

## What

| Command | Result |
|---|---|
| `/tickets` | Ticket counts per workflow state, for **every** project in `repos.json` (queried concurrently) |
| `/tickets <project>` | Counts per state for one project (board-ordered, with a total) |
| `/tickets <project> <state>` | **List** the tickets (identifier + title) in that state |
| `/ticket <id>` | One ticket — title, state, project, assignee, URL, description snippet |
| `/search-tickets <terms>` (alias `/find`) | Title/description text search across the workspace |

Example:
```
/tickets Nightshift
*Nightshift* — 31 total
• Backlog: 5
• Next: 1
• In Progress: 1
• In Review: 1
• Done: 22
```

## How

- **`internal/linear`** — `ProjectIssueCounts` (paginated, aggregated per state, ordered by board position), `ListProjectIssues` (optional exact state filter), `SearchIssues` (`containsIgnoreCase` `or`-filter on title/description). `Issue` gains optional `State` + `Assignee`; `GetIssueByIdentifier` now loads them (so `/requeue`'s existing lookup is reused for `/ticket`).
- **`internal/pipeline/commands.go`** — handlers + `splitProjectState`, which matches the **longest registered project name** that prefixes the argument so multi-word project names (e.g. "Auth Service") disambiguate cleanly from the trailing state. Bare `/tickets` fans the per-project queries out concurrently (WaitGroup → indexed slice, order preserved). Renders with `notify.EscapeMarkdown`, matching `/status`' style.
- Docs: CLAUDE.md package map updated (new commands + linear read methods).

## Notes

- Command naming: `/search` was renamed to `/search-tickets` (with `/find` as an alias) to stay consistent with the noun-scoped `/ticket`/`/tickets` family and avoid a too-generic verb.
- State filter on `/tickets <project> <state>` is matched exactly as Linear stores it (case-sensitive `eq`); an unknown/misspelled state returns a "check the state name" message rather than an error.
- List/search are capped (25 / 15) to keep Telegram messages bounded.

## Testing

`gofmt` clean · `go build ./...` · `go vet ./...` · `go test ./...` (and `-race` on the new concurrent path) all green. Tests cover aggregation+ordering, pagination, state-filter omission, search, `splitProjectState` (incl. multi-word + case-insensitive), and every handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)