### PR TITLE
ENG-105: Docker image + GHCR publish (deploy anywhere, no Pi)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Keep the build context small: only Go source + go.mod are needed to build.
+.git
+.github
+*.md
+docs/
+data/
+logs/
+*.log
+.env
+.env.local
+repos.json
+# Built artifacts (the image builds its own binary)
+nightshift
+nightshift.new
+nightshift-pi
+nightshift-arm64
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,17 @@ MAIN_BRANCH=main
 # Default ("claude") keeps existing behaviour unchanged.
 AGENT_BACKEND=claude
 
+# ── Container / headless auth (Docker, CI, any non-logged-in host) ──────────────
+# On a logged-in laptop the agent/gh/git already have credentials. In a container
+# there's no interactive login, so provide them here — Nightshift passes the
+# environment through to the CLIs it shells out to. (Ignored if already logged in.)
+#
+# ANTHROPIC_API_KEY=sk-ant-...        # for AGENT_BACKEND=claude
+# OPENAI_API_KEY=sk-...               # for AGENT_BACKEND=codex
+# GH_TOKEN=ghp_...                    # gh PR creation + git push (repo + PR scope)
+# GIT_USER_NAME=Nightshift            # commit identity (defaults to a bot)
+# GIT_USER_EMAIL=nightshift@users.noreply.github.com
+
 # Maximum number of tickets processed at the same time
 MAX_CONCURRENT=3
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+name: docker
+
+# Build the image on every relevant PR (validation only), and build + push to
+# GHCR on main and on version tags.
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "docker-entrypoint.sh"
+      - ".dockerignore"
+      - "**/*.go"
+      - "go.mod"
+      - ".github/workflows/docker.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      # Only authenticate (and thus push) when this isn't a fork PR.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version || github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,10 @@ GOOS=linux GOARCH=arm GOARM=7 go build -o nightshift ./cmd/nightshift
 
 `go vet ./...` should be clean.
 
+## Docker
+
+`Dockerfile` is a multi-stage build: a `golang` stage compiles the static binary, and a `node:20-bookworm-slim` runtime stage adds `git` + `gh` + both agent CLIs (`@anthropic-ai/claude-code`, `@openai/codex`) — Nightshift shells out to all of them, so the image can't be `scratch`. `docker-entrypoint.sh` sets a default git identity and wires `GH_TOKEN` into git/gh (a fresh container has neither — both were silently inherited from the dev's machine before). All mutable state is redirected under `/data` (a single volume) via the `REPOS_FILE`/`REPOS_BASE`/`WORKTREE_BASE`/`LOG_DIR`/`STATE_FILE` env overrides. `.github/workflows/docker.yml` builds on PRs (validation) and builds+pushes multi-arch (amd64/arm64) to GHCR on `main`/tags. Container auth is API-key based (no interactive login) — see the README "Docker" section.
+
 ## Operating (systemd)
 
 Day-2 operations are wrapped by the `Makefile` (run `make help` to list targets); the README "Operating the service" section documents them for users. The important ones:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1
