### PR TITLE
chore: align dev version placeholder with the 0.x release line

### DIFF
--- a/cmd/noctra/main.go
+++ b/cmd/noctra/main.go
@@ -42,7 +42,7 @@ import (
 
 // version is the build version. Defaults to a dev marker for `go build`/`go
 // run`; release builds stamp the real tag via -ldflags "-X main.version=...".
-var version = "2.0.0-dev"
+var version = "0.4.0-dev"
 
 // ANSI escape codes for the startup banner.
 const (

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -61,7 +61,7 @@ func IsNewer(latest, current string) bool {
 	if current == "" || current == "dev" {
 		return false
 	}
-	// Development / snapshot builds (e.g. "2.0.0-dev") can't be meaningfully
+	// Development / snapshot builds (e.g. "0.4.0-dev") can't be meaningfully
 	// compared to a release tag — don't nag.
 	if i := strings.IndexAny(current, "-+"); i >= 0 {
 		if suf := current[i:]; strings.Contains(suf, "dev") || strings.Contains(suf, "snapshot") {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -17,7 +17,7 @@ func TestIsNewer(t *testing.T) {
 		{"mixed v prefix", "v1.2.3", "1.2.2", true},
 		{"dev current", "v0.1.0", "dev", false},
 		{"empty current", "v0.1.0", "", false},
-		{"snapshot suffix current", "v0.2.0", "2.0.0-dev", false},
+		{"snapshot suffix current", "v0.2.0", "0.4.0-dev", false},
 		{"snapshot suffix current2", "v0.2.0", "0.1.0-snapshot", false},
 		{"prerelease latest still newer", "v0.2.0-rc1", "v0.1.0", true},
 		{"two-component versions", "v1.3", "v1.2", true},


### PR DESCRIPTION
Follow-up to the Nightshift→Noctra rename (ENG-204). The post-rename release is being tagged **v0.4.0** (continuing the existing `v0.3.x` line), so the misleading `2.0.0-dev` build fallback is corrected to `0.4.0-dev`, along with two illustrative `2.0.0-dev` references in `internal/selfupdate`.

Release artifacts are unaffected — GoReleaser stamps the real tag via `-ldflags "-X main.version=..."`; this only changes plain `go build` / `go run` dev builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)