### PR TITLE
ENG-177: Gemini review gate via Gemini CLI (subscription/OAuth) instead of the paid API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,13 +113,22 @@ TELEGRAM_CHAT_ID=
 TELEGRAM_VERBOSE=false
 
 # ── Gemini Review Gate (optional) ─────────────────────────────────────────────
-# Leave GEMINI_API_KEY empty to skip the review gate entirely.
-# Get your key at: https://aistudio.google.com/apikey
+# GEMINI_MODE controls how Nightshift talks to Gemini:
+#   api — paid Gemini API using GEMINI_API_KEY (default; existing behaviour)
+#   cli — shells out to the gemini CLI using your Google OAuth login
+#
+# For cli mode, install the Gemini CLI and run `gemini` once on the host to
+# complete the one-time Google login. If the CLI is missing or not logged in,
+# Nightshift skips the optional gate with a clear warning instead of crashing.
+#
+# Leave GEMINI_API_KEY empty in api mode to skip the review gate entirely.
+# Get an API key at: https://aistudio.google.com/apikey
+GEMINI_MODE=api
 
-# Gemini API key — leave empty to disable the review gate
+# Gemini API key — used only when GEMINI_MODE=api
 GEMINI_API_KEY=
 
-# Gemini model to use for code review
+# Gemini model to use for code review (API or CLI mode)
 GEMINI_MODEL=gemini-2.5-pro
 
 # How many fix passes Claude gets after Gemini flags issues

--- a/internal/agent/log.go
+++ b/internal/agent/log.go
@@ -69,29 +69,39 @@ func BlockedLine(output string) string {
 	return m
 }
 