+
+# ── Build stage ───────────────────────────────────────────────────────────────
+# Compile the static Nightshift binary. CGO is disabled so the result runs on
+# any Linux without libc surprises.
+FROM golang:1.23-bookworm AS build
+WORKDIR /src
+
+# Dependency layer first for caching. Nightshift is stdlib-only today (no
+# go.sum); the wildcard keeps this working if dependencies are added later.
+COPY go.mod go.su[m] ./
+RUN go mod download
+
+COPY . .
+ARG VERSION=docker
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+      -ldflags "-s -w -X main.version=${VERSION}" \
+      -o /out/nightshift ./cmd/nightshift
+
+# ── Runtime stage ─────────────────────────────────────────────────────────────
+# Nightshift shells out to git (worktrees/clone), gh (PR creation), and a coding
+# agent CLI (claude/codex — both are npm packages), so the runtime needs all of
+# them. The node base supplies the agent runtime; git + gh are added on top.
+FROM node:20-bookworm-slim AS runtime
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl git gnupg \
+ && install -m 0755 -d /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/*
+
+# Bundle BOTH coding-agent backends so AGENT_BACKEND=claude|codex works out of
+# the box. Auth is provided at runtime via ANTHROPIC_API_KEY / OPENAI_API_KEY
+# (interactive subscription login isn't viable in a detached container).
+RUN npm install -g @anthropic-ai/claude-code @openai/codex \
+ && npm cache clean --force
+
+COPY --from=build /out/nightshift /usr/local/bin/nightshift
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# All mutable state lives under /data so a single mounted volume persists the
+# repos cache, worktrees, logs, and the PR cursor across restarts. Each path is
+# an env override Nightshift already honours.
+ENV REPOS_FILE=/data/repos.json \
+    REPOS_BASE=/data/repos \
+    WORKTREE_BASE=/data/worktrees \
+    LOG_DIR=/data/logs \
+    STATE_FILE=/data/state.json
+WORKDIR /data
+VOLUME /data
+
+# The container's only process is Nightshift (PID 1 via exec); if it dies the
+# container exits, so an orchestrator's restart policy is the health mechanism.
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["nightshift"]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,35 @@ That's it. Move tickets to your trigger state (default: "Next") — or set `TRIG
 
 Prefer editing config by hand? Copy `.env.example` → `.env` and `repos.example.json` → `repos.json` instead of running the wizard.
 
+### Docker (any host — no Go, no Pi)
+
+A prebuilt image is published to GHCR with `git`, `gh`, and both agent CLIs baked in. Runs anywhere Docker does — your laptop, a $4 VPS, Railway/Fly/Render.
+
+```bash
+# 1. Config: keys via .env, repos via ./data/repos.json
+cp .env.example .env            # fill in LINEAR_API_KEY, AGENT_BACKEND, agent + GitHub keys
+mkdir -p data && cp repos.example.json data/repos.json   # use HTTPS git URLs
+
+# 2. Run
+docker run -d --name nightshift --env-file .env -v "$PWD/data:/data" \
+  ghcr.io/ahmadalmezaal/nightshift:latest
+docker logs -f nightshift       # watch it pick up tickets
+```
+
+Or with Compose: `docker compose up -d` (see [`docker-compose.yml`](docker-compose.yml)).
+
+**Container auth** differs from a logged-in laptop — there's no interactive login, so use API keys / tokens in `.env`:
+
+| Env var | For |
+|---------|-----|
+| `LINEAR_API_KEY` | Linear (required) |
+| `AGENT_BACKEND` | `claude` or `codex` |
+| `ANTHROPIC_API_KEY` *or* `OPENAI_API_KEY` | the agent backend you chose |
+| `GH_TOKEN` | `gh` PR creation + `git push` (a PAT or fine-grained token with repo + PR scope) |
+| `GIT_USER_NAME` / `GIT_USER_EMAIL` | commit identity (defaults to a `Nightshift` bot) |
+
+`GEMINI_API_KEY`, Telegram, and auto-iterate vars work the same as elsewhere. Everything mutable (repos cache, worktrees, logs, PR cursor) lives under the mounted `/data` volume, so restarts keep their state. Use **HTTPS** git URLs in `repos.json` so `GH_TOKEN` authenticates clones/pushes (SSH would need a mounted key).
+
 ### Raspberry Pi
 
 Easiest: download the prebuilt **`linux_arm64`** (Pi 4 / 5, 64-bit OS) or **`linux_armv7`** (Pi 3 / 32-bit OS) archive from the [Releases page](https://github.com/ahmadAlMezaal/nightshift/releases) — no Go toolchain on the Pi needed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+# One-command Nightshift via Docker.
+#
+#   1. Create .env  (copy .env.example, fill in keys — see "Docker" in the README)
+#   2. Put your repos.json in ./data/repos.json  (use HTTPS git URLs so GH_TOKEN works)
+#   3. docker compose up -d
+#
+# Pull the published image, or uncomment `build: .` to build from this checkout.
+services:
+  nightshift:
+    image: ghcr.io/ahmadalmezaal/nightshift:latest
+    # build: .
+    env_file: .env
+    volumes:
+      # Persists repos.json + the repos cache, worktrees, logs, and PR cursor.
+      - ./data:/data
+    restart: unless-stopped

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Entrypoint for the Nightshift container. Configures the bits Nightshift
+# normally inherits from a developer's machine (git identity, GitHub auth) so a
+# fresh container can commit and push without manual setup, then execs the CMD.
+set -e
+
+# Some orchestrators (Kubernetes runAsNonRoot, OpenShift) run with a HOME that
+# isn't writable by the container user, which breaks git/gh config writes below.
+# Fall back to a writable directory in that case.
+if [ ! -w "${HOME:-/root}" ]; then
+  export HOME=/tmp
+fi
+
+# Nightshift commits with the ambient git identity; a fresh container has none,
+# so `git commit` would fail. Default to a bot identity, overridable via env.
+git config --global user.name  "${GIT_USER_NAME:-Nightshift}"
+git config --global user.email "${GIT_USER_EMAIL:-nightshift@users.noreply.github.com}"
+# Worktrees/clones live on a mounted volume that may be owned by a different
+# uid than the container user — avoid git's "dubious ownership" refusal.
+# --replace-all keeps this idempotent so restarts don't pile up duplicate entries.
+git config --global --replace-all safe.directory '*'
+
+# GitHub auth: gh reads GH_TOKEN from the env for PR creation; wire the same
+# token into git's credential helper so `git push` over HTTPS works too.
+# Accept GITHUB_TOKEN as an alias (common in CI environments).
+if [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
+  export GH_TOKEN="${GH_TOKEN:-$GITHUB_TOKEN}"
+  gh auth setup-git >/dev/null 2>&1 || true
+fi
+
+exec "$@"


### PR DESCRIPTION
First slice of the open-source / hosted-deployment epic (ENG-105). Goal, restated with the right lens: **any developer can run Nightshift in minutes — nothing bespoke to a Pi or to one person's machine.** The Docker image is the foundation; the Railway/Fly/Render/DO templates all consume it next.

> The epic predates the Go rewrite. Per Ahmad's status comment, the install/release slice (GoReleaser, `go install`, multi-repo, license) is already done — this PR is the **Docker** slice. GHA-cron template, VPS templates, and README/launch polish are follow-up PRs.

## What's here

- **`Dockerfile`** — multi-stage: `golang` builds the static binary, then a `node:20-bookworm-slim` runtime adds `git` + `gh` + **both** agent CLIs (`@anthropic-ai/claude-code`, `@openai/codex`) so `AGENT_BACKEND` works out of the box. (Can't be `FROM scratch` — Nightshift shells out to all of them.)
- **`docker-entrypoint.sh`** — generalizes two things Nightshift previously inherited silently from a dev's machine:
  - a **git commit identity** (`GIT_USER_NAME`/`GIT_USER_EMAIL`, default a `Nightshift` bot) — without this a fresh container's `git commit` fails;
  - **GitHub auth** from `GH_TOKEN` (wired into both `gh` and git's credential helper for HTTPS push), plus `safe.directory '*'` for volume-owned worktrees.
- **Single `/data` volume** — all mutable state (repos cache, worktrees, logs, PR cursor) redirected there via the existing `REPOS_FILE`/`REPOS_BASE`/`WORKTREE_BASE`/`LOG_DIR`/`STATE_FILE` env overrides, so restarts keep state.
- **`docker-compose.yml`** (one-command run) + **`.dockerignore`**.
- **`.github/workflows/docker.yml`** — builds on PRs (validation), builds + pushes **multi-arch (amd64/arm64)** to `ghcr.io/ahmadalmezaal/nightshift` on `main`/tags.
- **Docs** — README "Docker" section with a container-auth table; `.env.example` documents the headless auth vars; CLAUDE.md note.

## Run it

```bash
cp .env.example .env                                   # keys + AGENT_BACKEND
mkdir -p data && cp repos.example.json data/repos.json # HTTPS git URLs
docker run -d --env-file .env -v "$PWD/data:/data" ghcr.io/ahmadalmezaal/nightshift:latest
```

## Decisions / notes (open to tweaks)

- **API-key auth, not subscription login.** A detached container can't do `claude`/`codex login`, so the Docker path uses `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/`GH_TOKEN`. Documented clearly.
- **Both agent CLIs bundled** for "just works" at the cost of image size (~node-slim + 2 npm CLIs). Could split to one-per-tag later if size matters.
- **Couldn't `docker build` in the dev sandbox** (no daemon) — the build is validated by this PR's CI run. Go build/vet, `sh -n` on the entrypoint, and YAML parse all pass locally.
- **De-bespoke follow-ups worth noting:** the GHA-cron template (next slice) conflicts with the persistent auto-iterate watcher; and `repos.json` should use HTTPS URLs in-container (SSH needs a mounted key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)