### PR TITLE
docs: document service ops + show agent backend in startup banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,15 @@ GOOS=linux GOARCH=arm GOARM=7 go build -o nightshift ./cmd/nightshift
 
 `go vet ./...` should be clean.
 
+## Operating (systemd)
+
+Day-2 operations are wrapped by the `Makefile` (run `make help` to list targets); the README "Operating the service" section documents them for users. The important ones:
+
+- `make update` — pull `main`, rebuild to a side file, **atomic-swap** the binary (safe while the old process is still executing), then `systemctl --user restart nightshift`. This is the upgrade path on the Pi.
+- `make start` / `stop` / `restart` / `status` / `logs` — thin `systemctl --user` wrappers (`logs` tails `journalctl --user-unit=nightshift.service -f`).
+
+The startup banner (`pipeline.banner`) prints the resolved runtime config — repos, watched trigger, **agent backend** (`p.agent.Label()` + CLI), review gate, auto-iterate, notifications — so a restart's `make logs` output shows exactly what's live. Keep new operationally-significant config visible there.
+
 ## Releasing
 
 Releases are automated with GoReleaser (`.goreleaser.yaml`) via `.github/workflows/release.yml`, triggered by pushing a `v*` tag. It cross-compiles linux `amd64`/`arm64`/`armv7` + darwin `amd64`/`arm64`, archives them with checksums, and publishes a GitHub Release. `main.version` is a `var` (not const) so the tag is stamped in via `-ldflags "-X main.version=..."`. Validate config changes locally with `goreleaser check` and `goreleaser release --snapshot --clean --skip=publish`.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ git tag v2.0.0 && git push origin v2.0.0
 
 ---
 
+## Operating the service
+
+Running Nightshift as a long-lived `systemd --user` service? The `Makefile` wraps the day-to-day operations so you don't have to remember the raw `systemctl` / build incantations (run `make help` to list everything):
+
+| Command | What it does |
+|---------|--------------|
+| `make update`  | **Pull latest, rebuild, restart.** Builds to a side file and atomically swaps the binary, so a failed build never leaves you without one and the swap is safe while the old process is still running. This is how you upgrade. |
+| `make restart` | Restart the service **without** rebuilding |
+| `make start` / `make stop` | Start / stop the service |
+| `make status`  | Show service status |
+| `make logs`    | Tail live logs (`journalctl --user-unit=nightshift.service -f`) |
+| `make build-pi`| Cross-compile an `arm64` binary for a Raspberry Pi |
+
+**Upgrading is just `make update` on the host** — it pulls `main`, rebuilds, and restarts in one step.
+
+The startup banner (visible in `make logs` right after a restart) prints the live configuration — including the active **Agent** backend (Claude Code or OpenAI Codex), the review gate, auto-iterate, and notification settings — so you can confirm at a glance what a freshly-restarted instance is actually running.
+
+---
+
 ## Repositories
 
 Nightshift picks the target repo **per-ticket**, from the ticket's Linear **project** — so you never have to edit config to switch projects.

