### PR TITLE
fix: directive-only setup must not fail startup validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,8 +190,11 @@ func Load(scriptDir string) (*Config, error) {
 	return cfg, nil
 }
 
-// Validate checks that required fields are set and that there's at least one
-// usable repo source (registry or REPO_PATH fallback).
+// Validate checks that required fields are set. It does NOT require a repos.json
+// registry or REPO_PATH: repos are resolved per-ticket — primarily from each
+// Linear project's "Repo:" directive, with the registry/REPO_PATH as optional
+// fallbacks — so a directive-only setup is valid, and a ticket that resolves to
+// nothing is skipped gracefully with a Linear comment (not a startup failure).
 func (c *Config) Validate() error {
 	var errs []string
 
@@ -224,11 +227,9 @@ func (c *Config) Validate() error {
 		errs = append(errs, fmt.Sprintf("REPO_PATH (%s) is not a git repository", c.RepoPath))
 	}
 
-	if c.Registry == nil && c.RepoPath == "" {
-		errs = append(errs,
-			fmt.Sprintf("no repos configured — run ./nightshift setup, create %s, or set REPO_PATH in .env",
-				c.ReposFile))
-	}
+	// No registry + no REPO_PATH is fine: repos come from Linear project
+	// "Repo:" directives at dispatch time. An unresolvable ticket is skipped
+	// per-ticket with a Linear comment, so this isn't a startup-fatal condition.
 
 	if len(errs) > 0 {
 		return fmt.Errorf("invalid configuration:\n  - %s", strings.Join(errs, "\n  - "))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -140,18 +140,19 @@ REPO_PATH="`+initBareRepo(t)+`"
 	}
 }
 
-func TestValidate_RequiresAtLeastOneRepoSource(t *testing.T) {
+func TestValidate_AllowsDirectiveOnlySetup(t *testing.T) {
 	isolateEnv(t)
 
+	// No repos.json and no REPO_PATH is valid: repos are routed per-ticket from
+	// each Linear project's "Repo:" directive. Validate must not fail on this.
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"`)
 	cfg, err := Load(dir)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	err = cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "no repos configured") {
-		t.Fatalf("expected no-repos error, got %v", err)
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("directive-only setup should validate, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Bug
A clean, directive-only install (no `repos.json`, no `REPO_PATH` — repos declared via each Linear project's `Repo:` directive) **crash-loops on startup**:
```
❌ invalid configuration:
  - no repos configured — run ./nightshift setup, create …/repos.json, or set REPO_PATH …
```
`config.Validate()` still treated "no registry AND no REPO_PATH" as fatal. We fixed `nightshift doctor` to accept directive-only setups in #101, but **missed the runtime validator** — so the recommended config can't boot.

## Fix
Remove that fatal check. Repos are resolved **per-ticket** (directive → `repos.json` → `REPO_PATH`), and a ticket that resolves to nothing is already skipped gracefully with a Linear comment — so an empty registry is not a startup-fatal condition. Updated the doc comment and flipped the test (`TestValidate_AllowsDirectiveOnlySetup`) to assert directive-only validates.

`go build`/`test`/`vet`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)