### PR TITLE
fix: don't treat a successful run as rate-limited (false positive discarding work)

### DIFF
--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -295,13 +295,16 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	}
 
 	output := agent.ReadAfter(logFile, offset)
-	if p.agent.HasRateLimit(output) {
+	// Rate limit is only classified on a failed run (see rateLimited), so a
+	// successful iteration whose transcript merely mentions "rate limit" (file
+	// content / diff) doesn't trigger a false shutdown.
+	if rateLimited(p.agent, runErr, output) {
 		logger.Warn("rate limit detected during iteration")
 		p.flagRateLimit()
 		return
 	}
 	if runErr != nil {
-		logger.Error("claude run failed", "err", runErr)
+		logger.Error("agent run failed", "err", runErr)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 		return
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -195,11 +195,11 @@ func (p *Pipeline) Run(ctx context.Context) error {
 
 		case <-ticker.C:
 			p.mu.Lock()
-			rateLimited := p.rateLimitDetected
+			rlDetected := p.rateLimitDetected
 			atCap := p.totalDispatches >= p.cfg.MaxDispatches
 			p.mu.Unlock()
 
-			if rateLimited {
+			if rlDetected {
 				slog.Info("🛑 rate limit detected — shutting down")
 				wg.Wait()
 				p.summary(ctx)
@@ -374,6 +374,16 @@ func (p *Pipeline) flagRateLimit() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.rateLimitDetected = true
+}
+
+// rateLimited reports whether a run should be treated as having hit a usage /
+// rate limit. A genuine limit makes the agent CLI FAIL, so this is only true
+// for a failed run whose output carries the backend's rate-limit markers. A
+// successful run is never rate-limited — even if its transcript mentions the
+// words (e.g. an agent editing a file that documents rate-limit handling).
+// Without the runErr gate, such a run had its completed work discarded (ENG-178).
+func rateLimited(b agent.Backend, runErr error, output string) bool {
+	return runErr != nil && b.HasRateLimit(output)
 }
 
 func (p *Pipeline) banner() {

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -139,12 +139,17 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	output := agent.ReadAfter(logFile, offset)
 
 	// ── Rate limit ───────────────────────────────────────────────────────────
-	if p.agent.HasRateLimit(output) {
+	// Only ever classified on a FAILED run (see rateLimited): scanning the
+	// transcript of a *successful* run caused false positives where an agent
+	// legitimately writing the words "rate limit" into a file got its completed
+	// work discarded (ENG-178 — Codex built the Nightshift landing page, whose
+	// copy advertises "rate-limit detection"; three good runs were thrown away).
+	if rateLimited(p.agent, runErr, output) {
 		logger.Warn("usage/rate limit detected — triggering shutdown")
 		p.bumpFailed(id)
 		p.flagRateLimit()
 		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
-			"🛑 **Nightshift: Rate limit detected**\n\nClaude hit a usage or rate limit while working on this ticket.\n\nTicket moved back to **%s**. Nightshift is shutting down to avoid further limit hits.",
+			"🛑 **Nightshift: Rate limit detected**\n\nThe agent hit a usage or rate limit while working on this ticket.\n\nTicket moved back to **%s**. Nightshift is shutting down to avoid further limit hits.",
 			p.cfg.TriggerState))
 		p.mu.Lock()
 		s, f, t := p.successCount, p.failCount, p.totalDispatches
@@ -159,10 +164,10 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// ── Non-zero exit ────────────────────────────────────────────────────────
 	if runErr != nil {
 		attempts := p.bumpFailed(id)
-		logger.Warn("claude exited with error",
+		logger.Warn("agent exited with error",
 			"err", runErr, "attempt", attempts, "max", p.cfg.MaxRetries)
 		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
-			"❌ **Nightshift: Agent failed** (attempt %d/%d)\n\nClaude exited with an error. Will retry on next poll cycle (up to %d attempts).\n\nTicket moved back to **%s**.",
+			"❌ **Nightshift: Agent failed** (attempt %d/%d)\n\nThe agent exited with an error. Will retry on next poll cycle (up to %d attempts).\n\nTicket moved back to **%s**.",
 			attempts, p.cfg.MaxRetries, p.cfg.MaxRetries, p.cfg.TriggerState))
 		p.telegram.Send(ctx, fmt.Sprintf("❌ *%s* — %s\nFailed (attempt %d/%d)",
 			id, notify.EscapeMarkdown(issue.Title), attempts, p.cfg.MaxRetries))

--- a/internal/pipeline/ratelimit_test.go
+++ b/internal/pipeline/ratelimit_test.go
@@ -1,0 +1,41 @@
+package pipeline
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ahmadAlMezaal/nightshift/internal/agent"
+)
+
+// TestRateLimited_OnlyOnFailure locks in the ENG-178 fix: a usage/rate limit is
+// a failure mode, so it must only be classified on a FAILED run. A successful
+// run whose transcript merely contains the words "rate limit" (e.g. the agent
+// edited a file that documents rate-limit handling) must never be treated as
+// rate-limited, or its completed work gets discarded.
+func TestRateLimited_OnlyOnFailure(t *testing.T) {
+	codex, err := agent.New("codex")
+	if err != nil {
+		t.Fatalf("New(codex): %v", err)
+	}
+
+	// Both of these match the backend's HasRateLimit regex.
+	limitErr := "Error: rate limit reached"
+	contentTrap := "{ h: \"Safe to leave alone\", p: \"...rate-limit detection...\" }" // ENG-178
+
+	// Successful run (runErr == nil): never rate-limited, even with markers.
+	if rateLimited(codex, nil, limitErr) {
+		t.Error("successful run must not be classified as rate-limited")
+	}
+	if rateLimited(codex, nil, contentTrap) {
+		t.Error("ENG-178 regression: successful run with 'rate-limit' in file content was flagged")
+	}
+
+	// Failed run: rate-limited only when the output carries the markers.
+	runErr := errors.New("exit status 1")
+	if !rateLimited(codex, runErr, limitErr) {
+		t.Error("failed run with rate-limit markers should be classified as rate-limited")
+	}
+	if rateLimited(codex, runErr, "build failed: syntax error") {
+		t.Error("failed run without markers should not be classified as rate-limited")
+	}
+}


### PR DESCRIPTION
## The bug

`HasRateLimit` scans the agent's **entire transcript**, so a *successful* run whose output merely contains the words "rate limit" / "usage limit" / "quota" was misclassified as hitting a usage limit. Nightshift then **discarded the completed work**, re-queued the ticket, and after a few cycles shut down with "🛑 Usage limit detected".

### Caught live on the Pi (Codex backend)

ENG-178 is the **Nightshift landing page** — whose copy literally advertises *"rate-limit detection"*. Codex implemented it correctly **three times** (`npm run build` passing, CC0 asset, reduced-motion handling) and each run was thrown away. **0 PRs created.** The matching lines in the transcript were the marketing copy Codex wrote, not a CLI error:

```
8227:  "...failure and rate-limit alerts..."
8228:  "...dispatch limits, rate-limit detection, and a trusted-reviewer allowlist..."
```

Codex's verbose `exec` output (it echoes diffs + file content) makes the collision likely, but the flaw affects Claude too — any ticket about rate limiting could trip it.

## The fix

A genuine usage/rate limit makes the agent CLI **fail**. So classify it only on a failed run:

```go
func rateLimited(b agent.Backend, runErr error, output string) bool {
    return runErr != nil && b.HasRateLimit(output)
}
```

- Used in both `process.go` and `iterate.go` (replaces the unconditional `HasRateLimit(output)` checks). A clean exit is **never** rate-limited, even if the words appear in the diff.
- Renamed the shadowing local `rateLimited` var in `Run` → `rlDetected`.
- Neutralized a few user-facing "Claude" strings to "the agent" in the touched messages.

## Test

`ratelimit_test.go` uses the **real Codex backend** and encodes the exact ENG-178 trap: a successful run with rate-limit copy in its output is *not* flagged; a failed run with the markers *is*.

`go build` / `go test ./...` / `go vet ./...` all pass.

## Note / follow-up

This is the high-value fix (stops discarding good work). A residual narrower case remains — a run that *fails for an unrelated reason* while its transcript happens to contain those words would still be misclassified as rate-limited. Tightening the per-backend regex to the CLI's real error signature would close that, but I'd want to confirm Codex's actual rate-limit error format first (couldn't reproduce locally). Happy to do that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)