### PR TITLE
fix: feed ticket comments to the agent so "clarify in comments" actually unblocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ The required-CLI set is backend-aware: `git` + `gh` + the selected agent CLI (`c
 |---------|---------|
 | `cmd/nightshift` | Entry point + subcommand dispatch (`run` / `setup` / `cleanup` / `doctor` / `version`); startup banner; `--help` |
 | `internal/config` | `.env` parser, `repos.json` loader, validated `Config`, `DefaultConfigDir` (`~/.nightshift/`) |
-| `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `FetchLabeledIssues`, `ResolveLabelID`, `RemoveLabel`, `SetState`, `Comment`; read queries for Telegram — `ProjectIssueCounts`, `ListProjectIssues`, `SearchIssues`, `GetIssueByIdentifier` |
+| `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `FetchLabeledIssues` (both fetch each issue's `comments` so human clarifications reach the agent — see `Issue.ClarificationComments`, which filters out Nightshift's own automated notices), `ResolveLabelID`, `RemoveLabel`, `SetState`, `Comment`; read queries for Telegram — `ProjectIssueCounts`, `ListProjectIssues`, `SearchIssues`, `GetIssueByIdentifier` |
 | `internal/repo` | Project → repo slug + registry; clone-on-demand; worktree create/cleanup; `BranchName`; `CreateWorktree` (from main) + `ResumeWorktree` (pull existing remote branch) |
 | `internal/agent` | Pluggable coding-agent backends behind the `Backend` interface (`agent.New` selects `claude`/`codex` from `AGENT_BACKEND`); shared `exec` plumbing with timeout; per-backend invocation flags + rate-limit parsing (`claude.go` / `codex.go`); backend-agnostic implement-prompt builder, `BuildFixPrompt`, `BlockedLine`, and log_offset parsing |
 | `internal/review` | Optional Gemini second-model review gate |

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -1,13 +1,21 @@
 package agent
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // BuildPromptInput is the data the prompt template needs about a ticket.
 type BuildPromptInput struct {
 	Identifier  string
 	Title       string
 	Description string
-	UseTeams    bool
+	// Comments are human clarifications from the ticket thread (already filtered
+	// of Nightshift's own automated notices). They are surfaced to the agent so
+	// that replying in the comments — what the BLOCKED notification tells a human
+	// to do — actually unblocks a retry.
+	Comments []string
+	UseTeams bool
 }
 
 // BuildPrompt returns the prompt sent to Claude for a ticket. Two flavors:
@@ -19,11 +27,17 @@ func BuildPrompt(in BuildPromptInput) string {
 		desc = "No description provided."
 	}
 
+	discussion := ""
+	if len(in.Comments) > 0 {
+		discussion = "\n\n## Ticket discussion (human clarifications — treat as authoritative, newest wins):\n" +
+			strings.Join(in.Comments, "\n\n")
+	}
+
 	if in.UseTeams {
 		return fmt.Sprintf(`You are a lead agent implementing a Linear ticket. You have a team of agents available.
 
 ## Ticket: %s — %s
-%s
+%s%s
 
 ## Your approach:
 1. First, read the codebase to understand the project structure, conventions, and testing patterns.
@@ -48,13 +62,13 @@ Provide a brief summary of what was implemented and any important decisions made
 ===NIGHTSHIFT SUMMARY===
 <your summary here>
 ===END NIGHTSHIFT SUMMARY===
-`, in.Identifier, in.Title, desc)
+`, in.Identifier, in.Title, desc, discussion)
 	}
 
 	return fmt.Sprintf(`You are implementing a Linear ticket.
 
 ## Ticket: %s — %s
-%s
+%s%s
 
 ## Instructions:
 1. Read the codebase to understand the project structure and conventions.
@@ -75,5 +89,5 @@ Provide a brief summary of what was implemented and any important decisions made
 ===NIGHTSHIFT SUMMARY===
 <your summary here>
 ===END NIGHTSHIFT SUMMARY===
-`, in.Identifier, in.Title, desc)
+`, in.Identifier, in.Title, desc, discussion)
 }

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPrompt_IncludesComments(t *testing.T) {
+	out := BuildPrompt(BuildPromptInput{
+		Identifier:  "ENG-186",
+		Title:       "Add website URL",
+		Description: "Add the URL to the README.",
+		Comments: []string{
+			"Ahmad: Use https://getnightshift.dev as the canonical URL.",
+		},
+	})
+
+	if !strings.Contains(out, "## Ticket discussion") {
+		t.Errorf("prompt missing discussion section:\n%s", out)
+	}
+	if !strings.Contains(out, "https://getnightshift.dev") {
+		t.Errorf("prompt missing the clarification comment:\n%s", out)
+	}
+}
+
+func TestBuildPrompt_NoDiscussionSectionWhenNoComments(t *testing.T) {
+	out := BuildPrompt(BuildPromptInput{
+		Identifier:  "ENG-1",
+		Title:       "Do a thing",
+		Description: "Details.",
+	})
+	if strings.Contains(out, "Ticket discussion") {
+		t.Errorf("prompt should not have a discussion section when there are no comments:\n%s", out)
+	}
+}
+
+func TestBuildPrompt_CommentsInTeamsFlavor(t *testing.T) {
+	out := BuildPrompt(BuildPromptInput{
+		Identifier:  "ENG-2",
+		Title:       "Teams ticket",
+		Description: "Details.",
+		Comments:    []string{"Ahmad: prefer the stdin approach."},
+		UseTeams:    true,
+	})
+	if !strings.Contains(out, "team of agents") {
+		t.Fatalf("expected the teams-flavor prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "prefer the stdin approach") {
+		t.Errorf("teams prompt missing the clarification comment:\n%s", out)
+	}
+}

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -77,7 +77,7 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 func (c *Client) FetchTriggerIssues(ctx context.Context, stateName string) ([]Issue, error) {
 	query := `query($state: String!) {
 	  teams { nodes { issues(filter: { state: { name: { eq: $state } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name } }
+	    nodes { id identifier title description url project { name } comments(first: 50) { nodes { body user { name } } } }
 	  } } }
 	}`
 
@@ -318,7 +318,7 @@ func (c *Client) SearchIssues(ctx context.Context, term string, limit int) ([]Is
 func (c *Client) FetchLabeledIssues(ctx context.Context, labelName string) ([]Issue, error) {
 	query := `query($label: String!) {
 	  teams { nodes { issues(filter: { labels: { name: { eq: $label } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name } }
+	    nodes { id identifier title description url project { name } comments(first: 50) { nodes { body user { name } } } }
 	  } } }
 	}`
 

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -77,7 +77,7 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 func (c *Client) FetchTriggerIssues(ctx context.Context, stateName string) ([]Issue, error) {
 	query := `query($state: String!) {
 	  teams { nodes { issues(filter: { state: { name: { eq: $state } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name } comments(first: 50) { nodes { body user { name } } } }
+	    nodes { id identifier title description url project { name } comments(last: 50) { nodes { body user { name } } } }
 	  } } }
 	}`
 
@@ -318,7 +318,7 @@ func (c *Client) SearchIssues(ctx context.Context, term string, limit int) ([]Is
 func (c *Client) FetchLabeledIssues(ctx context.Context, labelName string) ([]Issue, error) {
 	query := `query($label: String!) {
 	  teams { nodes { issues(filter: { labels: { name: { eq: $label } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name } comments(first: 50) { nodes { body user { name } } } }
+	    nodes { id identifier title description url project { name } comments(last: 50) { nodes { body user { name } } } }
 	  } } }
 	}`
 

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -66,8 +66,22 @@ var systemCommentMarkers = []string{
 }
 
 func isSystemComment(body string) bool {
+	// Classify only by the first non-empty line. A human who quotes one of our
+	// notifications (a "> 🚧 **Nightshift…" block) and then adds their own reply
+	// must still count as a clarification — so a leading ">" quote is never a
+	// system comment, and a marker buried later in the body doesn't trip it.
+	firstLine := ""
+	for _, line := range strings.Split(body, "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			firstLine = s
+			break
+		}
+	}
+	if strings.HasPrefix(firstLine, ">") {
+		return false
+	}
 	for _, m := range systemCommentMarkers {
-		if strings.Contains(body, m) {
+		if strings.Contains(firstLine, m) {
 			return true
 		}
 	}

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -3,6 +3,11 @@
 // between states, and posting comments.
 package linear
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Project is the Linear project a ticket belongs to. Nightshift uses the name
 // to look the target repo up in repos.json.
 type Project struct {
@@ -21,18 +26,73 @@ type User struct {
 	Name string `json:"name"`
 }
 
+// Comment is a single Linear comment. Body is Markdown; User is the author
+// (nil for app/integration comments). Only populated by queries that request
+// comments — the trigger fetches — and empty otherwise.
+type Comment struct {
+	Body string `json:"body"`
+	User *User  `json:"user,omitempty"`
+}
+
+// CommentConnection is the GraphQL connection wrapper around an issue's comments.
+type CommentConnection struct {
+	Nodes []Comment `json:"nodes"`
+}
+
 // Issue is the subset of a Linear issue Nightshift acts on. State and Assignee
 // are only populated by the read queries that request them (e.g.
-// GetIssueByIdentifier); they are nil otherwise.
+// GetIssueByIdentifier); they are nil otherwise. Comments is only populated by
+// the trigger fetches (FetchTriggerIssues / FetchLabeledIssues).
 type Issue struct {
-	ID          string         `json:"id"`
-	Identifier  string         `json:"identifier"`
-	Title       string         `json:"title"`
-	Description string         `json:"description"`
-	URL         string         `json:"url"`
-	Project     *Project       `json:"project,omitempty"`
-	State       *WorkflowState `json:"state,omitempty"`
-	Assignee    *User          `json:"assignee,omitempty"`
+	ID          string            `json:"id"`
+	Identifier  string            `json:"identifier"`
+	Title       string            `json:"title"`
+	Description string            `json:"description"`
+	URL         string            `json:"url"`
+	Project     *Project          `json:"project,omitempty"`
+	State       *WorkflowState    `json:"state,omitempty"`
+	Assignee    *User             `json:"assignee,omitempty"`
+	Comments    CommentConnection `json:"comments,omitempty"`
+}
+
+// systemCommentMarkers identify comments that Nightshift (or the Linear↔GitHub
+// sync) posted automatically. They must never be fed back to the agent as human
+// clarification — otherwise the agent's own BLOCKED notice would be echoed
+// straight back at it. Every Nightshift status comment is bold-prefixed with
+// "**Nightshift", which a human reply would not be.
+var systemCommentMarkers = []string{
+	"**Nightshift",
+	"This comment thread is synced",
+}
+
+func isSystemComment(body string) bool {
+	for _, m := range systemCommentMarkers {
+		if strings.Contains(body, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// ClarificationComments returns the human-authored comments on the issue,
+// formatted as "Author: body", with Nightshift's own automated notifications
+// and the GitHub-sync notice filtered out. The implement prompt includes these
+// so a human can unblock a ticket by replying in the comments — which is exactly
+// what the BLOCKED notification instructs them to do.
+func (i Issue) ClarificationComments() []string {
+	var out []string
+	for _, c := range i.Comments.Nodes {
+		body := strings.TrimSpace(c.Body)
+		if body == "" || isSystemComment(body) {
+			continue
+		}
+		author := "Someone"
+		if c.User != nil && c.User.Name != "" {
+			author = c.User.Name
+		}
+		out = append(out, fmt.Sprintf("%s: %s", author, body))
+	}
+	return out
 }
 
 // ProjectName returns the issue's project name, or "" if the ticket has no

--- a/internal/linear/types_test.go
+++ b/internal/linear/types_test.go
@@ -1,0 +1,39 @@
+package linear
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestClarificationComments_FiltersSystemComments(t *testing.T) {
+	issue := Issue{
+		Comments: CommentConnection{Nodes: []Comment{
+			// Linear↔GitHub sync notice — filtered.
+			{Body: "This comment thread is synced to a corresponding GitHub issue."},
+			// A genuine human clarification — kept.
+			{Body: "Use https://getnightshift.dev as the canonical URL.", User: &User{Name: "Ahmad"}},
+			// Nightshift's own BLOCKED notification — filtered (would otherwise be
+			// echoed back at the agent).
+			{Body: "🚧 **Nightshift needs your input** (attempt 1/3)\n\nThe agent got blocked..."},
+			// Whitespace-only — skipped.
+			{Body: "   "},
+			// Author missing — kept, attributed to "Someone".
+			{Body: "Also add a badge near the title."},
+		}},
+	}
+
+	got := issue.ClarificationComments()
+	want := []string{
+		"Ahmad: Use https://getnightshift.dev as the canonical URL.",
+		"Someone: Also add a badge near the title.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ClarificationComments:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestClarificationComments_EmptyWhenNoComments(t *testing.T) {
+	if got := (Issue{}).ClarificationComments(); len(got) != 0 {
+		t.Errorf("expected no comments, got %#v", got)
+	}
+}

--- a/internal/linear/types_test.go
+++ b/internal/linear/types_test.go
@@ -19,6 +19,9 @@ func TestClarificationComments_FiltersSystemComments(t *testing.T) {
 			{Body: "   "},
 			// Author missing — kept, attributed to "Someone".
 			{Body: "Also add a badge near the title."},
+			// Human reply that QUOTES the bot notification, then adds their own
+			// clarification — must be kept, not mistaken for a system comment.
+			{Body: "> 🚧 **Nightshift needs your input**\n\nActually, use the other URL.", User: &User{Name: "Ahmad"}},
 		}},
 	}
 
@@ -26,6 +29,7 @@ func TestClarificationComments_FiltersSystemComments(t *testing.T) {
 	want := []string{
 		"Ahmad: Use https://getnightshift.dev as the canonical URL.",
 		"Someone: Also add a badge near the title.",
+		"Ahmad: > 🚧 **Nightshift needs your input**\n\nActually, use the other URL.",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ClarificationComments:\n got: %#v\nwant: %#v", got, want)

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -89,6 +89,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 		Identifier:  id,
 		Title:       issue.Title,
 		Description: issue.Description,
+		Comments:    issue.ClarificationComments(),
 		UseTeams:    p.cfg.UseAgentTeams,
 	})
 


### PR DESCRIPTION
## Problem

When the agent emits `BLOCKED`, Nightshift comments on the ticket:

> 🚧 Nightshift needs your input — **Clarify in the ticket comments, then move it back to Next to retry.**

But that instruction was a lie: the agent **never read comments**. `FetchTriggerIssues` / `FetchLabeledIssues` only selected `title description url project`, and `BuildPrompt` only rendered title + description. So a human reply with the missing info was silently ignored — the next dispatch re-read the same description and re-blocked on the same reason, every poll.

This is exactly what happened on **ENG-186** (it asked to "confirm the canonical website URL with Ahmad," then blocked repeatedly — see its thread).

## Fix

- **Fetch comments.** Both trigger queries now pull `comments(first: 50) { nodes { body user { name } } }`.
- **Filter out our own noise.** `Issue.ClarificationComments()` returns only human-authored comments, dropping:
  - Nightshift's automated notifications (all bold-prefixed `**Nightshift`) — otherwise the agent's own BLOCKED message gets echoed back at it.
  - The Linear↔GitHub sync notice.
- **Surface them.** `BuildPrompt` renders a `## Ticket discussion (human clarifications — treat as authoritative, newest wins)` section (both single-agent and Agent Teams flavors), omitted when there are none.

Net effect: replying in a ticket's comments with the missing detail now reaches the agent on the next dispatch — making the existing notification truthful instead of misleading.

## Notes / scope
- Re-dispatch is still gated by the in-memory `failedAttempts` cap (`MaxRetries`), which only resets on restart — unchanged here. This PR fixes *what the agent sees*, not the retry-budget mechanics.
- No new config; comment fetch is always-on and cheap (trigger sets are small, capped at 50 comments/issue).

## Tests
- `linear`: `ClarificationComments` filters system/sync comments, attributes authors, handles empty.
- `agent`: `BuildPrompt` includes the discussion section when comments exist, omits it otherwise, in both prompt flavors.
- Full suite + `go vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)