### PR TITLE
feat: route tickets to repos via a Linear project "Repo:" directive (repos.json optional)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,15 @@ PR poll loop → github.ListNightshiftPRs → github.GetPR (comments+reviews+sta
 
 ## Multi-repo
 
-The target repo is chosen **per-ticket** from the ticket's Linear **project**, not from a single global path. `repos.json` (gitignored) maps a project name → `{ url, main_branch }`. `repo.Resolve` looks the project up, clones the repo on demand into `~/.nightshift-repos/<slug>` (lock-guarded against concurrent clone races via `mkdir(2)`), and returns the local path + main branch.
+The target repo is chosen **per-ticket**, not from a single global path. Resolution order:
 
-If a ticket's project has no registry entry, Nightshift falls back to `REPO_PATH` from `.env` if set, otherwise it skips the ticket with a Linear comment.
+1. **Linear project directive (no `repos.json` needed)** — if the ticket's Linear **project description** contains a `Repo: <owner/name | git URL>` line (optionally a `Branch: <name>` line), `repo.ResolveDirect` clones that repo directly. `linear.Project.RepoDirective` parses it; the trigger queries fetch `project { name description }` to make it available. An `owner/name` shorthand is expanded to a GitHub HTTPS URL (full `https://`/`git@` URLs are used verbatim, so non-GitHub hosts work). With no `Branch:`, the repo's actual default branch is read from `origin/HEAD` after clone (fallback `MAIN_BRANCH`).
+2. **`repos.json` registry (legacy / fallback)** — `repos.json` (gitignored) maps a project **name** → `{ url, main_branch }`. `repo.Resolve` looks the project up. Still fully supported; needed for repos you'd rather not declare in Linear.
+3. **`REPO_PATH`** — single-repo fallback when neither of the above matches; otherwise the ticket is skipped with a Linear comment.
+
+Both paths clone on demand into `~/.nightshift-repos/<slug>` (lock-guarded against concurrent clone races via `mkdir(2)`) and return the local path + base branch. The **auto-iterate** path resolves the same way: `matchPRtoProject` hits `repos.json` first, else `ResolveDirect` clones straight from the PR's own `owner/name` — so project-declared repos iterate too.
+
+The project-directive route means **`repos.json` is optional**: declare each project's repo in Linear and you can drop the file entirely.
 
 The registry can also be supplied inline via the **`REPOS_JSON`** env var (same shape as `repos.json`) — it takes precedence over `REPOS_FILE` and exists for PaaS deploys (Fly/Render/Railway) that can't mount a file. `config.ParseRepoRegistry` parses it; `config.Load` chooses env-vs-file.
 
@@ -65,8 +71,8 @@ The required-CLI set is backend-aware: `git` + `gh` + the selected agent CLI (`c
 |---------|---------|
 | `cmd/nightshift` | Entry point + subcommand dispatch (`run` / `setup` / `cleanup` / `doctor` / `version`); startup banner; `--help` |
 | `internal/config` | `.env` parser, `repos.json` loader, validated `Config`, `DefaultConfigDir` (`~/.nightshift/`) |
-| `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `FetchLabeledIssues` (both fetch each issue's `comments` so human clarifications reach the agent — see `Issue.ClarificationComments`, which filters out Nightshift's own automated notices), `ResolveLabelID`, `RemoveLabel`, `SetState`, `Comment`; read queries for Telegram — `ProjectIssueCounts`, `ListProjectIssues`, `SearchIssues`, `GetIssueByIdentifier` |
-| `internal/repo` | Project → repo slug + registry; clone-on-demand; worktree create/cleanup; `BranchName`; `CreateWorktree` (from main) + `ResumeWorktree` (pull existing remote branch) |
+| `internal/linear` | Linear GraphQL client: `ResolveStateIDs`, `FetchTriggerIssues`, `FetchLabeledIssues` (both fetch each issue's `comments` so human clarifications reach the agent — see `Issue.ClarificationComments`, which filters out Nightshift's own automated notices; project descriptions are fetched too, parsed by `Project.RepoDirective` for `Repo:`/`Branch:` routing), `ResolveLabelID`, `RemoveLabel`, `SetState`, `Comment`; read queries for Telegram — `ProjectIssueCounts`, `ListProjectIssues`, `SearchIssues`, `GetIssueByIdentifier` |
+| `internal/repo` | Repo resolution: `Resolve` (project name → `repos.json` entry) + `ResolveDirect` (explicit `owner/name`/URL from a Linear project's `Repo:` directive or a PR's own repo, with `origin/HEAD` default-branch detection); clone-on-demand; worktree create/cleanup; `BranchName`; `CreateWorktree` (from main) + `ResumeWorktree` (pull existing remote branch) |
 | `internal/agent` | Pluggable coding-agent backends behind the `Backend` interface (`agent.New` selects `claude`/`codex` from `AGENT_BACKEND`); shared `exec` plumbing with timeout; per-backend invocation flags + rate-limit parsing (`claude.go` / `codex.go`); backend-agnostic implement-prompt builder, `BuildFixPrompt`, `BlockedLine`, and log_offset parsing |
 | `internal/review` | Optional Gemini second-model review gate |
 | `internal/notify` | Optional Telegram notifier (fire-and-forget) |

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -81,7 +81,7 @@ func TestFetchTriggerIssues_ParsesProject(t *testing.T) {
 		variables  map[string]any
 	}{
 		authHeader: "test-key",
-		query:      "project { name }",
+		query:      "project { name description }",
 		variables:  map[string]any{"state": "Next"},
 	}, resp)
 

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -77,7 +77,7 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 func (c *Client) FetchTriggerIssues(ctx context.Context, stateName string) ([]Issue, error) {
 	query := `query($state: String!) {
 	  teams { nodes { issues(filter: { state: { name: { eq: $state } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name } comments(last: 50) { nodes { body user { name } } } }
+	    nodes { id identifier title description url project { name description } comments(last: 50) { nodes { body user { name } } } }
 	  } } }
 	}`
 
@@ -318,7 +318,7 @@ func (c *Client) SearchIssues(ctx context.Context, term string, limit int) ([]Is
 func (c *Client) FetchLabeledIssues(ctx context.Context, labelName string) ([]Issue, error) {
 	query := `query($label: String!) {
 	  teams { nodes { issues(filter: { labels: { name: { eq: $label } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name } comments(last: 50) { nodes { body user { name } } } }
+	    nodes { id identifier title description url project { name description } comments(last: 50) { nodes { body user { name } } } }
 	  } } }
 	}`
 

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -5,13 +5,41 @@ package linear
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
-// Project is the Linear project a ticket belongs to. Nightshift uses the name
-// to look the target repo up in repos.json.
+// Project is the Linear project a ticket belongs to. Nightshift routes the
+// ticket to a repo either by a "Repo:" directive in Description (preferred) or,
+// failing that, by looking Name up in repos.json.
 type Project struct {
-	Name string `json:"name"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+var (
+	repoDirectiveRe   = regexp.MustCompile(`(?im)^\s*Repo:\s*(.+?)\s*$`)
+	branchDirectiveRe = regexp.MustCompile(`(?im)^\s*Branch:\s*(.+?)\s*$`)
+)
+
+// RepoDirective parses a "Repo: <owner/name | url>" line (and an optional
+// "Branch: <name>" line) from the project description, letting a Linear project
+// declare its target repo without a repos.json entry. Returns ("","") when no
+// Repo line is present. branch is ignored unless a repo is also given.
+func (p *Project) RepoDirective() (repo, branch string) {
+	if p == nil {
+		return "", ""
+	}
+	if m := repoDirectiveRe.FindStringSubmatch(p.Description); m != nil {
+		repo = strings.TrimSpace(m[1])
+	}
+	if repo == "" {
+		return "", ""
+	}
+	if m := branchDirectiveRe.FindStringSubmatch(p.Description); m != nil {
+		branch = strings.TrimSpace(m[1])
+	}
+	return repo, branch
 }
 
 // WorkflowState is the column a ticket sits in (e.g. "Next", "In Review") and

--- a/internal/linear/types_test.go
+++ b/internal/linear/types_test.go
@@ -41,3 +41,34 @@ func TestClarificationComments_EmptyWhenNoComments(t *testing.T) {
 		t.Errorf("expected no comments, got %#v", got)
 	}
 }
+
+func TestProjectRepoDirective(t *testing.T) {
+	cases := []struct {
+		name             string
+		desc             string
+		wantRepo, wantBr string
+	}{
+		{"none", "Just a normal project summary.", "", ""},
+		{"repo only", "Autonomous agent.\n\nRepo: ahmadAlMezaal/nightshift-site", "ahmadAlMezaal/nightshift-site", ""},
+		{"repo and branch", "Repo: owner/site\nBranch: staging", "owner/site", "staging"},
+		{"full https url", "Repo: https://github.com/owner/site", "https://github.com/owner/site", ""},
+		{"branch alone ignored", "Branch: main\nNo repo here.", "", ""},
+		{"case-insensitive + spaces", "repo:   owner/x  \nBRANCH:  dev ", "owner/x", "dev"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := &Project{Name: "P", Description: c.desc}
+			r, b := p.RepoDirective()
+			if r != c.wantRepo || b != c.wantBr {
+				t.Errorf("got (%q,%q), want (%q,%q)", r, b, c.wantRepo, c.wantBr)
+			}
+		})
+	}
+}
+
+func TestProjectRepoDirective_NilSafe(t *testing.T) {
+	var p *Project
+	if r, b := p.RepoDirective(); r != "" || b != "" {
+		t.Errorf("nil project: got (%q,%q)", r, b)
+	}
+}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -182,16 +182,26 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	// same feedback, re-runs, and fails again — an infinite retry loop. The
 	// only exceptions are infra failures (timeout / rate-limit), handled
 	// further down, which intentionally retry.
-	project, err := p.matchPRtoProject(ch.PR.URL)
-	if err != nil {
-		logger.Error("could not match PR to a registered project", "err", err)
-		p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
-		return
-	}
-
-	resolved, err := p.resolver.Resolve(ctx, project)
-	if err != nil {
-		logger.Error("repo resolve failed", "err", err)
+	// Resolve the repo this PR lives in. Prefer a repos.json entry (keeps the
+	// registered main-branch); otherwise clone the PR's repo directly by its
+	// owner/name — so project-declared repos (not in repos.json) iterate too.
+	var resolved repo.Resolved
+	if project, err := p.matchPRtoProject(ch.PR.URL); err == nil {
+		resolved, err = p.resolver.Resolve(ctx, project)
+		if err != nil {
+			logger.Error("repo resolve failed", "err", err)
+			p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
+			return
+		}
+	} else if ownerRepo, e2 := prRepoOwnerRepo(ch.PR.URL); e2 == nil {
+		resolved, e2 = p.resolver.ResolveDirect(ctx, ownerRepo, "")
+		if e2 != nil {
+			logger.Error("repo resolve (direct) failed", "err", e2)
+			p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
+			return
+		}
+	} else {
+		logger.Error("could not resolve PR repo", "match_err", err, "url_err", e2)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
 		return
 	}

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -37,8 +37,19 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 		logger.Warn("could not write attempt header", "err", err)
 	}
 
-	// ── Resolve target repo from the ticket's Linear project ─────────────────
-	resolved, err := p.resolver.Resolve(ctx, issue.ProjectName())
+	// ── Resolve target repo ──────────────────────────────────────────────────
+	// A "Repo:" directive on the ticket's Linear project wins (no repos.json
+	// needed); otherwise fall back to the project→repos.json mapping.
+	var (
+		resolved repo.Resolved
+		err      error
+	)
+	if ref, branch := issue.Project.RepoDirective(); ref != "" {
+		logger.Info("repo from Linear project directive", "repo", ref, "branch", branch)
+		resolved, err = p.resolver.ResolveDirect(ctx, ref, branch)
+	} else {
+		resolved, err = p.resolver.Resolve(ctx, issue.ProjectName())
+	}
 	if err != nil {
 		logger.Error("repo resolution failed", "err", err)
 
@@ -50,7 +61,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 			// the agent down. Only one comment + notification is posted.
 			p.skipPermanently(id)
 			if cerr := p.linear.Comment(ctx, issue.ID,
-				fmt.Sprintf("❌ **Nightshift: No repo for this ticket**\n\n%s\n\nMap this ticket's project in `repos.json` (or run `./nightshift setup`), then restart Nightshift and move it back to **%s**.",
+				fmt.Sprintf("❌ **Nightshift: No repo for this ticket**\n\n%s\n\nAdd a `Repo: owner/name` line to this ticket's **Linear project description** (optionally a `Branch:` line), or map the project in `repos.json`. Then move it back to **%s**.",
 					err.Error(), p.cfg.TriggerState)); cerr != nil {
 				slog.Warn("linear Comment failed", "issue_id", issue.ID, "err", cerr)
 			}

--- a/internal/repo/resolve.go
+++ b/internal/repo/resolve.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ahmadAlMezaal/nightshift/internal/config"
+	"github.com/ahmadAlMezaal/nightshift/internal/github"
 )
 
 // NonTransientError signals a failure that is deterministic and cannot
@@ -92,6 +94,60 @@ func (r *Resolver) Resolve(ctx context.Context, project string) (Resolved, error
 	return Resolved{}, &NonTransientError{Err: fmt.Errorf(
 		"no repo is mapped for the project %q in repos.json, and no REPO_PATH fallback is configured",
 		project)}
+}
+
+// ResolveDirect locates (cloning on demand) a repo named explicitly — by a
+// Linear project's "Repo:" directive or, in the auto-iterate path, by a PR's own
+// repository — bypassing the repos.json registry entirely. ref may be an
+// "owner/name" shorthand (assumed GitHub) or a full https/ssh git URL. branch
+// overrides the base branch; when empty, the repo's actual default branch (read
+// after clone) is used, falling back to MainBranch.
+func (r *Resolver) ResolveDirect(ctx context.Context, ref, branch string) (Resolved, error) {
+	ownerRepo, err := github.ExtractOwnerRepo(ref)
+	if err != nil {
+		return Resolved{}, &NonTransientError{Err: fmt.Errorf(
+			"%q is not a valid owner/name or git URL: %w", ref, err)}
+	}
+
+	url := strings.TrimSpace(ref)
+	if !strings.Contains(url, "://") && !strings.HasPrefix(url, "git@") {
+		url = "https://github.com/" + ownerRepo
+	}
+
+	dest := filepath.Join(r.ReposBase, Slug(ownerRepo))
+	if !isGitRepo(dest) {
+		if err := os.MkdirAll(r.ReposBase, 0o755); err != nil {
+			return Resolved{}, fmt.Errorf("mkdir %s: %w", r.ReposBase, err)
+		}
+		if err := checkRemoteAccess(ctx, url); err != nil {
+			return Resolved{}, fmt.Errorf(
+				"cannot access %q — the host running Nightshift needs git auth for it "+
+					"(an SSH key, or `gh auth login` for HTTPS URLs): %w", url, err)
+		}
+		if err := ensureCloned(ctx, url, dest); err != nil {
+			return Resolved{}, fmt.Errorf("clone %s: %w", url, err)
+		}
+	}
+
+	if branch == "" {
+		branch = defaultBranch(ctx, dest, r.MainBranch)
+	}
+	return Resolved{Path: dest, MainBranch: branch}, nil
+}
+
+// defaultBranch reads the repo's default branch from origin/HEAD (set by clone),
+// falling back to fallback when it can't be determined.
+func defaultBranch(ctx context.Context, dir, fallback string) string {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return fallback
+	}
+	ref := strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/")
+	if ref == "" {
+		return fallback
+	}
+	return ref
 }
 
 // checkRemoteAccess runs `git ls-remote` to verify the host can reach the

--- a/internal/repo/resolve_test.go
+++ b/internal/repo/resolve_test.go
@@ -233,3 +233,54 @@ func TestAllRepoPaths_DedupesAndFilters(t *testing.T) {
 		t.Errorf("second path: got %q, want %q", paths[1], fallback)
 	}
 }
+
+func TestResolveDirect_AlreadyClonedUsesExplicitBranch(t *testing.T) {
+	base := t.TempDir()
+	// Pre-create the slug dir as a "clone" so ResolveDirect skips the network.
+	dest := filepath.Join(base, Slug("owner/site-repo"))
+	if err := os.MkdirAll(filepath.Join(dest, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := &Resolver{ReposBase: base, MainBranch: "main"}
+
+	res, err := r.ResolveDirect(context.Background(), "owner/site-repo", "staging")
+	if err != nil {
+		t.Fatalf("ResolveDirect: %v", err)
+	}
+	if res.Path != dest {
+		t.Errorf("Path: got %q, want %q", res.Path, dest)
+	}
+	if res.MainBranch != "staging" {
+		t.Errorf("explicit branch should win: got %q", res.MainBranch)
+	}
+}
+
+func TestResolveDirect_NoBranchFallsBackToMainBranch(t *testing.T) {
+	base := t.TempDir()
+	dest := filepath.Join(base, Slug("owner/site-repo"))
+	if err := os.MkdirAll(filepath.Join(dest, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := &Resolver{ReposBase: base, MainBranch: "main"}
+
+	// No branch given and the fake repo has no origin/HEAD → fall back.
+	res, err := r.ResolveDirect(context.Background(), "owner/site-repo", "")
+	if err != nil {
+		t.Fatalf("ResolveDirect: %v", err)
+	}
+	if res.MainBranch != "main" {
+		t.Errorf("branch fallback: got %q, want main", res.MainBranch)
+	}
+}
+
+func TestResolveDirect_InvalidRefIsNonTransient(t *testing.T) {
+	r := &Resolver{ReposBase: t.TempDir(), MainBranch: "main"}
+	_, err := r.ResolveDirect(context.Background(), "this is not a repo!", "")
+	if err == nil {
+		t.Fatal("expected an error for an invalid ref")
+	}
+	var nte *NonTransientError
+	if !errors.As(err, &nte) {
+		t.Fatalf("want NonTransientError, got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
## Why

Today the target repo is keyed on the ticket's **Linear project name → `repos.json` entry**. That forces one project per repo *and* a `repos.json` file you have to keep in sync. This came up trying to dispatch a website ticket (ENG-187) to `nightshift-site` while it lives in the same `Nightshift` project as the Go code — there was no way to do it without a separate project + registry edit.

## What

A Linear **project** can now declare its repo in its own **description**:

```
Repo: ahmadAlMezaal/nightshift-site
Branch: main          ← optional
```

Every ticket in that project routes there — **no `repos.json` needed.** `owner/name` is expanded to a GitHub HTTPS URL; full `https://`/`git@` URLs are used verbatim (non-GitHub hosts work). With no `Branch:`, the repo's real default branch is read from `origin/HEAD` after clone.

### Resolution order (dispatch)
1. **Project `Repo:` directive** (`ResolveDirect`) — no registry needed.
2. **`repos.json`** registry by project name (legacy, still fully supported).
3. **`REPO_PATH`** fallback, else skip with a Linear comment.

### Auto-iterate path
`matchPRtoProject` tries `repos.json` first; if the repo isn't registered it falls back to `ResolveDirect` from the **PR's own `owner/name`** — so project-declared repos iterate on review/CI feedback too.

## `repos.json` is now optional, not removed
It still handles cases the directive can't (SSH/GitLab, repos you'd rather not declare in Linear, non-default branches). Migrate projects to the directive at your pace, then delete the file if you want.

## Changes
- `linear`: `Project.Description` + `Project.RepoDirective`; trigger queries fetch `project { name description }`.
- `repo`: `ResolveDirect` (explicit ref → clone-on-demand, reusing the clone-lock) + `defaultBranch` (origin/HEAD detection).
- `pipeline`: dispatch + auto-iterate wired to prefer the directive / PR repo.
- Docs: CLAUDE.md multi-repo section + package map.

## Tests
- `RepoDirective` parsing (repo-only, repo+branch, full URL, branch-alone ignored, case-insensitive, nil-safe).
- `ResolveDirect` (explicit branch wins; no-branch → `MAIN_BRANCH` fallback; invalid ref → `NonTransientError`).
- Updated the trigger-query assertion. Full suite + `go vet` green.

## Follow-ups (not in this PR)
- README / `nightshift setup` wizard copy still describe `repos.json` as the only path — worth a docs pass.
- Could detect the default branch for the registry path too (currently registry uses its configured `main_branch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)