### PR TITLE
observability: surface agent log path + make tail/watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,12 @@
 BINARY := nightshift
 PKG    := ./cmd/nightshift
 
+# Where per-ticket agent transcripts live. Defaults to ./logs (the config dir
+# when running from a repo checkout); override if you set LOG_DIR in .env.
+LOG_DIR ?= logs
+
 .DEFAULT_GOAL := help
-.PHONY: help build test vet run setup cleanup build-pi update start stop restart status logs
+.PHONY: help build test vet run setup cleanup build-pi update start stop restart status logs tail watch
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} \
@@ -65,5 +69,16 @@ restart: ## Restart the systemd service (does not rebuild)
 status: ## Show service status
 	systemctl --user status nightshift
 
-logs: ## Tail live logs (Ctrl+C to stop)
+logs: ## Tail Nightshift's own service logs (Ctrl+C to stop)
 	journalctl --user-unit=nightshift.service -f
+
+# ── Agent transcripts (what Claude/Codex is actually doing) ─────────────────
+
+tail: ## Tail one ticket's agent transcript (make tail TICKET=ENG-42)
+	@test -n "$(TICKET)" || { echo "usage: make tail TICKET=ENG-42"; exit 1; }
+	tail -f "$(LOG_DIR)/$(TICKET).log"
+
+watch: ## Tail the most recently active agent transcript
+	@f="$$(ls -t $(LOG_DIR)/*.log 2>/dev/null | head -1)"; \
+	test -n "$$f" || { echo "no agent logs in $(LOG_DIR)/"; exit 1; }; \
+	echo "tailing $$f"; tail -f "$$f"

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -263,7 +263,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	_ = agent.AttemptHeader(logFile)
 	offset := agent.OffsetBefore(logFile)
 
-	logger.Info("running agent", "backend", p.agent.Name())
+	logger.Info("running agent", "backend", p.agent.Name(), "log", logFile)
 
 	runErr := p.agent.Run(ctx, agent.RunOptions{
 		Workdir:       wt.Path,

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -93,6 +93,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	logger.Info("running agent",
 		"backend", p.agent.Name(),
+		"log", logFile,
 		"timeout", p.cfg.AgentTimeout,
 		"agent_teams", p.cfg.UseAgentTeams)
 


### PR DESCRIPTION
## Why

`make logs` (journald) only shows Nightshift's own `slog` lines — poll/dispatch/"running agent". The agent's actual transcript (what Claude/Codex is reasoning, running, and patching) streams to a **per-ticket file**, `logs/<ID>.log`. Nothing pointed you there, so watching a live run meant `find`-ing the file by hand. Hit this while monitoring a real Codex run on a Pi.

## Changes

- **`log=<path>` on the "running agent" line** (process.go + iterate.go) so the service log tells you exactly what to tail:
  ```
  INFO running agent id=ENG-178 backend=codex log=/…/logs/ENG-178.log timeout=45m0s agent_teams=false
  ```
- **`make tail TICKET=ENG-42`** — follow one ticket's transcript.
- **`make watch`** — follow the most recently active transcript (when you don't care which ticket).
- `LOG_DIR ?= logs` override; reworded `make logs` help to distinguish the *service* log from the *agent* transcripts.

## Verification

`go build` / `go test ./...` / `go vet ./...` pass. `make help` lists the new targets; both new targets guard cleanly when `TICKET` is unset / no logs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)