### PR TITLE
fix: address ENG-195 review comments (follow-up to #109)

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -104,15 +104,19 @@ func Install(force, start bool) error {
 			fmt.Println("✓ Enabled and started nightshift.service")
 		}
 		// Lingering lets the user service keep running after logout / across reboots.
-		// user.Current() is more reliable than $USER, which can be empty in
-		// non-interactive shells / systemd / cron contexts.
+		// Prefer user.Current() (reliable in systemd/cron), fall back to $USER, and
+		// warn if neither yields a username (e.g. cgo-disabled minimal containers).
 		if loginctl, lerr := exec.LookPath("loginctl"); lerr == nil {
+			username := os.Getenv("USER")
 			if u, uerr := user.Current(); uerr == nil {
-				if out, err := exec.Command(loginctl, "enable-linger", u.Username).CombinedOutput(); err != nil {
-					fmt.Fprintf(os.Stderr, "⚠️  could not enable lingering (%v): %s\n", err, out)
-				} else {
-					fmt.Println("✓ Enabled lingering (service survives logout)")
-				}
+				username = u.Username
+			}
+			if username == "" {
+				fmt.Fprintln(os.Stderr, "⚠️  could not enable lingering: username is empty")
+			} else if out, err := exec.Command(loginctl, "enable-linger", username).CombinedOutput(); err != nil {
+				fmt.Fprintf(os.Stderr, "⚠️  could not enable lingering (%v): %s\n", err, out)
+			} else {
+				fmt.Println("✓ Enabled lingering (service survives logout)")
 			}
 		}
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 )
 
@@ -103,12 +104,15 @@ func Install(force, start bool) error {
 			fmt.Println("✓ Enabled and started nightshift.service")
 		}
 		// Lingering lets the user service keep running after logout / across reboots.
+		// user.Current() is more reliable than $USER, which can be empty in
+		// non-interactive shells / systemd / cron contexts.
 		if loginctl, lerr := exec.LookPath("loginctl"); lerr == nil {
-			user := os.Getenv("USER")
-			if out, err := exec.Command(loginctl, "enable-linger", user).CombinedOutput(); err != nil {
-				fmt.Fprintf(os.Stderr, "⚠️  could not enable lingering (%v): %s\n", err, out)
-			} else {
-				fmt.Println("✓ Enabled lingering (service survives logout)")
+			if u, uerr := user.Current(); uerr == nil {
+				if out, err := exec.Command(loginctl, "enable-linger", u.Username).CombinedOutput(); err != nil {
+					fmt.Fprintf(os.Stderr, "⚠️  could not enable lingering (%v): %s\n", err, out)
+				} else {
+					fmt.Println("✓ Enabled lingering (service survives logout)")
+				}
 			}
 		}
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,8 +80,11 @@ tar -xzf "$TMP/$ASSET" -C "$TMP" nightshift \
 	|| err "could not extract nightshift from $ASSET"
 
 mkdir -p "$INSTALL_DIR"
+# Unlink any existing binary first so reinstalling over a running nightshift
+# doesn't fail with "text file busy" (applies to both install and the cp fallback).
+rm -f "$INSTALL_DIR/nightshift" 2>/dev/null
 install -m 0755 "$TMP/nightshift" "$INSTALL_DIR/nightshift" 2>/dev/null \
-	|| { rm -f "$INSTALL_DIR/nightshift" 2>/dev/null; cp "$TMP/nightshift" "$INSTALL_DIR/nightshift" && chmod 0755 "$INSTALL_DIR/nightshift"; }
+	|| { cp "$TMP/nightshift" "$INSTALL_DIR/nightshift" && chmod 0755 "$INSTALL_DIR/nightshift"; }
 
 echo "✓ Installed nightshift to $INSTALL_DIR/nightshift"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,7 @@ curl -fsSL "$BASE/checksums.txt" -o "$TMP/checksums.txt" \
 	|| err "download failed: $BASE/checksums.txt"
 
 # --- verify sha256 ----------------------------------------------------------
-want="$(grep " $ASSET\$" "$TMP/checksums.txt" | awk '{print $1}')"
+want="$(awk -v a="$ASSET" '$2 == a { print $1 }' "$TMP/checksums.txt")"
 [ -n "$want" ] || err "no checksum for $ASSET in checksums.txt"
 
 if command -v sha256sum >/dev/null 2>&1; then
@@ -81,7 +81,7 @@ tar -xzf "$TMP/$ASSET" -C "$TMP" nightshift \
 
 mkdir -p "$INSTALL_DIR"
 install -m 0755 "$TMP/nightshift" "$INSTALL_DIR/nightshift" 2>/dev/null \
-	|| { cp "$TMP/nightshift" "$INSTALL_DIR/nightshift" && chmod 0755 "$INSTALL_DIR/nightshift"; }
+	|| { rm -f "$INSTALL_DIR/nightshift" 2>/dev/null; cp "$TMP/nightshift" "$INSTALL_DIR/nightshift" && chmod 0755 "$INSTALL_DIR/nightshift"; }
 
 echo "✓ Installed nightshift to $INSTALL_DIR/nightshift"
 


### PR DESCRIPTION
Follow-up to **#109** (merged before its review comments were resolved — my miss). Applies all four Gemini review comments:

1. **`install-service` user resolution** — `enable-linger` now uses `user.Current().Username` instead of `$USER`, which can be empty in non-interactive shells / systemd / cron. (+ `os/user` import.)
2. **install.sh checksum match** — `awk '$2 == asset'` exact match instead of `grep " $ASSET\$"` (the asset name's `.`s are regex wildcards) + drops the redundant `grep | awk`.
3. **install.sh binary install** — `rm -f` the existing binary before the `cp` fallback so reinstalling over a running `nightshift` doesn't fail with "text file busy".

Verified: `go build`/`go test`/`go vet`/`gofmt` clean; `sh -n scripts/install.sh` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)