### PR TITLE
fix: read project Repo: directive from content (the markdown body), not description (ENG-200)

### DIFF
--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -81,7 +81,7 @@ func TestFetchTriggerIssues_ParsesProject(t *testing.T) {
 		variables  map[string]any
 	}{
 		authHeader: "test-key",
-		query:      "project { name description }",
+		query:      "project { name description content }",
 		variables:  map[string]any{"state": "Next"},
 	}, resp)
 

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -77,7 +77,7 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 func (c *Client) FetchTriggerIssues(ctx context.Context, stateName string) ([]Issue, error) {
 	query := `query($state: String!) {
 	  teams { nodes { issues(filter: { state: { name: { eq: $state } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name description } comments(last: 50) { nodes { body user { name } } } }
+	    nodes { id identifier title description url project { name description content } comments(last: 50) { nodes { body user { name } } } }
 	  } } }
 	}`
 
@@ -318,7 +318,7 @@ func (c *Client) SearchIssues(ctx context.Context, term string, limit int) ([]Is
 func (c *Client) FetchLabeledIssues(ctx context.Context, labelName string) ([]Issue, error) {
 	query := `query($label: String!) {
 	  teams { nodes { issues(filter: { labels: { name: { eq: $label } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name description } comments(last: 50) { nodes { body user { name } } } }
+	    nodes { id identifier title description url project { name description content } comments(last: 50) { nodes { body user { name } } } }
 	  } } }
 	}`
 

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -13,8 +13,13 @@ import (
 // ticket to a repo either by a "Repo:" directive in Description (preferred) or,
 // failing that, by looking Name up in repos.json.
 type Project struct {
-	Name        string `json:"name"`
+	Name string `json:"name"`
+	// Description is Linear's SHORT project description (GraphQL `description`).
 	Description string `json:"description,omitempty"`
+	// Content is the project's markdown BODY (GraphQL `content`) — this is where
+	// a human writes the multi-line `Repo:` directive, so it's the field
+	// RepoDirective reads first.
+	Content string `json:"content,omitempty"`
 }
 
 var (
@@ -30,16 +35,23 @@ func (p *Project) RepoDirective() (repo, branch string) {
 	if p == nil {
 		return "", ""
 	}
-	if m := repoDirectiveRe.FindStringSubmatch(p.Description); m != nil {
+	// The directive lives in the project's markdown body (GraphQL `content`);
+	// fall back to the short `description` in case it was written there instead.
+	for _, src := range []string{p.Content, p.Description} {
+		m := repoDirectiveRe.FindStringSubmatch(src)
+		if m == nil {
+			continue
+		}
 		repo = strings.TrimSpace(m[1])
+		if repo == "" {
+			continue
+		}
+		if bm := branchDirectiveRe.FindStringSubmatch(src); bm != nil {
+			branch = strings.TrimSpace(bm[1])
+		}
+		return repo, branch
 	}
-	if repo == "" {
-		return "", ""
-	}
-	if m := branchDirectiveRe.FindStringSubmatch(p.Description); m != nil {
-		branch = strings.TrimSpace(m[1])
-	}
-	return repo, branch
+	return "", ""
 }
 
 // WorkflowState is the column a ticket sits in (e.g. "Next", "In Review") and

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -31,7 +31,7 @@ var (
 // "Branch: <name>" line) from the project description, letting a Linear project
 // declare its target repo without a repos.json entry. Returns ("","") when no
 // Repo line is present. branch is ignored unless a repo is also given.
-func (p *Project) RepoDirective() (repo, branch string) {
+func (p *Project) RepoDirective() (string, string) {
 	if p == nil {
 		return "", ""
 	}
@@ -42,14 +42,15 @@ func (p *Project) RepoDirective() (repo, branch string) {
 		if m == nil {
 			continue
 		}
-		repo = strings.TrimSpace(m[1])
-		if repo == "" {
+		r := strings.TrimSpace(m[1])
+		if r == "" {
 			continue
 		}
+		var b string
 		if bm := branchDirectiveRe.FindStringSubmatch(src); bm != nil {
-			branch = strings.TrimSpace(bm[1])
+			b = strings.TrimSpace(bm[1])
 		}
-		return repo, branch
+		return r, b
 	}
 	return "", ""
 }

--- a/internal/linear/types_test.go
+++ b/internal/linear/types_test.go
@@ -45,19 +45,25 @@ func TestClarificationComments_EmptyWhenNoComments(t *testing.T) {
 func TestProjectRepoDirective(t *testing.T) {
 	cases := []struct {
 		name             string
-		desc             string
+		content, desc    string // content = markdown body (primary), desc = short description (fallback)
 		wantRepo, wantBr string
 	}{
-		{"none", "Just a normal project summary.", "", ""},
-		{"repo only", "Autonomous agent.\n\nRepo: ahmadAlMezaal/nightshift-site", "ahmadAlMezaal/nightshift-site", ""},
-		{"repo and branch", "Repo: owner/site\nBranch: staging", "owner/site", "staging"},
-		{"full https url", "Repo: https://github.com/owner/site", "https://github.com/owner/site", ""},
-		{"branch alone ignored", "Branch: main\nNo repo here.", "", ""},
-		{"case-insensitive + spaces", "repo:   owner/x  \nBRANCH:  dev ", "owner/x", "dev"},
+		{"none", "", "Just a normal project summary.", "", ""},
+		// Directive in the markdown body (content) — the real-world case that
+		// the ENG-200 bug broke (we used to read description only).
+		{"content repo only", "Autonomous agent.\n\nRepo: ahmadAlMezaal/nightshift-site", "", "ahmadAlMezaal/nightshift-site", ""},
+		{"content repo + branch", "Repo: owner/site\nBranch: staging", "", "owner/site", "staging"},
+		{"content full https url", "Repo: https://github.com/owner/site", "", "https://github.com/owner/site", ""},
+		// Fallback: directive written in the short description still works.
+		{"description fallback", "", "Repo: owner/x", "owner/x", ""},
+		// content takes precedence over description.
+		{"content beats description", "Repo: owner/from-content", "Repo: owner/from-desc", "owner/from-content", ""},
+		{"branch alone ignored", "Branch: main\nNo repo here.", "", "", ""},
+		{"case-insensitive + spaces", "repo:   owner/x  \nBRANCH:  dev ", "", "owner/x", "dev"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			p := &Project{Name: "P", Description: c.desc}
+			p := &Project{Name: "P", Content: c.content, Description: c.desc}
 			r, b := p.RepoDirective()
 			if r != c.wantRepo || b != c.wantBr {
 				t.Errorf("got (%q,%q), want (%q,%q)", r, b, c.wantRepo, c.wantBr)


### PR DESCRIPTION
## The bug (found by dogfooding)
A directive-only install (no `repos.json`) fails **every** ticket with *"No repo for this ticket"* — even though the Linear project's body has a valid `Repo: owner/name` line.

Linear's GraphQL `Project` has **two** text fields:
```graphql
content: String       # "The project's content in markdown format"   ← the Repo: line lives here
description: String!   # "The short description of the project"        ← what we were querying
```
The trigger queries fetched `project { name description }` and `RepoDirective()` parsed `description` — the short summary, which never contains the directive. **Directive routing has never actually worked in prod; `repos.json` always masked it as a fallback** until it was removed.

## Fix
- Add `content` to the `Project` struct and fetch it in both trigger queries: `project { name description content }`.
- `RepoDirective()` parses the directive from `content` first, falling back to `description`.
- Field names verified against Linear's published GraphQL schema (not guessed — a bad field would break dispatch entirely).

## Tests
`TestProjectRepoDirective` now covers the **content** path (the real case), the `description` fallback, and content-takes-precedence. `go build`/`test`/`vet`/`gofmt` clean.

Unblocks ENG-201 (remove the registry). Must verify directive-only routing in prod after this ships before removing `repos.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)