### PR TITLE
ENG-105: cloud deploy templates (Fly/Render/Railway/DO) + REPOS_JSON

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,11 @@ AGENT_BACKEND=claude
 # GH_TOKEN=ghp_...                    # gh PR creation + git push (repo + PR scope)
 # GIT_USER_NAME=Nightshift            # commit identity (defaults to a bot)
 # GIT_USER_EMAIL=nightshift@users.noreply.github.com
+#
+# REPOS_JSON — supply the project→repo registry inline instead of a repos.json
+# file (for PaaS deploys with no file mounts: Fly/Render/Railway). Takes
+# precedence over REPOS_FILE. Same shape as repos.json, on one line:
+# REPOS_JSON={"repos":{"My Project":{"url":"https://github.com/you/repo.git"}}}
 
 # Maximum number of tickets processed at the same time
 MAX_CONCURRENT=3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ The target repo is chosen **per-ticket** from the ticket's Linear **project**, n
 
 If a ticket's project has no registry entry, Nightshift falls back to `REPO_PATH` from `.env` if set, otherwise it skips the ticket with a Linear comment.
 
+The registry can also be supplied inline via the **`REPOS_JSON`** env var (same shape as `repos.json`) — it takes precedence over `REPOS_FILE` and exists for PaaS deploys (Fly/Render/Railway) that can't mount a file. `config.ParseRepoRegistry` parses it; `config.Load` chooses env-vs-file.
+
 `./nightshift setup` is the interactive wizard that generates `.env` and `repos.json`. `repos.example.json` is the checked-in template.
 
 ## Coding-agent backend (`AGENT_BACKEND`)
@@ -123,7 +125,7 @@ GOOS=linux GOARCH=arm GOARM=7 go build -o nightshift ./cmd/nightshift
 
 ## Docker
 
