### PR TITLE
ENG-194: retire docs/ stubs + add AGENTS.md for Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Nightshift
 
+> `AGENTS.md` at the repo root is a symlink to this file, so the Codex backend (`AGENT_BACKEND=codex`) reads the same project guidance Claude does. Edit `CLAUDE.md`; `AGENTS.md` follows.
+
 Autonomous Linear-to-PR agent in Go. Polls Linear for tickets in a trigger state or with a trigger label, dispatches Claude Code to implement them, creates PRs, and moves tickets to review. Optionally (`AUTO_ITERATE_PRS=true`) it also watches the PRs it opened and pushes follow-up commits in response to review feedback and CI failures.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ If the agent gets stuck or makes no changes, the ticket is moved back to **Next*
 
 ## Writing Good Tickets
 
-Nightshift is only as good as your tickets. See [docs/WRITING-GOOD-TICKETS.md](docs/WRITING-GOOD-TICKETS.md) for a full guide.
+Nightshift is only as good as your tickets. See the [`writing-good-tickets` skill](.claude/skills/writing-good-tickets/SKILL.md) for a full guide.
 
 **The one-line rule:** the agent needs to know *what* to change, *where* to change it, and *how you'll know it's done*.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,6 +1,0 @@
-# Troubleshooting Nightshift
-
-The operational troubleshooting runbook now lives in the Claude Code skill at [`.claude/skills/troubleshooting/SKILL.md`](../.claude/skills/troubleshooting/SKILL.md).
-
-Use that skill when tickets are not picked up, agent runs fail, PR creation breaks, review/CI iteration stalls, or stale worktrees and branches need cleanup.
-

--- a/docs/WRITING-GOOD-TICKETS.md
+++ b/docs/WRITING-GOOD-TICKETS.md
@@ -1,6 +1,0 @@
-# Writing Good Tickets
-
-The repeatable Nightshift ticket-writing playbook now lives in the Claude Code skill at [`.claude/skills/writing-good-tickets/SKILL.md`](../.claude/skills/writing-good-tickets/SKILL.md).
-
-Use that skill when drafting or reviewing tickets for autonomous implementation. The short rule remains: say what to change, where to change it, how to verify it, and what is out of scope.
-


### PR DESCRIPTION
Closes the concrete parts of **ENG-194**.

## Changes
- **Removed `docs/` stubs** — `docs/TROUBLESHOOTING.md` and `docs/WRITING-GOOD-TICKETS.md` were just 2-line pointers to the `.claude/skills/*` versions (the source of truth since ENG-185). `docs/` is now gone.
- **Fixed the one inbound link** — README "Writing Good Tickets" now points at the [`writing-good-tickets` skill](.claude/skills/writing-good-tickets/SKILL.md) (it was the only repo-wide reference to either stub).
- **Added `AGENTS.md` → `CLAUDE.md` symlink** (mode `120000`) so the **Codex** backend (`AGENT_BACKEND=codex`) reads the same project guidance Claude gets from `CLAUDE.md`. Single source of truth — edit `CLAUDE.md`, `AGENTS.md` follows. Noted at the top of `CLAUDE.md`.

## Skills audit (the "evaluate more skills" part)
The existing skills already cover the repeatable knowledge:
| Topic | Covered by |
|-------|-----------|
| Releasing (GoReleaser `v*` flow) | `build-and-release` |
| Setup / deploy (Pi, Docker, cloud) | `setup-and-config` |
| Log reading / failure diagnosis | `troubleshooting` |
| Ticket writing | `writing-good-tickets` |

**Conclusion:** no new skill warranted right now. A dedicated *observability* skill (poll heartbeat, `nightshift logs`, PR-watch lines) is the only plausible gap and can fold into `troubleshooting` if it grows — left as a note, not built.

No Go changes; `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)