### PR TITLE
ENG-105: README launch polish + CONTRIBUTING + Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This project adopts the **[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)** as its Code of Conduct. The full text (standards of behavior and enforcement guidelines) lives at that link.
+
+In short: be respectful, welcoming, and collaborative. We want participation in Nightshift to be a harassment-free experience for everyone, regardless of background or identity.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to the project maintainer, [@ahmadAlMezaal](https://github.com/ahmadAlMezaal) (via GitHub direct message or a private report). All reports will be reviewed and handled confidentially.
+
+Maintainers are responsible for clarifying standards and may take appropriate, fair corrective action in response to behavior they deem inappropriate, following the Contributor Covenant's enforcement guidelines.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,6 +6,6 @@ In short: be respectful, welcoming, and collaborative. We want participation in 
 
 ## Reporting
 
-If you experience or witness unacceptable behavior, report it to the project maintainer, [@ahmadAlMezaal](https://github.com/ahmadAlMezaal) (via GitHub direct message or a private report). All reports will be reviewed and handled confidentially.
+If you experience or witness unacceptable behavior, report it privately to the project maintainer, [@ahmadAlMezaal](https://github.com/ahmadAlMezaal), at **ahmad.hmazaal@gmail.com**. All reports will be reviewed and handled confidentially.
 
 Maintainers are responsible for clarifying standards and may take appropriate, fair corrective action in response to behavior they deem inappropriate, following the Contributor Covenant's enforcement guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Nightshift
+
+Thanks for your interest! Nightshift is a single Go binary that turns Linear tickets into PRs. Contributions are welcome — bug fixes, new deploy targets, and new **backends** (coding agent, project management, git host) especially.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Dev setup
+
+Requires **Go 1.23+**. The `Makefile` wraps the common commands (`make help` lists them):
+
+```bash
+git clone https://github.com/ahmadAlMezaal/nightshift.git
+cd nightshift
+make build      # go build -o nightshift ./cmd/nightshift
+make test       # go test ./...
+make vet        # go vet ./...
+```
+
+CI runs `go vet`, `go build`, `go test -race`, and `golangci-lint` on every PR — run them locally first to avoid round-trips.
+
+For local development, `go run ./cmd/nightshift ...` uses the repo's own `.env` / `repos.json` (the cwd-checkout override), so you don't touch `~/.nightshift/`.
+
+## Project layout
+
+The **Package map** in [CLAUDE.md](CLAUDE.md) documents every `internal/<pkg>`. The short version:
+
+- `internal/pipeline` — the poll loop and the per-ticket lifecycle (dispatch → worktree → agent → review → PR → Linear).
+- `internal/agent` — pluggable coding-agent backends behind the `Backend` interface (Claude / Codex).
+- `internal/config`, `internal/linear`, `internal/github`, `internal/repo`, `internal/watch`, `internal/telegram` — config, the external integrations, and the PR-watch classifier.
+
+## Pull requests
+
+- Keep them **small and focused** — one logical change per PR.
+- Add or update tests for behaviour changes; keep `go vet` and lint clean.
+- Write a clear description: **what** changed and **why**. Reference the issue if there is one.
+- Branch off the latest `main`.
+
+## Adding a backend
+
+The coding agent is pluggable behind `agent.Backend` (see `internal/agent`). A new agent CLI needs roughly two things — argv construction and rate-limit phrasing — plus its CLI registered in `internal/config`. The same spirit applies to future project-management (Linear → others) and git-host (GitHub → others) integrations: keep the surface behind an interface and the rest of the pipeline unchanged.
+
+## Reporting bugs
+
+Open a GitHub issue with repro steps. For runtime problems, include the relevant slice of `make logs` (the service log) and, if it's about an agent run, the per-ticket transcript (`make tail TICKET=ENG-42`). Redact secrets.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 > Move tickets to Next. Go to sleep. Wake up to PRs.
 
+[![CI](https://github.com/ahmadAlMezaal/nightshift/actions/workflows/ci.yml/badge.svg)](https://github.com/ahmadAlMezaal/nightshift/actions/workflows/ci.yml)
+[![Docker](https://github.com/ahmadAlMezaal/nightshift/actions/workflows/docker.yml/badge.svg)](https://github.com/ahmadAlMezaal/nightshift/actions/workflows/docker.yml)
+[![Release](https://img.shields.io/github/v/release/ahmadAlMezaal/nightshift?sort=semver)](https://github.com/ahmadAlMezaal/nightshift/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.23+-00ADD8.svg)](go.mod)
+
 Nightshift picks up your Linear tickets, implements them with your coding agent of choice — **Claude Code or OpenAI Codex** — and creates PRs, all while you sleep. Iterate on review feedback and CI failures, and drive the whole thing from Telegram.
+
+<!-- TODO(maintainer): drop a ~20s demo GIF here — drag a ticket to "Next" → PR appears — e.g. ![demo](docs/demo.gif) -->
 
 ---
 
@@ -26,6 +34,40 @@ Nightshift:
 
 You: Wake up → Review 3 PRs → Merge   (check on it from Telegram any time)
 ```
+
+```mermaid
+flowchart LR
+    L[Linear ticket in Next] --> N[Nightshift poll loop]
+    N --> W[git worktree per ticket]
+    W --> A[Agent: Claude or Codex]
+    A --> G{Gemini review?}
+    G -->|pass / disabled| PR[gh pr create]
+    G -->|issues found| A
+    PR --> R[Linear: In Review]
+    PR -.->|AUTO_ITERATE_PRS| WATCH[watch PR feedback + CI]
+    WATCH -.-> A
+    N -.->|alerts + commands| TG[Telegram]
+```
+
+---
+
+## Quickstart
+
+The fastest path — local, ~5 minutes:
+
+```bash
+go install github.com/ahmadAlMezaal/nightshift/cmd/nightshift@latest
+claude            # or: codex login   — authenticate your agent once
+gh auth login     # GitHub access for PRs
+nightshift setup  # interactive: backend, Linear key, repos → writes .env + repos.json
+nightshift        # start polling
+```
+
+Drag a Linear ticket into **Next** → Nightshift clones the repo, runs the agent in an isolated worktree, opens a PR, and moves the ticket to **In Review**.
+
+> ⚠️ **The one thing newcomers trip on:** a ticket's Linear **project** must map, in `repos.json`, to the repo where its code lives. A wrong mapping means the agent runs in the wrong repo, makes no changes, and the ticket bounces back. See [Repositories](#repositories).
+
+**No hardware?** Skip to [Docker](#docker-any-host--no-go-no-pi) or [Cloud (Fly/Render/Railway/DO)](#cloud-fly--render--railway--digitalocean) — same idea, with API-key auth and repos supplied via `REPOS_JSON`.
 
 ---
 
@@ -389,6 +431,12 @@ A Claude-only experimental mode (`USE_AGENT_TEAMS=true`) where a lead Claude age
 ```
 
 Cleanup iterates every registered repo, deletes merged branches, force-deletes unmerged `nightshift/*` branches that don't have an open PR, prunes worktrees, and clears agent logs older than 7 days.
+
+---
+
+## Contributing
+
+PRs welcome — bug fixes, new deploy targets, or new agent / project-management / git backends. See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup (`make build` / `test` / `vet`) and the project layout, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Fun fact: Nightshift implements many of its own tickets.
 
 ---
 


### PR DESCRIPTION
Final slice of the open-source/deploy epic — turn the docs into a launch-grade front door (without bloating them).

## Changes

- **Badges** — CI / Docker / Release / License / Go, so the repo reads as a real, maintained project at a glance.
- **Quickstart** (new, near the top) — the ~5-minute local path in one block, a pointer to the Docker/Cloud paths for no-hardware setups, and a ⚠️ callout for the **#1 newcomer trap** we hit repeatedly this week: a ticket's Linear *project* must map to the right repo in `repos.json`, or the agent runs in the wrong repo and makes no changes.
- **Mermaid architecture diagram** in "How it works" (renders inline on GitHub) — Linear → Nightshift → agent → Gemini → PR → In Review, with the auto-iterate and Telegram side-paths.
- **CONTRIBUTING.md** — dev setup (`make build`/`test`/`vet`), project layout (→ CLAUDE.md package map), PR conventions, and how to add a backend.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, adopted by reference, with a maintainer contact.
- Short **Contributing** section in the README linking both.

## Notes

- **Demo GIF:** left a `TODO` placeholder — it needs a real screen recording (ticket → Next → PR appears). That's the one launch asset I can't generate; drop a ~20s GIF at `docs/demo.gif` and uncomment the line.
- **CoC by reference, not inline:** the full Contributor Covenant text tripped an output content filter (its enumeration of prohibited conduct), so the file adopts it via link — standard practice and filter-safe.
- Docs only; `go build` clean.

With this, ENG-105's deploy + open-source surface is complete: Docker (#90), cloud templates + REPOS_JSON (#92), and now launch docs. Remaining epic item is the optional GitHub Actions cron template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)