### PR TITLE
ENG-199: `nightshift logs`: default to recent entries, not the full history

### DIFF
--- a/cmd/nightshift/main.go
+++ b/cmd/nightshift/main.go
@@ -243,6 +243,18 @@ func runCleanup(scriptDir string, force bool) error {
 	return cleanup.Run(ctx, cfg, force)
 }
 
+// logsArgs returns the journalctl arguments for `nightshift logs`. Extracted
+// as a pure function so the flag logic is unit-testable.
+func logsArgs(follow bool) []string {
+	args := []string{"--user-unit=nightshift.service"}
+	if follow {
+		args = append(args, "-f")
+	} else {
+		args = append(args, "-n", "200")
+	}
+	return args
+}
+
 // runLogs tails Nightshift's own service logs. On a systemd host it execs
 // journalctl for the user unit (optionally following). When journalctl isn't
 // available (macOS dev box, Docker), it points the user at where logs actually
@@ -257,11 +269,7 @@ func runLogs(scriptDir string, follow bool) error {
 		return nil
 	}
 
-	args := []string{"--user-unit=nightshift.service"}
-	if follow {
-		args = append(args, "-f")
-	}
-	cmd := exec.Command(jctl, args...)
+	cmd := exec.Command(jctl, logsArgs(follow)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/cmd/nightshift/main_test.go
+++ b/cmd/nightshift/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -45,5 +46,35 @@ func TestCompletionScript_UnknownShell(t *testing.T) {
 	}
 	if _, err := completionScript(""); err == nil {
 		t.Error("expected error for empty shell, got nil")
+	}
+}
+
+func TestLogsArgs_Default(t *testing.T) {
+	args := logsArgs(false)
+	if !slices.Contains(args, "--user-unit=nightshift.service") {
+		t.Error("missing --user-unit flag")
+	}
+	if !slices.Contains(args, "-n") {
+		t.Fatal("default (no follow) should include -n")
+	}
+	nIdx := slices.Index(args, "-n")
+	if nIdx+1 >= len(args) || args[nIdx+1] != "200" {
+		t.Errorf("expected -n 200, got args: %v", args)
+	}
+	if slices.Contains(args, "-f") {
+		t.Error("-f should not be present when follow is false")
+	}
+}
+
+func TestLogsArgs_Follow(t *testing.T) {
+	args := logsArgs(true)
+	if !slices.Contains(args, "--user-unit=nightshift.service") {
+		t.Error("missing --user-unit flag")
+	}
+	if !slices.Contains(args, "-f") {
+		t.Error("follow mode should include -f")
+	}
+	if slices.Contains(args, "-n") {
+		t.Error("-n should not be present when following")
 	}
 }


### PR DESCRIPTION
## ENG-199: `nightshift logs`: default to recent entries, not the full history

**Linear:** https://linear.app/amazz/issue/ENG-199/nightshift-logs-default-to-recent-entries-not-the-full-history

## What was implemented

Made `nightshift logs` default to showing the last 200 lines instead of the full journal history.

**Changes in `cmd/nightshift/main.go`:**
- Extracted journalctl argument assembly into a pure `logsArgs(follow bool) []string` function for testability.
- When `follow` is false (the default), `logsArgs` appends `-n 200` so journalctl shows only the most recent 200 lines.
- When `follow` is true (`-f`/`--follow`), behavior is unchanged — it tails live output without a line limit.

**Changes in `cmd/nightshift/main_test.go`:**
- Added `TestLogsArgs_Default`: verifies default mode includes `--user-unit`, `-n 200`, and no `-f`.
- Added `TestLogsArgs_Follow`: verifies follow mode includes `--user-unit`, `-f`, and no `-n`.

`go build ./...`, `go test ./...`, and `go vet ./...` all pass clean.

---

*Implemented by [Nightshift](https://github.com/ahmadAlMezaal/nightshift) 🌙 using Claude Code*