### PR TITLE
docs: shell-aware PATH hint in install.sh + README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ nightshift setup  # interactive: backend, Linear key, repos → writes .env
 nightshift        # start polling — or run it as a service (see below)
 ```
 
+> **`nightshift: command not found`?** The installer drops the binary in `~/.local/bin`; if that's not on your `PATH`, add it (the installer prints the exact line for your shell — `~/.bashrc`/`~/.zshrc`) or just open a new shell. This is normal for any user-local install (`go install`, `pip --user`, rustup, …) — not Nightshift-specific.
+
 Prefer the Go toolchain? `go install github.com/ahmadAlMezaal/nightshift/cmd/nightshift@latest` works too.
 
 Tell each Linear **project** which repo it maps to by adding one line to the project's description:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,17 +92,24 @@ echo "✓ Installed nightshift to $INSTALL_DIR/nightshift"
 case ":$PATH:" in
 	*":$INSTALL_DIR:"*) ;;
 	*)
-		# Point at the rc file for the user's login shell so the hint is actionable.
-		case "${SHELL##*/}" in
-			zsh)  rc="$HOME/.zshrc" ;;
-			bash) rc="$HOME/.bashrc" ;;
-			*)    rc="$HOME/.profile" ;;
-		esac
 		echo
 		echo "⚠️  $INSTALL_DIR is not on your PATH yet. Add it once:"
-		echo "    echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> $rc   # persist for new shells"
-		echo "    export PATH=\"$INSTALL_DIR:\$PATH\"                 # …and use it in this shell now"
-		echo "  (Debian/Raspberry Pi OS: opening a fresh login shell also picks it up automatically.)"
+		# fish has its own syntax and doesn't read POSIX profile/rc files.
+		case "${SHELL##*/}" in
+			fish)
+				echo "    fish_add_path $INSTALL_DIR"
+				;;
+			*)
+				case "${SHELL##*/}" in
+					zsh)  rc="$HOME/.zshrc" ;;
+					bash) rc="$HOME/.bashrc" ;;
+					*)    rc="$HOME/.profile" ;;
+				esac
+				echo "    echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> $rc   # persist for new shells"
+				echo "    export PATH=\"$INSTALL_DIR:\$PATH\"                 # …and use it in this shell now"
+				echo "  (Debian/Raspberry Pi OS: opening a fresh login shell also picks it up automatically.)"
+				;;
+		esac
 		;;
 esac
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,9 +92,17 @@ echo "✓ Installed nightshift to $INSTALL_DIR/nightshift"
 case ":$PATH:" in
 	*":$INSTALL_DIR:"*) ;;
 	*)
+		# Point at the rc file for the user's login shell so the hint is actionable.
+		case "${SHELL##*/}" in
+			zsh)  rc="$HOME/.zshrc" ;;
+			bash) rc="$HOME/.bashrc" ;;
+			*)    rc="$HOME/.profile" ;;
+		esac
 		echo
-		echo "⚠️  $INSTALL_DIR is not on your PATH. Add it, e.g.:"
-		echo "    echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.profile && . ~/.profile"
+		echo "⚠️  $INSTALL_DIR is not on your PATH yet. Add it once:"
+		echo "    echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> $rc   # persist for new shells"
+		echo "    export PATH=\"$INSTALL_DIR:\$PATH\"                 # …and use it in this shell now"
+		echo "  (Debian/Raspberry Pi OS: opening a fresh login shell also picks it up automatically.)"
 		;;
 esac
 


### PR DESCRIPTION
Smooths the exact rough edge hit during a real Pi install: `nightshift: command not found` because `~/.local/bin` wasn't on PATH yet.

- **install.sh** — the PATH hint is now **shell-aware**: it suggests `~/.zshrc` / `~/.bashrc` / `~/.profile` based on `$SHELL`, prints both the persist line *and* an immediate `export` for the current shell (so you're not stuck after editing the rc), and notes that Debian/Pi OS picks it up on a fresh login.
- **README** — adds a short "command not found? add `~/.local/bin` to PATH" note under the install one-liner, framing it as standard for any user-local install (`go install`, `pip --user`, rustup…), not Nightshift-specific.

Docs/script only — no Go changes. `sh -n scripts/install.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)