### PR TITLE
fix: cap "no changes" / BLOCKED re-dispatch (stop the infinite loop)

### DIFF
--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -176,11 +176,15 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	}
 
 	// ── BLOCKED ──────────────────────────────────────────────────────────────
+	// Count the attempt: the ticket is left in the trigger state, so without a
+	// retry cap it would be re-dispatched every poll until the dispatch budget
+	// is gone. After MaxRetries it's skipped until restart / human input.
 	if blocked := agent.BlockedLine(output); blocked != "" {
-		logger.Info("blocked", "line", blocked)
+		attempts := p.bumpFailed(id)
+		logger.Info("blocked", "line", blocked, "attempt", attempts, "max", p.cfg.MaxRetries)
 		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
-			"🚧 **Nightshift needs your input**\n\nClaude got blocked on this ticket:\n\n> %s\n\nPlease clarify in the ticket comments, then move back to **%s** to retry.",
-			blocked, p.cfg.TriggerState))
+			"🚧 **Nightshift needs your input** (attempt %d/%d)\n\nThe agent got blocked on this ticket:\n\n> %s\n\nClarify in the ticket comments, then move it back to **%s** to retry. After %d attempts it won't be re-dispatched until Nightshift restarts.",
+			attempts, p.cfg.MaxRetries, blocked, p.cfg.TriggerState, p.cfg.MaxRetries))
 		p.telegram.Send(ctx, fmt.Sprintf("⚠️ *%s* — Blocked\n%s", id, notify.EscapeMarkdown(blocked)))
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
@@ -204,10 +208,15 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 		return
 	}
 	if !dirty && !committed {
-		logger.Warn("no changes made")
+		// Count the attempt — otherwise this re-queues to the trigger state every
+		// poll and burns the whole dispatch budget on one unprogressable ticket
+		// (e.g. a vague description, already-done work, or a ticket pointed at the
+		// wrong repo). After MaxRetries it's skipped until restart.
+		attempts := p.bumpFailed(id)
+		logger.Warn("no changes made", "attempt", attempts, "max", p.cfg.MaxRetries)
 		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
-			"💭 **Nightshift: No code changes made**\n\nClaude completed the session without modifying any files. This usually means the ticket description is too vague or needs more context.\n\nAdd more detail to the ticket description and move back to **%s** to retry.",
-			p.cfg.TriggerState))
+			"💭 **Nightshift: No code changes made** (attempt %d/%d)\n\nThe agent completed without modifying any files — usually the ticket is too vague, already done, or its Linear project maps to the wrong repo.\n\nAdd more detail (or check the project → repo mapping in `repos.json`), then move it back to **%s** to retry. After %d attempts it won't be re-dispatched until Nightshift restarts.",
+			attempts, p.cfg.MaxRetries, p.cfg.TriggerState, p.cfg.MaxRetries))
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}


### PR DESCRIPTION
## The bug

Caught live on the Pi: ENG-178 was picked up ~10 times in a row, then the session shut down with "max dispatches reached".

```
WARN no changes made id=ENG-178
INFO 🎯 dispatching id=ENG-178 ...
WARN no changes made id=ENG-178
... ×10 ...
INFO 🛑 max dispatches reached — shutting down limit=10
```

The `no changes made` and `BLOCKED` paths move the ticket back to the trigger state but **never call `bumpFailed`**, so `MAX_RETRIES` never trips. Any ticket that can't progress — vague description, already-done work, or (ENG-178's actual cause) a Linear project mapped to the **wrong repo** — gets re-dispatched every poll until it drains the whole `MAX_DISPATCHES` budget and spams Telegram. Every *other* failure path (timeout, non-zero exit, rate-limit) already counts a retry; these two were the gap.

## The fix

Both paths now call `bumpFailed`, so they're bounded by `MAX_RETRIES` like everything else: a few attempts, then `pollOnce` skips the ticket ("max retries hit") until restart. The "no changes" Linear comment now also names the likely causes — including the **project → repo mapping**, which is exactly what bit ENG-178.

## Not in scope (ENG-178's root cause is config, not code)

ENG-178 made no changes because its project now resolves to the `nightshift` repo (the CLI) instead of `nightshift-site` (where the landing page lives) — so the agent correctly does nothing. That's a `repos.json` mapping fix on the host, separate from this loop bug. This PR just makes Nightshift fail *gracefully* (bounded) instead of looping when that kind of mismatch happens.

`go build` / `go test ./...` / `go vet ./...` all pass. Branched off fresh `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)