--- a/internal/agent/backend.go
+++ b/internal/agent/backend.go
@@ -38,6 +38,9 @@ type RunOptions struct {
 type Backend interface {
 	// Name is the canonical backend identifier ("claude" / "codex").
 	Name() string
+	// Label is the human-friendly backend name for banners / logs
+	// (e.g. "Claude Code", "OpenAI Codex").
+	Label() string
 	// CLI is the executable Nightshift requires on PATH for this backend.
 	CLI() string
 	// Run invokes the CLI in opts.Workdir, streaming stdout+stderr to

--- a/internal/agent/backend_test.go
+++ b/internal/agent/backend_test.go
@@ -29,14 +29,20 @@ func TestNew_SelectsBackend(t *testing.T) {
 }
 
 func TestBackend_CLIAndLabel(t *testing.T) {
-	claude, _ := New("claude")
+	claude, err := New("claude")
+	if err != nil {
+		t.Fatalf("New(\"claude\") error: %v", err)
+	}
 	if claude.CLI() != "claude" {
 		t.Errorf("claude CLI = %q, want claude", claude.CLI())
 	}
 	if claude.Label() != "Claude Code" {
 		t.Errorf("claude Label = %q, want \"Claude Code\"", claude.Label())
 	}
-	codex, _ := New("codex")
+	codex, err := New("codex")
+	if err != nil {
+		t.Fatalf("New(\"codex\") error: %v", err)
+	}
 	if codex.CLI() != "codex" {
 		t.Errorf("codex CLI = %q, want codex", codex.CLI())
 	}

--- a/internal/agent/backend_test.go
+++ b/internal/agent/backend_test.go
@@ -28,14 +28,20 @@ func TestNew_SelectsBackend(t *testing.T) {
 	}
 }
 
-func TestBackend_CLIName(t *testing.T) {
+func TestBackend_CLIAndLabel(t *testing.T) {
 	claude, _ := New("claude")
 	if claude.CLI() != "claude" {
 		t.Errorf("claude CLI = %q, want claude", claude.CLI())
 	}
+	if claude.Label() != "Claude Code" {
+		t.Errorf("claude Label = %q, want \"Claude Code\"", claude.Label())
+	}
 	codex, _ := New("codex")
 	if codex.CLI() != "codex" {
 		t.Errorf("codex CLI = %q, want codex", codex.CLI())
+	}
+	if codex.Label() != "OpenAI Codex" {
+		t.Errorf("codex Label = %q, want \"OpenAI Codex\"", codex.Label())
 	}
 }
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -10,8 +10,9 @@ import (
 // print mode. This is Nightshift's default and original backend.
 type claudeBackend struct{}
 
-func (claudeBackend) Name() string { return "claude" }
-func (claudeBackend) CLI() string  { return "claude" }
+func (claudeBackend) Name() string  { return "claude" }
+func (claudeBackend) Label() string { return "Claude Code" }
+func (claudeBackend) CLI() string   { return "claude" }
 
 // Run invokes `claude --print` in opts.Workdir. When UseAgentTeams is set the
 // experimental agent-teams flag is exported into the child environment.

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -15,8 +15,9 @@ import (
 // If a future Codex release renames flags, only codexArgs needs to change.
 type codexBackend struct{}
 
-func (codexBackend) Name() string { return "codex" }
-func (codexBackend) CLI() string  { return "codex" }
+func (codexBackend) Name() string  { return "codex" }
+func (codexBackend) Label() string { return "OpenAI Codex" }
+func (codexBackend) CLI() string   { return "codex" }
 
 // Run invokes `codex exec` in opts.Workdir. UseAgentTeams is Claude-only and
 // is ignored here.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -385,6 +385,10 @@ func (p *Pipeline) banner() {
 	if p.telegram.Enabled {
 		notifyMode = "Telegram"
 	}
+	agentMode := fmt.Sprintf("%s (%s)", p.agent.Label(), p.agent.CLI())
+	if p.cfg.UseAgentTeams {
+		agentMode += " + agent teams"
+	}
 	autoIterMode := "Disabled"
 	if p.watcher != nil {
 		autoIterMode = fmt.Sprintf("On (cap %d, poll %s)",
@@ -410,6 +414,7 @@ func (p *Pipeline) banner() {
 	} else {
 		fmt.Printf("   Watching:       %q column\n", p.cfg.TriggerState)
 	}
+	fmt.Printf("   Agent:          %s\n", agentMode)
 	fmt.Printf("   Review:         %s\n", reviewMode)
 	fmt.Printf("   Auto-iterate:   %s\n", autoIterMode)
 	fmt.Printf("   Max concurrent: %d\n", p.cfg.MaxConcurrent)


### PR DESCRIPTION
## Why

Two gaps surfaced while running Nightshift as a `systemd --user` service on a Raspberry Pi:

1. **Ops were undocumented.** The `Makefile` has the whole day-2 surface (`update`, `start`, `stop`, `restart`, `status`, `logs`, `build-pi`) but it was discoverable only by running `make help` — neither the README nor CLAUDE.md mentioned it. `make update` (pull → atomic-swap rebuild → restart) is the normal upgrade path and wasn't written down anywhere.
2. **The startup banner didn't say which agent backend was active.** It listed review / auto-iterate / notifications, but after ENG-176 added Claude-or-Codex you couldn't tell from `make logs` whether a restarted instance was running `claude` or `codex`.

## Changes

- **README:** new "Operating the service" section — a table of the `make` ops targets and the one-line "upgrading is just `make update`" workflow.
- **CLAUDE.md:** matching "Operating (systemd)" note, plus a reminder to keep operationally-significant config visible in the banner.
- **Banner:** added `Backend.Label()` ("Claude Code" / "OpenAI Codex") and an `Agent:` line to `pipeline.banner` showing label + CLI (and `+ agent teams` when enabled).

### Banner before → after

```
   Watching:       "Next" column
   Review:         Disabled
```
```
   Watching:       "Next" column
   Agent:          OpenAI Codex (codex)
   Review:         Disabled
```

## Verification

`go build ./...`, `go test ./...` (incl. new `Label()` coverage), and `go vet ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)