### PR TITLE
ENG-203: Upgrade GitHub Actions to latest Node 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     name: test + vet + build + lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -29,6 +29,6 @@ jobs:
       - name: go test
         run: go test -race ./...
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.5.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,22 +23,22 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       # Only authenticate (and thus push) when this isn't a fork PR.
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,15 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # full history so the changelog can diff against the last tag
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
Closes ENG-203.

GitHub force-runs Actions on Node 24 starting **2026-06-16** and removes Node 20 from runners on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The v0.3.0 release run surfaced the Node 20 deprecation warning.

Bumps **every** action across all three workflows to its latest major, with the exact tags verified against the GitHub releases API at implementation time. **Version-only** change — no workflow logic, step inputs, or GoReleaser config touched.

| Workflow | Action | From → To |
|---|---|---|
| ci.yml | `actions/checkout` | v4 → **v6** |
| ci.yml | `actions/setup-go` | v5 → **v6** |
| ci.yml | `golangci/golangci-lint-action` | v7 → **v9** |
| release.yml | `actions/checkout` | v4 → **v6** |
| release.yml | `actions/setup-go` | v5 → **v6** |
| release.yml | `goreleaser/goreleaser-action` | v6 → **v7** |
| docker.yml | `actions/checkout` | v4 → **v6** |
| docker.yml | `docker/setup-qemu-action` | v3 → **v4** |
| docker.yml | `docker/setup-buildx-action` | v3 → **v4** |
| docker.yml | `docker/login-action` | v3 → **v4** |
| docker.yml | `docker/metadata-action` | v5 → **v6** |
| docker.yml | `docker/build-push-action` | v6 → **v7** |

## Notes on the riskier bumps

- **golangci-lint-action v7 → v9** — v9 still targets golangci-lint **v2**, so the pinned `version: v2.5.0` input is unchanged and valid. CI on this PR exercises it directly.
- **goreleaser-action v6 → v7** — only the action bumps; the `version: "~> v2"` GoReleaser pin and `args: release --clean` are untouched (validated locally with `goreleaser check` / `--snapshot` on the current config).
- `release.yml` only runs on `v*` tags, so it isn't exercised by this PR — but the change is the action wrapper version only.

## Verification

- All three workflow files YAML-parse cleanly.
- CI (checkout/setup-go/golangci-lint) and the Docker validation build run on this PR — both should be green with no Node 20 deprecation annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)