### PR TITLE
ENG-206: add `noctra uninstall` command

### DIFF
--- a/cmd/noctra/main.go
+++ b/cmd/noctra/main.go
@@ -131,14 +131,17 @@ func realMain() error {
 		}
 		return service.Install(force, start)
 	case "uninstall":
-		purge, force := false, false
-		for _, a := range os.Args[2:] {
-			switch a {
-			case "--purge":
-				purge = true
-			case "--force", "-y":
-				force = true
-			}
+		purge, force, help, err := parseUninstallArgs(os.Args[2:])
+		if err != nil {
+			// Unknown/typo'd flag (e.g. "--pruge"): refuse rather than silently
+			// fall through to removing the service + binary.
+			fmt.Fprint(os.Stderr, uninstallUsage)
+			return err
+		}
+		if help {
+			// Help must never trigger the destructive action.
+			fmt.Print(uninstallUsage)
+			return nil
 		}
 		if purge && !force {
 			if !isInteractive() {
@@ -193,6 +196,41 @@ func printBanner() {
 	fmt.Print(ansiAmber, bannerArt, ansiReset)
 	fmt.Printf("  %s🌙 v%s%s — Autonomous Linear → PR agent\n\n", ansiDim, version, ansiReset)
 }
+
+// parseUninstallArgs interprets the flags for the destructive `uninstall`
+// subcommand. help reports that usage was requested (a no-op); an unrecognized
+// flag returns an error so a typo never falls through to the uninstall. Pure,
+// so the flag handling is unit-testable.
+func parseUninstallArgs(args []string) (purge, force, help bool, err error) {
+	for _, a := range args {
+		switch a {
+		case "--purge":
+			purge = true
+		case "--force", "-y":
+			force = true
+		case "--help", "-h":
+			help = true
+		default:
+			return false, false, false, fmt.Errorf("unknown flag %q for uninstall", a)
+		}
+	}
+	return purge, force, help, nil
+}
+
+// uninstallUsage is the help text for the destructive `uninstall` subcommand,
+// shown on `--help` and on an unrecognized flag (so a typo never falls through
+// to removing the service + binary).
+const uninstallUsage = `Usage: noctra uninstall [--purge] [--force|-y]
+
+Remove the systemd --user service and the installed binary. State is kept
+unless --purge is given.
+
+  --purge       also delete ~/.noctra* state (config + logs, cloned repos,
+                worktrees, and the PR cursor)
+  --force, -y   skip the --purge confirmation prompt (required for --purge
+                when running non-interactively)
+  --help, -h    show this message
+`
 
 // printUsage prints the CLI usage/help screen.
 func printUsage() {

--- a/cmd/noctra/main.go
+++ b/cmd/noctra/main.go
@@ -9,6 +9,7 @@
 //	noctra doctor     preflight dependency and config checks
 //	noctra update     self-update to the latest release (--restart)
 //	noctra install-service  install the systemd --user unit (--start, --force)
+//	noctra uninstall  remove the service + binary (--purge also removes state)
 //	noctra logs       tail the service logs (-f to follow)
 //	noctra start      start the systemd --user service
 //	noctra stop       stop the systemd --user service
@@ -129,6 +130,31 @@ func realMain() error {
 			}
 		}
 		return service.Install(force, start)
+	case "uninstall":
+		purge, force := false, false
+		for _, a := range os.Args[2:] {
+			switch a {
+			case "--purge":
+				purge = true
+			case "--force", "-y":
+				force = true
+			}
+		}
+		if purge && !force {
+			if !isInteractive() {
+				return fmt.Errorf("refusing to --purge non-interactively without --force")
+			}
+			fmt.Println("⚠️  --purge permanently deletes Noctra's config, cloned repos, worktrees, and PR cursor:")
+			if paths, err := service.PurgePaths(); err == nil {
+				for _, p := range paths {
+					fmt.Println("     " + p)
+				}
+			}
+			if !askYesNo("Delete this state?", false) {
+				return fmt.Errorf("uninstall --purge aborted")
+			}
+		}
+		return service.Uninstall(purge)
 	case "start", "stop", "restart", "status":
 		return runService(cmd)
 	case "completion":
@@ -179,6 +205,7 @@ func printUsage() {
 	fmt.Println("  doctor    Preflight dependency and config checks")
 	fmt.Println("  update    Self-update to the latest release (--restart to restart the service)")
 	fmt.Println("  install-service  Install the systemd --user unit (--start to enable+start, --force to overwrite)")
+	fmt.Println("  uninstall  Remove the service + binary (--purge also deletes ~/.noctra* state, --force to skip the prompt)")
 	fmt.Println("  logs      Tail the service logs (-f / --follow to stream)")
 	fmt.Println("  start     Start the systemd --user service")
 	fmt.Println("  stop      Stop the systemd --user service")
@@ -311,7 +338,7 @@ func runService(verb string) error {
 // subcommands is the list completion offers. Kept in one place so the help
 // text, the completion script, and tests stay in sync.
 var subcommands = []string{
-	"run", "setup", "update", "install-service", "logs", "start", "stop", "restart",
+	"run", "setup", "update", "install-service", "uninstall", "logs", "start", "stop", "restart",
 	"status", "doctor", "cleanup", "completion", "version", "help",
 }
 

--- a/cmd/noctra/main_test.go
+++ b/cmd/noctra/main_test.go
@@ -78,3 +78,37 @@ func TestLogsArgs_Follow(t *testing.T) {
 		t.Error("-n should not be present when following")
 	}
 }
+
+func TestParseUninstallArgs(t *testing.T) {
+	tests := []struct {
+		name               string
+		args               []string
+		purge, force, help bool
+		wantErr            bool
+	}{
+		{"no args", nil, false, false, false, false},
+		{"purge", []string{"--purge"}, true, false, false, false},
+		{"force long", []string{"--force"}, false, true, false, false},
+		{"force short", []string{"-y"}, false, true, false, false},
+		{"purge + force", []string{"--purge", "--force"}, true, true, false, false},
+		{"help long", []string{"--help"}, false, false, true, false},
+		{"help short", []string{"-h"}, false, false, true, false},
+		{"unknown/typo flag", []string{"--pruge"}, false, false, false, true},
+		{"unknown after valid", []string{"--purge", "--nope"}, false, false, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			purge, force, help, err := parseUninstallArgs(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return // on error the bool returns are unused
+			}
+			if purge != tt.purge || force != tt.force || help != tt.help {
+				t.Errorf("got purge=%v force=%v help=%v; want purge=%v force=%v help=%v",
+					purge, force, help, tt.purge, tt.force, tt.help)
+			}
+		})
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strings"
 )
 
 // unitFile renders the systemd --user unit content for Noctra. It is a pure
@@ -143,6 +144,31 @@ func PurgePaths() ([]string, error) {
 	}, nil
 }
 
+// installedBinaryPath parses the ExecStart path out of the installed unit file
+// so uninstall removes the *service's* binary, not whichever binary the command
+// happened to be invoked with (e.g. a dev `./noctra` run from a checkout).
+// Returns "" when the unit is absent or has no parseable ExecStart, leaving the
+// caller to fall back to the running executable.
+func installedBinaryPath() string {
+	dest, err := unitPath()
+	if err != nil {
+		return ""
+	}
+	content, err := os.ReadFile(dest)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		if v := strings.TrimPrefix(strings.TrimSpace(line), "ExecStart="); v != strings.TrimSpace(line) {
+			// ExecStart is "<binary> run" — take the first field.
+			if fields := strings.Fields(v); len(fields) > 0 {
+				return fields[0]
+			}
+		}
+	}
+	return ""
+}
+
 // Uninstall is the inverse of Install: it stops + disables the systemd --user
 // unit, removes it, reloads the daemon, and deletes the installed binary. When
 // purge is true it also removes Noctra's state (see PurgePaths). It is lenient —
@@ -151,6 +177,10 @@ func PurgePaths() ([]string, error) {
 // The caller is responsible for confirming a purge (this function performs no
 // prompting, so it stays free of stdin and unit-testable around the edges).
 func Uninstall(purge bool) error {
+	// Resolve the binary to delete from the unit's ExecStart BEFORE we remove
+	// the unit — falling back to the running executable when there's no unit.
+	binPath := installedBinaryPath()
+
 	// Service teardown — best-effort, and skipped entirely without systemd.
 	if sctl, err := exec.LookPath("systemctl"); err != nil {
 		fmt.Println("systemctl not found — no systemd service to remove (skipping).")
@@ -176,6 +206,9 @@ func Uninstall(purge bool) error {
 			return err
 		}
 		for _, p := range paths {
+			if _, err := os.Stat(p); os.IsNotExist(err) {
+				continue // never created (e.g. custom paths) — don't claim we removed it
+			}
 			if err := os.RemoveAll(p); err != nil {
 				fmt.Fprintf(os.Stderr, "⚠️  could not remove %s: %v\n", p, err)
 			} else {
@@ -187,11 +220,16 @@ func Uninstall(purge bool) error {
 
 	// Remove the binary last: once the service is stopped, deleting the running
 	// executable is safe on Unix (the open file is unlinked, not truncated).
-	if exe, err := resolveExe(); err == nil {
-		if err := os.Remove(exe); err == nil {
-			fmt.Printf("✓ Removed %s\n", exe)
+	if binPath == "" {
+		if exe, err := resolveExe(); err == nil {
+			binPath = exe
+		}
+	}
+	if binPath != "" {
+		if err := os.Remove(binPath); err == nil {
+			fmt.Printf("✓ Removed %s\n", binPath)
 		} else if !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "⚠️  could not remove the binary at %s: %v\n", exe, err)
+			fmt.Fprintf(os.Stderr, "⚠️  could not remove the binary at %s: %v\n", binPath, err)
 		}
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -125,6 +125,84 @@ func Install(force, start bool) error {
 	return nil
 }
 
+// PurgePaths returns the default ~/.noctra* locations that `uninstall --purge`
+// removes: the config dir (.env + logs/), the clone cache, the worktrees, and
+// the PR-cursor store. Pure but for reading $HOME, so it's unit-testable.
+// These mirror the home-relative defaults in internal/config (REPOS_BASE etc.);
+// a custom-path install is reported so the operator can remove those by hand.
+func PurgePaths() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	return []string{
+		filepath.Join(home, ".noctra"),
+		filepath.Join(home, ".noctra-repos"),
+		filepath.Join(home, ".noctra-worktrees"),
+		filepath.Join(home, ".noctra-state.json"),
+	}, nil
+}
+
+// Uninstall is the inverse of Install: it stops + disables the systemd --user
+// unit, removes it, reloads the daemon, and deletes the installed binary. When
+// purge is true it also removes Noctra's state (see PurgePaths). It is lenient —
+// a missing systemctl (non-systemd host) or an already-absent unit/binary is a
+// warning, not a failure — so a partial install can always be cleaned up.
+// The caller is responsible for confirming a purge (this function performs no
+// prompting, so it stays free of stdin and unit-testable around the edges).
+func Uninstall(purge bool) error {
+	// Service teardown — best-effort, and skipped entirely without systemd.
+	if sctl, err := exec.LookPath("systemctl"); err != nil {
+		fmt.Println("systemctl not found — no systemd service to remove (skipping).")
+	} else {
+		// stop/disable are best-effort: the unit may already be stopped/absent.
+		_ = exec.Command(sctl, "--user", "stop", "noctra.service").Run()
+		_ = exec.Command(sctl, "--user", "disable", "noctra.service").Run()
+		if dest, err := unitPath(); err == nil {
+			if err := os.Remove(dest); err == nil {
+				fmt.Printf("✓ Removed %s\n", dest)
+			} else if !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "⚠️  could not remove %s: %v\n", dest, err)
+			}
+		}
+		if out, err := exec.Command(sctl, "--user", "daemon-reload").CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  systemctl --user daemon-reload: %v: %s\n", err, out)
+		}
+	}
+
+	if purge {
+		paths, err := PurgePaths()
+		if err != nil {
+			return err
+		}
+		for _, p := range paths {
+			if err := os.RemoveAll(p); err != nil {
+				fmt.Fprintf(os.Stderr, "⚠️  could not remove %s: %v\n", p, err)
+			} else {
+				fmt.Printf("✓ Removed %s\n", p)
+			}
+		}
+		fmt.Println("  (custom REPOS_BASE / WORKTREE_BASE / STATE_FILE / LOG_DIR paths, if any, were not touched — remove them manually.)")
+	}
+
+	// Remove the binary last: once the service is stopped, deleting the running
+	// executable is safe on Unix (the open file is unlinked, not truncated).
+	if exe, err := resolveExe(); err == nil {
+		if err := os.Remove(exe); err == nil {
+			fmt.Printf("✓ Removed %s\n", exe)
+		} else if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "⚠️  could not remove the binary at %s: %v\n", exe, err)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Noctra uninstalled.")
+	if !purge {
+		fmt.Println("  State was kept (~/.noctra*). Re-run with --purge to remove it too.")
+	}
+	return nil
+}
+
 func printNextSteps(started bool) {
 	fmt.Println()
 	if started {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,6 +20,32 @@ func TestUnitFile(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("unit file missing %q\n---\n%s", want, out)
 		}
+	}
+}
+
+func TestInstalledBinaryPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// No unit yet → empty (caller falls back to the running exe).
+	if got := installedBinaryPath(); got != "" {
+		t.Errorf("installedBinaryPath with no unit = %q, want \"\"", got)
+	}
+
+	// Write a unit and confirm the ExecStart binary (sans the "run" arg) is parsed.
+	dest, err := unitPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const wantExe = "/home/u/.local/bin/noctra"
+	if err := os.WriteFile(dest, []byte(unitFile(wantExe, "/usr/bin")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := installedBinaryPath(); got != wantExe {
+		t.Errorf("installedBinaryPath = %q, want %q", got, wantExe)
 	}
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -17,6 +18,31 @@ func TestUnitFile(t *testing.T) {
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("unit file missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestPurgePaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := PurgePaths()
+	if err != nil {
+		t.Fatalf("PurgePaths: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(home, ".noctra"),
+		filepath.Join(home, ".noctra-repos"),
+		filepath.Join(home, ".noctra-worktrees"),
+		filepath.Join(home, ".noctra-state.json"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("PurgePaths returned %d paths, want %d: %v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("PurgePaths[%d] = %q, want %q", i, got[i], w)
 		}
 	}
 }


### PR DESCRIPTION
Closes ENG-206.

Adds an `uninstall` subcommand — the inverse of `install-service` — so a Noctra install can be torn down from the CLI instead of by hand (the gap that surfaced during the ENG-204 rename cutover).

## Behaviour

- **`noctra uninstall`** — `systemctl --user stop` + `disable noctra.service` (best-effort), remove the unit file, `daemon-reload`, then delete the installed binary. State is kept.
- **`noctra uninstall --purge`** — additionally removes `~/.noctra`, `~/.noctra-repos`, `~/.noctra-worktrees`, `~/.noctra-state.json`.
- **Safety** — `--purge` lists the paths and prompts when interactive; refuses non-interactively unless `--force` (`-y`).
- **Lenient** — a missing `systemctl` (non-systemd host) or an already-absent unit/binary is a warning, not a failure, so a partial install can always be cleaned up. The binary is removed last (safe to unlink a running executable on Unix).

Wired into the dispatch switch, `--help`, the package doc comment, and the completion `subcommands` list. `PurgePaths` is a pure HOME-relative helper with a unit test (matching `unitFile` / `completionScript` / `logsArgs`).

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Smoke-tested in a sandboxed `HOME`: `--purge --force` removed all four state paths + the binary and skipped the service step on a non-systemd host; plain uninstall kept state with a hint; idempotent on an already-clean install.

Branch intentionally **not** prefixed `noctra/` so the live instance's PR watcher leaves it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)