-// ExtractSummary returns Claude's final attempt's summary, stripping the
-// "--- Attempt …" markers and DEBUG: lines, and keeping only the last 40
-// lines. Matches the awk/grep pipeline the bash version used to build the PR
-// body.
+// Summary markers the prompt asks the agent to wrap its final summary in (see
+// BuildPrompt). Extracting between these is backend-agnostic and deterministic:
+// it strips everything the CLI streams around the summary — Codex's diff dump
+// and "tokens used" footer, Claude's preamble — without guessing from line
+// counts. ExtractSummary falls back to the last-N-lines heuristic when the
+// markers are absent (older logs, or an agent that didn't comply).
+const (
+	SummaryStartMarker = "===NIGHTSHIFT SUMMARY==="
+	SummaryEndMarker   = "===END NIGHTSHIFT SUMMARY==="
+)
+
+// ExtractSummary returns the agent's final-attempt summary for the PR body.
+//
+// Preferred path: the content between the last SummaryStartMarker/SummaryEndMarker
+// pair the agent printed. Fallback (no markers): the "--- Attempt …"-scoped tail
+// with DEBUG: lines and any trailing CLI usage footer stripped, capped to the
+// last 40 lines — matching the awk/grep pipeline the bash version used.
 func ExtractSummary(logContents string) string {
 	const maxLines = 40
 
-	// Find the start of the last attempt.
-	idx := strings.LastIndex(logContents, "--- Attempt ")
-	last := logContents
-	if idx >= 0 {
-		// Skip to the line after the marker.
-		nl := strings.IndexByte(logContents[idx:], '\n')
-		if nl >= 0 {
-			last = logContents[idx+nl+1:]
-		} else {
-			last = ""
-		}
+	// Scope to the last attempt first so stale markers from an earlier attempt
+	// in the same appended log can't win over the current one.
+	last := lastAttempt(logContents)
+
+	// Preferred: deterministic marker-delimited summary.
+	if s, ok := betweenMarkers(last); ok {
+		return s
 	}
 
-	// Filter out DEBUG: lines.
+	// Filter out DEBUG: lines and any trailing CLI usage footer (e.g. Codex's
+	// "tokens used" line).
 	var kept []string
-	for _, line := range strings.Split(last, "\n") {
+	for _, line := range strings.Split(stripUsageFooter(last), "\n") {
 		if strings.HasPrefix(line, "DEBUG: ") {
 			continue
 		}
@@ -109,4 +119,49 @@ func ExtractSummary(logContents string) string {
 		kept = kept[len(kept)-maxLines:]
 	}
 	return strings.Join(kept, "\n")
+}
+
+// lastAttempt returns logContents from after the final "--- Attempt …" marker
+// to the end (the whole input if there is no marker).
+func lastAttempt(logContents string) string {
+	idx := strings.LastIndex(logContents, "--- Attempt ")
+	if idx < 0 {
+		return logContents
+	}
+	nl := strings.IndexByte(logContents[idx:], '\n')
+	if nl < 0 {
+		return ""
+	}
+	return logContents[idx+nl+1:]
+}
+
+// betweenMarkers returns the trimmed text between the last SummaryStartMarker
+// and the first SummaryEndMarker after it. ok is false when the pair is absent,
+// so the caller can fall back to the heuristic. Using the LAST start marker
+// guards against the agent echoing the instruction earlier in its output.
+func betweenMarkers(s string) (string, bool) {
+	start := strings.LastIndex(s, SummaryStartMarker)
+	if start < 0 {
+		return "", false
+	}
+	rest := s[start+len(SummaryStartMarker):]
+	end := strings.Index(rest, SummaryEndMarker)
+	if end < 0 {
+		return "", false
+	}
+	summary := strings.TrimSpace(rest[:end])
+	if summary == "" {
+		return "", false
+	}
+	return summary, true
+}
+
+// usageFooterRe matches a trailing token-usage footer some CLIs print after the
+// agent's message (notably Codex's "tokens used: 167,195"). Anchored to the end
+// so it never eats a legitimate mid-summary mention.
+var usageFooterRe = regexp.MustCompile(`(?is)\n\s*tokens used\b.*$`)
+
+// stripUsageFooter removes a trailing CLI usage footer if present.
+func stripUsageFooter(s string) string {
+	return usageFooterRe.ReplaceAllString(s, "")
 }

--- a/internal/agent/log_test.go
+++ b/internal/agent/log_test.go
@@ -65,3 +65,55 @@ Added a new feature.
 		t.Errorf("summary should contain real content, got:\n%s", got)
 	}
 }
+
+func TestExtractSummary_PrefersMarkerDelimitedSummary(t *testing.T) {
+	// Simulates a Codex run: the CLI streams the diff and a usage footer around
+	// the marker-wrapped summary. Only the marked content should survive.
+	log := "--- Attempt 2024-01-01T01:00:00 ---\n" +
+		"DEBUG: pwd = /repo\n" +
+		"+func Foo() {}\n" +
+		"-old line\n" +
+		"@@ -1,2 +1,2 @@\n" +
+		SummaryStartMarker + "\n" +
+		"Implemented ENG-177.\nAdded GEMINI_MODE=api|cli.\n" +
+		SummaryEndMarker + "\n" +
+		"tokens used\n167,195\n"
+
+	got := ExtractSummary(log)
+	want := "Implemented ENG-177.\nAdded GEMINI_MODE=api|cli."
+	if got != want {
+		t.Errorf("marker extraction:\n got: %q\nwant: %q", got, want)
+	}
+	for _, leak := range []string{"func Foo", "@@", "tokens used", "167,195", "DEBUG:"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("summary leaked %q:\n%s", leak, got)
+		}
+	}
+}
+
+func TestExtractSummary_UsesLastMarkerPair(t *testing.T) {
+	// The agent may echo the instruction (including the markers) earlier in its
+	// output; the actual summary is the LAST pair.
+	log := SummaryStartMarker + "\n<your summary here>\n" + SummaryEndMarker + "\n" +
+		"...work...\n" +
+		SummaryStartMarker + "\nThe real summary.\n" + SummaryEndMarker + "\n"
+	if got := ExtractSummary(log); got != "The real summary." {
+		t.Errorf("should use last marker pair, got: %q", got)
+	}
+}
+
+func TestExtractSummary_FallbackStripsUsageFooter(t *testing.T) {
+	// No markers (older log / non-compliant agent): the heuristic still drops a
+	// trailing Codex-style usage footer.
+	log := "--- Attempt 2024-01-01T01:00:00 ---\n" +
+		"DEBUG: pwd = /repo\n" +
+		"Implemented the feature.\n" +
+		"tokens used: 167,195\n"
+	got := ExtractSummary(log)
+	if !strings.Contains(got, "Implemented the feature") {
+		t.Errorf("fallback should keep real content, got: %q", got)
+	}
+	if strings.Contains(got, "tokens used") || strings.Contains(got, "167,195") {
+		t.Errorf("fallback should strip usage footer, got: %q", got)
+	}
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -43,7 +43,11 @@ func BuildPrompt(in BuildPromptInput) string {
 - Do NOT create PRs or push branches — Nightshift handles that.
 
 ## When done:
-Provide a brief summary of what was implemented and any important decisions made.
+Provide a brief summary of what was implemented and any important decisions made. Wrap the summary between these exact marker lines, each alone on its own line with nothing else:
+
+===NIGHTSHIFT SUMMARY===
+<your summary here>
+===END NIGHTSHIFT SUMMARY===
 `, in.Identifier, in.Title, desc)
 	}
 
@@ -66,6 +70,10 @@ Provide a brief summary of what was implemented and any important decisions made
 - Do NOT create PRs or push branches — Nightshift handles that.
 
 ## When done:
-Provide a brief summary of what was implemented and any important decisions made.
+Provide a brief summary of what was implemented and any important decisions made. Wrap the summary between these exact marker lines, each alone on its own line with nothing else:
+
+===NIGHTSHIFT SUMMARY===
+<your summary here>
+===END NIGHTSHIFT SUMMARY===
 `, in.Identifier, in.Title, desc)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ const (
 	DefaultMaxDispatches    = 10
 	DefaultMaxRetries       = 3
 	DefaultAgentTimeout     = 45 * time.Minute
+	DefaultGeminiMode       = "api"
 	DefaultGeminiModel      = "gemini-2.5-pro"
 	DefaultMaxReviewRetries = 1
 
@@ -85,6 +86,7 @@ type Config struct {
 	TelegramVerbose  bool // also notify on dispatch (otherwise: terminal events only)
 
 	// Gemini review gate (optional)
+	GeminiMode       string
 	GeminiAPIKey     string
 	GeminiModel      string
 	MaxReviewRetries int
@@ -142,6 +144,7 @@ func Load(scriptDir string) (*Config, error) {
 		TelegramChatID:   getenv(fileEnv, "TELEGRAM_CHAT_ID", ""),
 		TelegramVerbose:  getbool(fileEnv, "TELEGRAM_VERBOSE", false),
 
+		GeminiMode:   strings.ToLower(strings.TrimSpace(getenv(fileEnv, "GEMINI_MODE", DefaultGeminiMode))),
 		GeminiAPIKey: getenv(fileEnv, "GEMINI_API_KEY", ""),
 		GeminiModel:  getenv(fileEnv, "GEMINI_MODEL", DefaultGeminiModel),
 
@@ -209,6 +212,12 @@ func (c *Config) Validate() error {
 		}
 	default:
 		errs = append(errs, fmt.Sprintf("TRIGGER_MODE must be \"state\" or \"label\", got %q", c.TriggerMode))
+	}
+
+	switch c.GeminiMode {
+	case "api", "cli":
+	default:
+		errs = append(errs, fmt.Sprintf("GEMINI_MODE must be \"api\" or \"cli\", got %q", c.GeminiMode))
 	}
 
 	if c.RepoPath != "" && !isGitRepo(c.RepoPath) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,7 +18,7 @@ var nightshiftEnvKeys = []string{
 	"MAX_CONCURRENT", "POLL_INTERVAL", "USE_AGENT_TEAMS",
 	"MAX_DISPATCHES", "MAX_RETRIES", "AGENT_TIMEOUT_MINUTES",
 	"TELEGRAM_ENABLED", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID", "TELEGRAM_VERBOSE",
-	"GEMINI_API_KEY", "GEMINI_MODEL", "MAX_REVIEW_RETRIES",
+	"GEMINI_MODE", "GEMINI_API_KEY", "GEMINI_MODEL", "MAX_REVIEW_RETRIES",
 	"REPOS_FILE", "REPOS_BASE", "WORKTREE_BASE", "LOG_DIR",
 	"AUTO_ITERATE_PRS", "MAX_PR_ITERATIONS", "PR_POLL_INTERVAL",
 	"TRUSTED_REVIEWERS", "STATE_FILE",
@@ -443,6 +443,56 @@ func TestLoad_AgentBackendDefaultsToClaude(t *testing.T) {
 	}
 	if got := cfg.RequiredCLIs(); got[len(got)-1] != "claude" {
 		t.Errorf("RequiredCLIs should end with the agent CLI, got %v", got)
+	}
+}
+
+func TestLoad_GeminiModeDefaultsToAPI(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"`)
+	writeFile(t, filepath.Join(dir, "repos.json"), `{"repos": {}}`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.GeminiMode != DefaultGeminiMode {
+		t.Errorf("GeminiMode: got %q, want %q", cfg.GeminiMode, DefaultGeminiMode)
+	}
+}
+
+func TestLoad_GeminiModeLowercased(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"
+GEMINI_MODE="CLI"`)
+	writeFile(t, filepath.Join(dir, "repos.json"), `{"repos": {}}`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.GeminiMode != "cli" {
+		t.Errorf("GeminiMode should be lowercased, got %q", cfg.GeminiMode)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate should pass with cli mode: %v", err)
+	}
+}
+
+func TestValidate_RejectsUnknownGeminiMode(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"
+GEMINI_MODE="other"`)
+	writeFile(t, filepath.Join(dir, "repos.json"), `{"repos": {}}`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "GEMINI_MODE") {
+		t.Fatalf("expected GEMINI_MODE error, got %v", err)
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -71,7 +71,7 @@ func New(cfg *config.Config) *Pipeline {
 		linear:         linear.New(cfg.LinearAPIKey),
 		resolver:       repo.FromConfig(cfg),
 		telegram:       notify.New(cfg.TelegramEnabled, cfg.TelegramBotToken, cfg.TelegramChatID),
-		review:         review.New(cfg.GeminiAPIKey, cfg.GeminiModel),
+		review:         review.NewWithMode(cfg.GeminiMode, cfg.GeminiAPIKey, cfg.GeminiModel),
 		agent:          backend,
 		active:         map[string]struct{}{},
 		cancels:        map[string]context.CancelFunc{},
@@ -389,7 +389,7 @@ func rateLimited(b agent.Backend, runErr error, output string) bool {
 func (p *Pipeline) banner() {
 	reviewMode := "Disabled"
 	if p.review.Enabled() {
-		reviewMode = fmt.Sprintf("Gemini (%s)", p.cfg.GeminiModel)
+		reviewMode = fmt.Sprintf("Gemini %s (%s)", p.review.Mode, p.review.Model)
 	}
 	notifyMode := "Disabled"
 	if p.telegram.Enabled {

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ahmadAlMezaal/nightshift/internal/linear"
 	"github.com/ahmadAlMezaal/nightshift/internal/notify"
 	"github.com/ahmadAlMezaal/nightshift/internal/repo"
+	"github.com/ahmadAlMezaal/nightshift/internal/review"
 )
 
 // process is one ticket's full lifecycle: resolve repo → worktree → run
@@ -229,6 +230,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	// ── Gemini review gate (optional) ────────────────────────────────────────
 	reviewPassed := true
+	reviewSkipped := false
 	var reviewBody string
 	reviewAttempts := 0
 
@@ -239,12 +241,25 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 			diff := gitDiff(ctx, wt.Path)
 			r, err := p.review.Review(ctx, issue.Title, issue.Description, diff)
 			if err != nil {
+				if errors.Is(err, review.ErrUnavailable) {
+					logger.Warn("gemini review gate skipped", "err", err)
+					reviewPassed = true
+					reviewSkipped = true
+					reviewBody = r.Body
+					break
+				}
 				logger.Warn("gemini review request failed", "err", err)
 				reviewPassed = false
 				reviewBody = err.Error()
 				break
 			}
 			reviewBody = r.Body
+			if r.Skipped {
+				reviewPassed = true
+				reviewSkipped = true
+				logger.Warn("gemini review gate skipped", "reason", r.Body)
+				break
+			}
 			if r.Passed {
 				reviewPassed = true
 				logger.Info("✅ gemini review passed")
@@ -320,8 +335,12 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	reviewSection := ""
 	if p.review.Enabled() {
-		if reviewPassed {
-			reviewSection = fmt.Sprintf("\n---\n\n✅ **Multi-model review:** Passed (Gemini `%s`)", p.cfg.GeminiModel)
+		if reviewSkipped {
+			reviewSection = fmt.Sprintf("\n---\n\n⚠️ **Multi-model review:** Skipped (Gemini `%s` via `%s`)\n\n%s",
+				p.review.Model, p.review.Mode, reviewBody)
+		} else if reviewPassed {
+			reviewSection = fmt.Sprintf("\n---\n\n✅ **Multi-model review:** Passed (Gemini `%s` via `%s`)",
+				p.review.Model, p.review.Mode)
 		} else {
 			reviewSection = fmt.Sprintf(
 				"\n\n---\n\n⚠️ **Multi-model review:** Did not pass after %d attempt(s). Please review before merging:\n\n<details>\n<summary>Gemini review comments</summary>\n\n```\n%s\n```\n\n</details>",

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -303,8 +303,8 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// changes, the staged set is empty and a plain `git commit` would fail with
 	// "nothing to commit" and bounce a valid implementation (ENG-182).
 	commitMsg := fmt.Sprintf(
-		"feat: implement %s — %s\n\nImplemented by Nightshift using Claude Code\n\nLinear: %s",
-		id, issue.Title, issue.URL)
+		"feat: implement %s — %s\n\nImplemented by Nightshift using %s\n\nLinear: %s",
+		id, issue.Title, p.agent.Label(), issue.URL)
 
 	staged, err := hasStagedChanges(ctx, wt.Path)
 	if err != nil {
@@ -349,8 +349,8 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	}
 
 	prBody := fmt.Sprintf(
-		"## %s: %s\n\n**Linear:** %s\n\n## What was implemented\n\n%s\n%s\n---\n\n*Implemented by [Nightshift](https://github.com/ahmadAlMezaal/nightshift) 🌙 using Claude Code*",
-		id, issue.Title, issue.URL, summary, reviewSection)
+		"## %s: %s\n\n**Linear:** %s\n\n## What was implemented\n\n%s\n%s\n---\n\n*Implemented by [Nightshift](https://github.com/ahmadAlMezaal/nightshift) 🌙 using %s*",
+		id, issue.Title, issue.URL, summary, reviewSection, p.agent.Label())
 
 	// ── gh pr create ─────────────────────────────────────────────────────────
 	prURL, err := ghCreatePR(ctx, resolved.Path,

--- a/internal/review/gemini.go
+++ b/internal/review/gemini.go
@@ -11,13 +11,24 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os/exec"
 	"strings"
 	"time"
 )
 
+const defaultMode = "api"
+
+// ErrUnavailable means the selected Gemini backend is not usable on this host
+// (for example: CLI missing or not logged in). Callers should skip the optional
+// review gate instead of treating this like a failed review.
+var ErrUnavailable = errors.New("gemini review unavailable")
+
 // Result is the outcome of a single review pass.
 type Result struct {
 	Passed bool
+	// Skipped reports that the optional gate could not run because its selected
+	// backend is not available on this host.
+	Skipped bool
 	// Body is Gemini's review text — surfaced in the PR body if the gate
 	// did not pass.
 	Body string
@@ -25,6 +36,7 @@ type Result struct {
 
 // Gate is a Gemini-backed reviewer.
 type Gate struct {
+	Mode   string
 	APIKey string
 	Model  string
 	HTTP   *http.Client
@@ -32,10 +44,20 @@ type Gate struct {
 
 // New returns a Gate. model defaults to "gemini-2.5-pro" when empty.
 func New(apiKey, model string) *Gate {
+	return NewWithMode(defaultMode, apiKey, model)
+}
+
+// NewWithMode returns a Gate for either the Gemini API or Gemini CLI.
+func NewWithMode(mode, apiKey, model string) *Gate {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == "" {
+		mode = defaultMode
+	}
 	if model == "" {
 		model = "gemini-2.5-pro"
 	}
 	return &Gate{
+		Mode:   mode,
 		APIKey: apiKey,
 		Model:  model,
 		HTTP:   &http.Client{Timeout: 120 * time.Second},
@@ -43,7 +65,12 @@ func New(apiKey, model string) *Gate {
 }
 
 // Enabled reports whether the gate is configured to run.
-func (g *Gate) Enabled() bool { return g != nil && g.APIKey != "" }
+func (g *Gate) Enabled() bool {
+	if g == nil {
+		return false
+	}
+	return g.Mode == "cli" || g.APIKey != ""
+}
 
 // Review sends a diff + ticket context to Gemini and returns its verdict.
 func (g *Gate) Review(ctx context.Context, ticketTitle, ticketDescription, diff string) (Result, error) {
@@ -51,7 +78,15 @@ func (g *Gate) Review(ctx context.Context, ticketTitle, ticketDescription, diff 
 		return Result{Passed: true, Body: "PASS (Gemini not configured)"}, nil
 	}
 
-	prompt := fmt.Sprintf(`You are a senior code reviewer. Review this diff against the ticket requirements.
+	prompt := buildPrompt(ticketTitle, ticketDescription, diff)
+	if g.Mode == "cli" {
+		return g.reviewCLI(ctx, prompt)
+	}
+	return g.reviewAPI(ctx, prompt)
+}
+
+func buildPrompt(ticketTitle, ticketDescription, diff string) string {
+	return fmt.Sprintf(`You are a senior code reviewer. Review this diff against the ticket requirements.
 
 ## Ticket: %s
 %s
@@ -73,7 +108,9 @@ Start your response with exactly one of:
 
 Then provide your review comments.`,
 		ticketTitle, ticketDescription, diff)
+}
 
+func (g *Gate) reviewAPI(ctx context.Context, prompt string) (Result, error) {
 	body, err := json.Marshal(map[string]any{
 		"contents":         []any{map[string]any{"parts": []any{map[string]any{"text": prompt}}}},
 		"generationConfig": map[string]any{"temperature": 0.1, "maxOutputTokens": 4096},
@@ -119,5 +156,36 @@ Then provide your review comments.`,
 	}
 
 	text := parsed.Candidates[0].Content.Parts[0].Text
-	return Result{Passed: strings.Contains(strings.ToUpper(text), "VERDICT: PASS"), Body: text}, nil
+	return parseResult(text), nil
+}
+
+func (g *Gate) reviewCLI(ctx context.Context, prompt string) (Result, error) {
+	if _, err := exec.LookPath("gemini"); err != nil {
+		return Result{Skipped: true, Passed: true, Body: "Gemini CLI not found in PATH. Install it and run `gemini` once to log in."},
+			fmt.Errorf("%w: gemini CLI not found in PATH", ErrUnavailable)
+	}
+
+	cmd := exec.CommandContext(ctx, "gemini", "--model", g.Model, "--prompt", prompt)
+	out, err := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(out))
+	if err != nil {
+		msg := text
+		if msg == "" {
+			msg = err.Error()
+		}
+		return Result{Skipped: true, Passed: true, Body: fmt.Sprintf("Gemini CLI unavailable: %s", msg)},
+			fmt.Errorf("%w: gemini CLI failed: %s", ErrUnavailable, msg)
+	}
+	if text == "" {
+		return Result{}, errors.New("gemini CLI returned no output")
+	}
+	return parseResult(text), nil
+}
+
+func parseResult(text string) Result {
+	upper := strings.ToUpper(text)
+	return Result{
+		Passed: strings.Contains(upper, "VERDICT: PASS"),
+		Body:   text,
+	}
 }

--- a/internal/review/gemini.go
+++ b/internal/review/gemini.go
@@ -165,21 +165,49 @@ func (g *Gate) reviewCLI(ctx context.Context, prompt string) (Result, error) {
 			fmt.Errorf("%w: gemini CLI not found in PATH", ErrUnavailable)
 	}
 
-	cmd := exec.CommandContext(ctx, "gemini", "--model", g.Model, "--prompt", prompt)
+	cmd := exec.CommandContext(ctx, "gemini", "--model", g.Model)
+	cmd.Stdin = strings.NewReader(prompt)
 	out, err := cmd.CombinedOutput()
 	text := strings.TrimSpace(string(out))
 	if err != nil {
+		if ctx.Err() != nil {
+			return Result{}, ctx.Err()
+		}
 		msg := text
 		if msg == "" {
 			msg = err.Error()
 		}
-		return Result{Skipped: true, Passed: true, Body: fmt.Sprintf("Gemini CLI unavailable: %s", msg)},
-			fmt.Errorf("%w: gemini CLI failed: %s", ErrUnavailable, msg)
+		if isCLIUnavailableMessage(msg) {
+			return Result{Skipped: true, Passed: true, Body: fmt.Sprintf("Gemini CLI unavailable: %s", msg)},
+				fmt.Errorf("%w: gemini CLI failed: %s", ErrUnavailable, msg)
+		}
+		return Result{}, fmt.Errorf("gemini CLI failed: %s", msg)
 	}
 	if text == "" {
 		return Result{}, errors.New("gemini CLI returned no output")
 	}
 	return parseResult(text), nil
+}
+
+func isCLIUnavailableMessage(msg string) bool {
+	msg = strings.ToLower(msg)
+	authHints := []string{
+		"not logged in",
+		"login required",
+		"not authenticated",
+		"authentication required",
+		"auth required",
+		"no credentials",
+		"could not load credentials",
+		"run gemini first",
+		"run gemini once",
+	}
+	for _, hint := range authHints {
+		if strings.Contains(msg, hint) {
+			return true
+		}
+	}
+	return false
 }
 
 func parseResult(text string) Result {

--- a/internal/review/gemini_test.go
+++ b/internal/review/gemini_test.go
@@ -1,0 +1,86 @@
+package review
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReviewCLIParsesPass(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeGemini(t, dir, `#!/bin/sh
+case "$*" in
+  *"--model gemini-test"*) ;;
+  *) echo "missing model" >&2; exit 2 ;;
+esac
+echo "VERDICT: PASS"
+echo "Looks good."
+`)
+	t.Setenv("PATH", dir)
+
+	g := NewWithMode("cli", "", "gemini-test")
+	got, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	if !got.Passed || got.Skipped {
+		t.Fatalf("result = %+v, want passed and not skipped", got)
+	}
+	if !strings.Contains(got.Body, "Looks good.") {
+		t.Errorf("Body = %q", got.Body)
+	}
+}
+
+func TestReviewCLIMissingIsUnavailable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	g := NewWithMode("cli", "", "gemini-test")
+	got, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if !got.Skipped || !got.Passed {
+		t.Fatalf("result = %+v, want skipped pass", got)
+	}
+	if !strings.Contains(got.Body, "not found") {
+		t.Errorf("Body = %q, want missing CLI hint", got.Body)
+	}
+}
+
+func TestReviewCLINonZeroIsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeGemini(t, dir, `#!/bin/sh
+echo "not logged in: run gemini first" >&2
+exit 1
+`)
+	t.Setenv("PATH", dir)
+
+	g := NewWithMode("cli", "", "gemini-test")
+	got, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if !got.Skipped || !strings.Contains(got.Body, "not logged in") {
+		t.Fatalf("result = %+v, want skipped auth hint", got)
+	}
+}
+
+func TestReviewAPIRequiresKeyForEnabled(t *testing.T) {
+	if NewWithMode("api", "", "").Enabled() {
+		t.Fatal("api mode without GEMINI_API_KEY should be disabled")
+	}
+	if !NewWithMode("cli", "", "").Enabled() {
+		t.Fatal("cli mode should be enabled without GEMINI_API_KEY")
+	}
+}
+
+func writeFakeGemini(t *testing.T, dir, body string) {
+	t.Helper()
+	path := filepath.Join(dir, "gemini")
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/review/gemini_test.go
+++ b/internal/review/gemini_test.go
@@ -16,13 +16,26 @@ case "$*" in
   *"--model gemini-test"*) ;;
   *) echo "missing model" >&2; exit 2 ;;
 esac
+case "$*" in
+  *"--prompt"*) echo "prompt should be sent on stdin" >&2; exit 2 ;;
+esac
+found=
+while IFS= read -r line; do
+  case "$line" in
+    *"DIFF_CONTENT"*) found=1 ;;
+  esac
+done
+if [ "$found" != "1" ]; then
+  echo "missing stdin prompt" >&2
+  exit 2
+fi
 echo "VERDICT: PASS"
 echo "Looks good."
 `)
 	t.Setenv("PATH", dir)
 
 	g := NewWithMode("cli", "", "gemini-test")
-	got, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	got, err := g.Review(context.Background(), "Ticket", "Description", "DIFF_CONTENT")
 	if err != nil {
 		t.Fatalf("Review: %v", err)
 	}
@@ -50,7 +63,7 @@ func TestReviewCLIMissingIsUnavailable(t *testing.T) {
 	}
 }
 
-func TestReviewCLINonZeroIsUnavailable(t *testing.T) {
+func TestReviewCLIAuthFailureIsUnavailable(t *testing.T) {
 	dir := t.TempDir()
 	writeFakeGemini(t, dir, `#!/bin/sh
 echo "not logged in: run gemini first" >&2
@@ -65,6 +78,27 @@ exit 1
 	}
 	if !got.Skipped || !strings.Contains(got.Body, "not logged in") {
 		t.Fatalf("result = %+v, want skipped auth hint", got)
+	}
+}
+
+func TestReviewCLINonAuthFailureIsNotUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeGemini(t, dir, `#!/bin/sh
+echo "rate limit exceeded" >&2
+exit 1
+`)
+	t.Setenv("PATH", dir)
+
+	g := NewWithMode("cli", "", "gemini-test")
+	got, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	if err == nil {
+		t.Fatal("Review returned nil error, want CLI failure")
+	}
+	if errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, should not be ErrUnavailable", err)
+	}
+	if got.Skipped || got.Passed {
+		t.Fatalf("result = %+v, want non-skipped failure", got)
 	}
 }
 

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -148,13 +148,27 @@ func Run(scriptDir string) error {
 
 	// ── Optional: Gemini review gate ───────────────────────────────────────────
 	geminiKey := ""
-	if existingEnv["GEMINI_API_KEY"] != "" {
+	geminiMode := existingEnv["GEMINI_MODE"]
+	if geminiMode == "" {
+		geminiMode = config.DefaultGeminiMode
+	}
+	if strings.EqualFold(geminiMode, "cli") || existingEnv["GEMINI_API_KEY"] != "" {
 		fmt.Println("Gemini review gate is currently enabled.")
 		if w.confirm("Keep it enabled?") {
-			geminiKey = w.askEx("Gemini API key", askOpts{existing: existingEnv["GEMINI_API_KEY"], secret: true})
+			geminiMode = w.chooseGeminiMode(geminiMode)
+			if geminiMode == "api" {
+				geminiKey = w.askEx("Gemini API key", askOpts{existing: existingEnv["GEMINI_API_KEY"], secret: true})
+			}
+		} else {
+			geminiMode = config.DefaultGeminiMode
 		}
 	} else if w.confirm("Enable the Gemini review gate?") {
-		geminiKey = w.askEx("Gemini API key", askOpts{secret: true})
+		geminiMode = w.chooseGeminiMode(geminiMode)
+		if geminiMode == "api" {
+			geminiKey = w.askEx("Gemini API key", askOpts{secret: true})
+		}
+	} else {
+		geminiMode = config.DefaultGeminiMode
 	}
 
 	// ── Optional: Telegram ─────────────────────────────────────────────────────
@@ -212,7 +226,12 @@ func Run(scriptDir string) error {
 	fmt.Printf("  MAX_DISPATCHES        = %d\n", dispatches)
 	fmt.Printf("  MAX_RETRIES           = %d\n", retries)
 	fmt.Printf("  AGENT_TIMEOUT_MINUTES = %d\n", timeoutMin)
-	fmt.Printf("  GEMINI_API_KEY        = %s\n", maskOrNone(geminiKey))
+	fmt.Printf("  GEMINI_MODE           = %s\n", geminiMode)
+	if geminiMode == "cli" {
+		fmt.Printf("  GEMINI_API_KEY        = (not used in cli mode)\n")
+	} else {
+		fmt.Printf("  GEMINI_API_KEY        = %s\n", maskOrNone(geminiKey))
+	}
 	fmt.Printf("  AUTO_ITERATE_PRS      = %s\n", autoIterate)
 	if autoIterate == "true" {
 		fmt.Printf("  MAX_PR_ITERATIONS     = %d\n", maxIter)
@@ -259,6 +278,7 @@ func Run(scriptDir string) error {
 		retries:      strconv.Itoa(retries),
 		timeoutMin:   strconv.Itoa(timeoutMin),
 		geminiKey:    geminiKey,
+		geminiMode:   geminiMode,
 		tgEnabled:    tgEnabled,
 		tgToken:      tgToken,
 		tgChat:       tgChat,
@@ -512,6 +532,33 @@ func (w *wizard) chooseEngine(existing string) string {
 	}
 }
 
+func (w *wizard) chooseGeminiMode(existing string) string {
+	fmt.Println("Gemini review mode:")
+	fmt.Println("  1) API — uses GEMINI_API_KEY from Google AI Studio")
+	fmt.Println("  2) CLI — uses the gemini CLI; run `gemini` once on the host to log in")
+	fallback := "1"
+	if strings.EqualFold(existing, "cli") {
+		fallback = "2"
+	}
+	for {
+		s := w.askEx("Choose", askOpts{fallback: fallback})
+		if w.eof {
+			if strings.EqualFold(existing, "cli") {
+				return "cli"
+			}
+			return "api"
+		}
+		switch s {
+		case "1":
+			return "api"
+		case "2":
+			return "cli"
+		default:
+			fmt.Println("  Enter 1 or 2.")
+		}
+	}
+}
+
 func (w *wizard) printCLIStatus(agentBackend string) {
 	fmt.Println("Required CLIs:")
 	clis := []string{"git", "gh", config.AgentCLIs()[agentBackend]}
@@ -683,7 +730,7 @@ type envValues struct {
 	triggerMode, trigger, triggerLabel, review   string
 	mainBranch, repoPath                         string
 	concurrency, dispatches, retries, timeoutMin string
-	geminiKey                                    string
+	geminiMode, geminiKey                        string
 	tgEnabled, tgToken, tgChat, tgVerbose        string
 	autoIterate, maxIter, prPoll, trusted        string
 }
@@ -736,6 +783,9 @@ TELEGRAM_CHAT_ID="%s"
 # Also notify on every ticket dispatch (more chatty)
 TELEGRAM_VERBOSE="%s"
 
+# Gemini review gate: "api" uses GEMINI_API_KEY; "cli" shells out to gemini.
+# For cli mode, install Gemini CLI and run 'gemini' once on this host to log in.
+GEMINI_MODE="%s"
 GEMINI_API_KEY="%s"
 GEMINI_MODEL="gemini-2.5-pro"
 MAX_REVIEW_RETRIES="1"
@@ -757,7 +807,7 @@ TRUSTED_REVIEWERS="%s"
 		v.concurrency,
 		v.dispatches, v.retries, v.timeoutMin,
 		v.tgEnabled, v.tgToken, v.tgChat, v.tgVerbose,
-		v.geminiKey,
+		v.geminiMode, v.geminiKey,
 		v.autoIterate, v.maxIter, v.prPoll, v.trusted,
 	)
 	return os.WriteFile(path, []byte(body), 0o600)

--- a/internal/setup/wizard_test.go
+++ b/internal/setup/wizard_test.go
@@ -129,6 +129,56 @@ func TestAskInt_EOFNoExistingUsesFallback(t *testing.T) {
 	}
 }
 
+func TestChooseGeminiMode(t *testing.T) {
+	w := newWizardWithInput("2\n")
+	if got := w.chooseGeminiMode("api"); got != "cli" {
+		t.Errorf("chooseGeminiMode returned %q, want cli", got)
+	}
+}
+
+func TestChooseGeminiModeEOFPreservesCLI(t *testing.T) {
+	w := newWizardWithInput("")
+	if got := w.chooseGeminiMode("cli"); got != "cli" {
+		t.Errorf("chooseGeminiMode EOF returned %q, want cli", got)
+	}
+}
+
+func TestWriteEnvFileIncludesGeminiMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := writeEnvFile(path, envValues{
+		linearKey:    "lin_xyz",
+		team:         "ENG",
+		agentBackend: "claude",
+		triggerMode:  "state",
+		trigger:      "Next",
+		review:       "In Review",
+		mainBranch:   "main",
+		concurrency:  "3",
+		dispatches:   "10",
+		retries:      "3",
+		timeoutMin:   "45",
+		geminiMode:   "cli",
+		tgEnabled:    "false",
+		tgVerbose:    "false",
+		autoIterate:  "false",
+		maxIter:      "3",
+		prPoll:       "120",
+	}); err != nil {
+		t.Fatalf("writeEnvFile: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if !strings.Contains(text, `GEMINI_MODE="cli"`) {
+		t.Errorf("generated .env missing GEMINI_MODE:\n%s", text)
+	}
+	if !strings.Contains(text, "run 'gemini' once") {
+		t.Errorf("generated .env missing CLI login hint:\n%s", text)
+	}
+}
+
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {


### PR DESCRIPTION
## ENG-177: Gemini review gate via Gemini CLI (subscription/OAuth)

**Linear:** https://linear.app/amazz/issue/ENG-177/gemini-review-gate-via-gemini-cli-subscriptionoauth-instead-of-the

### What this does

Adds a `GEMINI_MODE=api|cli` switch to the optional second-model review gate so it can run through the **Gemini CLI** (subscription / OAuth login) instead of only the **paid Gemini API**. Default stays `api`, so existing setups are unchanged.

In `cli` mode the gate shells out to:

```
gemini --model <model>   # prompt piped via stdin
```

and parses the same `VERDICT: PASS` / `VERDICT: FAIL` response format as the API path.

### Changes

- **`internal/review/gemini.go`** — `NewWithMode`, prompt extracted into `buildPrompt`, split `reviewAPI` / `reviewCLI` paths.
- **Graceful skip** — `review.ErrUnavailable` when the CLI is missing or not logged in; the pipeline logs and skips the optional gate (marking the PR review section "Skipped") rather than treating it as a failed review.
- **`.env.example`** — documents `GEMINI_MODE`, API-vs-CLI tradeoffs, and CLI login guidance.
- **Setup wizard** — choose API or CLI mode; preserves/disables existing Gemini settings correctly.
- **Config** — load + validate `GEMINI_MODE`.
- **Tests** — config, wizard output, CLI PASS parsing, missing-CLI skip, and CLI auth/error handling.

### Review feedback addressed (commit 2e2bed7)

- **Large-diff robustness (E2BIG):** the prompt is now piped via **stdin** (`cmd.Stdin = strings.NewReader(prompt)`) instead of being passed as a `--prompt` argument, so large diffs no longer risk "argument list too long".
- **Don't silently pass on transient failures:** only genuine auth/setup failures (`isCLIUnavailableMessage`) are mapped to `ErrUnavailable` and skipped. Any other non-zero exit (rate limit, network, model error) now returns a real error — the pipeline records the gate as **not passed** and attaches the error, instead of bypassing the gate. Context cancellation/timeout is propagated as the context error.

### Verification

- `go test ./...`
- `go vet ./...`

---

*Implemented by [Nightshift](https://github.com/ahmadAlMezaal/nightshift) 🌙*

---

### Also in this PR — PR-body generation fix (commit 0bc5fa7)

While testing the Codex backend, the generated PR descriptions came out malformed (raw diff hunks + a `tokens used` footer leaking into "What was implemented"). Root cause: `ExtractSummary` kept the last 40 log lines, which is clean for Claude but not for Codex's streamed output.

- The implement prompt now wraps the summary in `===NIGHTSHIFT SUMMARY===` / `===END NIGHTSHIFT SUMMARY===` markers; `ExtractSummary` extracts that region deterministically (backend-agnostic), falling back to the heuristic (now also stripping a trailing usage footer) for older/non-compliant logs.
- The PR body and commit trailer now name the **actual agent backend** (`p.agent.Label()` — "Claude Code" / "OpenAI Codex") instead of hardcoding "Claude Code".