-`Dockerfile` is a multi-stage build: a `golang` stage compiles the static binary, and a `node:20-bookworm-slim` runtime stage adds `git` + `gh` + both agent CLIs (`@anthropic-ai/claude-code`, `@openai/codex`) — Nightshift shells out to all of them, so the image can't be `scratch`. `docker-entrypoint.sh` sets a default git identity and wires `GH_TOKEN` into git/gh (a fresh container has neither — both were silently inherited from the dev's machine before). All mutable state is redirected under `/data` (a single volume) via the `REPOS_FILE`/`REPOS_BASE`/`WORKTREE_BASE`/`LOG_DIR`/`STATE_FILE` env overrides. `.github/workflows/docker.yml` builds on PRs (validation) and builds+pushes multi-arch (amd64/arm64) to GHCR on `main`/tags. Container auth is API-key based (no interactive login) — see the README "Docker" section.
+`Dockerfile` is a multi-stage build: a `golang` stage compiles the static binary, and a `node:20-bookworm-slim` runtime stage adds `git` + `gh` + both agent CLIs (`@anthropic-ai/claude-code`, `@openai/codex`) — Nightshift shells out to all of them, so the image can't be `scratch`. `docker-entrypoint.sh` sets a default git identity and wires `GH_TOKEN` into git/gh (a fresh container has neither — both were silently inherited from the dev's machine before). All mutable state is redirected under `/data` (a single volume) via the `REPOS_FILE`/`REPOS_BASE`/`WORKTREE_BASE`/`LOG_DIR`/`STATE_FILE` env overrides. `.github/workflows/docker.yml` builds on PRs (validation) and builds+pushes multi-arch (amd64/arm64) to GHCR on `main`/tags. Container auth is API-key based (no interactive login) — see the README "Docker" section. Cloud deploy templates consuming this image live at the repo root: `fly.toml`, `render.yaml`, `railway.json`, and `deploy/digitalocean-cloud-init.yaml` (all use `REPOS_JSON` since PaaS has no file mounts).
 
 ## Operating (systemd)
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ Or with Compose: `docker compose up -d` (see [`docker-compose.yml`](docker-compo
 
 `GEMINI_API_KEY`, Telegram, and auto-iterate vars work the same as elsewhere. Everything mutable (repos cache, worktrees, logs, PR cursor) lives under the mounted `/data` volume, so restarts keep their state. Use **HTTPS** git URLs in `repos.json` so `GH_TOKEN` authenticates clones/pushes (SSH would need a mounted key).
 
+### Cloud (Fly · Render · Railway · DigitalOcean)
+
+Always-on, no hardware. Each template deploys the GHCR image; set the same secrets as the Docker table above. Since these platforms can't mount a `repos.json` file, supply the registry inline via **`REPOS_JSON`** (the same JSON, as an env var):
+
+```bash
+REPOS_JSON='{"repos":{"My Project":{"url":"https://github.com/you/repo.git"}}}'
+```
+
+| Platform | File | Deploy |
+|----------|------|--------|
+| **Fly.io** | [`fly.toml`](fly.toml) | `fly volumes create nightshift_data --size 1` → `fly secrets set …` → `fly deploy` |
+| **Render** | [`render.yaml`](render.yaml) | New → Blueprint → pick repo → fill secret env vars |
+| **Railway** | [`railway.json`](railway.json) | New → Deploy from repo (builds the Dockerfile); add a `/data` volume + variables |
+| **DigitalOcean** | [`deploy/digitalocean-cloud-init.yaml`](deploy/digitalocean-cloud-init.yaml) | Paste into a droplet's *User data* (read the secrets warning in the file) |
+
+All four persist `/data` (Fly volume / Render disk / Railway volume / droplet disk) so restarts keep state.
+
 ### Raspberry Pi
 
 Easiest: download the prebuilt **`linux_arm64`** (Pi 4 / 5, 64-bit OS) or **`linux_armv7`** (Pi 3 / 32-bit OS) archive from the [Releases page](https://github.com/ahmadAlMezaal/nightshift/releases) — no Go toolchain on the Pi needed.

--- a/deploy/digitalocean-cloud-init.yaml
+++ b/deploy/digitalocean-cloud-init.yaml
@@ -1,0 +1,31 @@
+#cloud-config
+# DigitalOcean (or any cloud-init host) — boots a ~$4/mo droplet that runs
+# Nightshift in Docker, auto-restarting and surviving reboots.
+#
+# Paste this into the droplet's "User data" field at creation
+# (Create Droplet → Advanced → Add Initialization scripts).
+#
+# ⚠️  SECURITY: user-data is readable from the droplet's metadata endpoint, so
+# the keys below are visible to anything on the box. For anything real, leave
+# the REPLACE_ME values out and instead SSH in after boot and run the same
+# `docker run` with your secrets, or use a secrets manager.
+
+package_update: true
+packages:
+  - docker.io
+
+runcmd:
+  - systemctl enable --now docker
+  - mkdir -p /opt/nightshift/data
+  - |
+    docker run -d --name nightshift --restart unless-stopped \
+      -e LINEAR_API_KEY="REPLACE_ME" \
+      -e AGENT_BACKEND="claude" \
+      -e ANTHROPIC_API_KEY="REPLACE_ME" \
+      -e GH_TOKEN="REPLACE_ME" \
+      -e REPOS_JSON='{"repos":{"My Project":{"url":"https://github.com/you/repo.git"}}}' \
+      -v /opt/nightshift/data:/data \
+      ghcr.io/ahmadalmezaal/nightshift:latest
+  # Logs:    docker logs -f nightshift
+  # Upgrade: docker pull ghcr.io/ahmadalmezaal/nightshift:latest && \
+  #          docker rm -f nightshift && <re-run the docker run above>

--- a/deploy/digitalocean-cloud-init.yaml
+++ b/deploy/digitalocean-cloud-init.yaml
@@ -16,6 +16,9 @@ packages:
 
 runcmd:
   - systemctl enable --now docker
+  # `--now` returns before dockerd is fully ready; wait so `docker run` doesn't
+  # intermittently fail to reach the daemon.
+  - until docker info >/dev/null 2>&1; do sleep 1; done
   - mkdir -p /opt/nightshift/data
   - |
     docker run -d --name nightshift --restart unless-stopped \

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,27 @@
+# Fly.io — run Nightshift as an always-on worker (no public ports).
+#
+#   fly apps create nightshift            # pick your own app name (edit `app` below)
+#   fly volumes create nightshift_data --size 1 --region iad
+#   fly secrets set LINEAR_API_KEY=... AGENT_BACKEND=claude \
+#       ANTHROPIC_API_KEY=... GH_TOKEN=... \
+#       REPOS_JSON='{"repos":{"My Project":{"url":"https://github.com/you/repo.git"}}}'
+#   fly deploy
+#
+# Secrets become env vars in the container. REPOS_JSON replaces a mounted
+# repos.json (Fly has no file mounts). Use HTTPS git URLs so GH_TOKEN works.
+
+app = "nightshift"
+primary_region = "iad"
+
+[build]
+  image = "ghcr.io/ahmadalmezaal/nightshift:latest"
+
+# Persists the repos cache, worktrees, logs, and PR cursor across restarts.
+[[mounts]]
+  source = "nightshift_data"
+  destination = "/data"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "1gb"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,7 +172,14 @@ func Load(scriptDir string) (*Config, error) {
 	cfg.TrustedReviewers = getlist(fileEnv, "TRUSTED_REVIEWERS")
 	cfg.StateFile = getenv(fileEnv, "STATE_FILE", filepath.Join(home, ".nightshift-state.json"))
 
-	cfg.Registry, err = LoadRepoRegistry(reposFile)
+	// REPOS_JSON supplies the project→repo registry inline (instead of a
+	// repos.json file) — needed for PaaS deploys (Fly/Render/Railway) that have
+	// no file mounts. When set, it takes precedence over REPOS_FILE.
+	if inline := getenv(fileEnv, "REPOS_JSON", ""); inline != "" {
+		cfg.Registry, err = ParseRepoRegistry([]byte(inline))
+	} else {
+		cfg.Registry, err = LoadRepoRegistry(reposFile)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/repos.go
+++ b/internal/config/repos.go
@@ -51,6 +51,13 @@ func parseRepoRegistry(data []byte, source string) (*RepoRegistry, error) {
 	if r.Repos == nil {
 		return nil, fmt.Errorf("%s has no \"repos\" object", source)
 	}
+	// Fail fast on a missing URL — otherwise it surfaces much later as a
+	// confusing clone error when a ticket for that project comes in.
+	for name, entry := range r.Repos {
+		if entry.URL == "" {
+			return nil, fmt.Errorf("%s: repo %q has an empty \"url\"", source, name)
+		}
+	}
 	return &r, nil
 }
 

--- a/internal/config/repos.go
+++ b/internal/config/repos.go
@@ -31,13 +31,25 @@ func LoadRepoRegistry(path string) (*RepoRegistry, error) {
 		}
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
+	return parseRepoRegistry(data, path)
+}
 
+// ParseRepoRegistry parses an inline repos.json document (e.g. from the
+// REPOS_JSON env var). Used for PaaS deploys — Fly/Render/Railway can't mount a
+// file, so the registry is supplied as an environment variable instead.
+func ParseRepoRegistry(data []byte) (*RepoRegistry, error) {
+	return parseRepoRegistry(data, "REPOS_JSON")
+}
+
+// parseRepoRegistry unmarshals registry JSON. source is used only for error
+// messages (a file path or "REPOS_JSON").
+func parseRepoRegistry(data []byte, source string) (*RepoRegistry, error) {
 	var r RepoRegistry
 	if err := json.Unmarshal(data, &r); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
+		return nil, fmt.Errorf("parse %s: %w", source, err)
 	}
 	if r.Repos == nil {
-		return nil, fmt.Errorf("%s has no \"repos\" object", path)
+		return nil, fmt.Errorf("%s has no \"repos\" object", source)
 	}
 	return &r, nil
 }

--- a/internal/config/repos_test.go
+++ b/internal/config/repos_test.go
@@ -21,6 +21,9 @@ func TestParseRepoRegistry(t *testing.T) {
 	if _, err := ParseRepoRegistry([]byte(`{}`)); err == nil {
 		t.Error("expected error when \"repos\" object is missing")
 	}
+	if _, err := ParseRepoRegistry([]byte(`{"repos":{"Web App":{"url":""}}}`)); err == nil {
+		t.Error("expected error when a repo has an empty url")
+	}
 }
 
 func TestLoad_ReposJSONEnvTakesPrecedence(t *testing.T) {

--- a/internal/config/repos_test.go
+++ b/internal/config/repos_test.go
@@ -6,6 +6,47 @@ import (
 	"testing"
 )
 
+func TestParseRepoRegistry(t *testing.T) {
+	r, err := ParseRepoRegistry([]byte(`{"repos":{"Web App":{"url":"https://github.com/me/web.git"}}}`))
+	if err != nil {
+		t.Fatalf("ParseRepoRegistry: %v", err)
+	}
+	e, ok := r.Lookup("Web App")
+	if !ok || e.URL != "https://github.com/me/web.git" {
+		t.Errorf("Lookup: got %+v ok=%v", e, ok)
+	}
+	if _, err := ParseRepoRegistry([]byte(`not json`)); err == nil {
+		t.Error("expected error on invalid JSON")
+	}
+	if _, err := ParseRepoRegistry([]byte(`{}`)); err == nil {
+		t.Error("expected error when \"repos\" object is missing")
+	}
+}
+
+func TestLoad_ReposJSONEnvTakesPrecedence(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("REPOS_JSON", `{"repos":{"Inline Project":{"url":"https://github.com/me/inline.git"}}}`)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"`)
+	// A repos.json file exists but REPOS_JSON should win.
+	writeFile(t, filepath.Join(dir, "repos.json"), `{"repos":{"File Project":{"url":"https://github.com/me/file.git"}}}`)
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := cfg.Registry.Lookup("Inline Project"); !ok {
+		t.Error("REPOS_JSON registry should be loaded")
+	}
+	if _, ok := cfg.Registry.Lookup("File Project"); ok {
+		t.Error("repos.json file should be ignored when REPOS_JSON is set")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
 func TestLoadRepoRegistry(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "repos.json")

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ALWAYS",
+    "numReplicas": 1
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,30 @@
+# Render Blueprint — run Nightshift as a background worker.
+#
+#   1. Push this repo (or your fork) to GitHub.
+#   2. Render Dashboard → New → Blueprint → pick the repo.
+#   3. Fill in the secret env vars (marked sync:false) when prompted.
+#
+# A worker has no public URL. The disk persists /data (repos cache, worktrees,
+# logs, PR cursor). REPOS_JSON supplies the registry inline (no file mount).
+services:
+  - type: worker
+    name: nightshift
+    runtime: image
+    image:
+      url: ghcr.io/ahmadalmezaal/nightshift:latest
+    plan: starter
+    disk:
+      name: nightshift-data
+      mountPath: /data
+      sizeGB: 1
+    envVars:
+      - key: AGENT_BACKEND
+        value: claude
+      - key: LINEAR_API_KEY
+        sync: false
+      - key: ANTHROPIC_API_KEY   # or OPENAI_API_KEY for AGENT_BACKEND=codex
+        sync: false
+      - key: GH_TOKEN
+        sync: false
+      - key: REPOS_JSON          # {"repos":{"My Project":{"url":"https://github.com/you/repo.git"}}}
+        sync: false


### PR DESCRIPTION
Second slice of the open-source/deploy epic (after the Docker image, #90). Gives developers **always-on Nightshift with zero hardware** — pick a platform, set a few secrets, deploy. Every template consumes the published GHCR image.

## Templates

| Platform | File | How |
|----------|------|-----|
| **Fly.io** | `fly.toml` | worker + volume; `fly secrets set …` → `fly deploy` |
| **Render** | `render.yaml` | Blueprint background worker + disk; secret `envVars` (`sync:false`) |
| **Railway** | `railway.json` | builds the Dockerfile; `/data` volume + variables via dashboard |
| **DigitalOcean** | `deploy/digitalocean-cloud-init.yaml` | droplet *User data*; `docker run --restart` (with a secrets-in-user-data warning) |

All four persist `/data` so restarts keep the repos cache, worktrees, logs, and PR cursor.

## Enabling change: `REPOS_JSON`

PaaS targets can't mount a `repos.json` file, so without this the templates couldn't supply the project→repo registry at all. Added a `REPOS_JSON` env var that carries the same JSON inline:

```bash
REPOS_JSON='{"repos":{"My Project":{"url":"https://github.com/you/repo.git"}}}'
```

`config.ParseRepoRegistry` parses it; `config.Load` prefers `REPOS_JSON` over `REPOS_FILE`. Covered by tests (parse + precedence-over-file + validation passes).

## Docs

README "Cloud" section (per-platform table + the `REPOS_JSON` note), `.env.example`, and CLAUDE.md updated.

## Verification

`go build` / `go test ./...` / `go vet ./...` pass. All four templates parse (TOML/YAML/JSON). Can't end-to-end deploy to each provider from here — the configs follow each platform's documented schema and the image itself is already validated (#90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)