### PR TITLE
ENG-208: speed up the Docker image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # QEMU is only needed to emulate the non-native arch (arm64). PRs build
+      # amd64-only (see platforms below), so skip the emulation setup there.
       - uses: docker/setup-qemu-action@v4
+        if: github.event_name != 'pull_request'
       - uses: docker/setup-buildx-action@v4
 
       # Only authenticate (and thus push) when this isn't a fork PR.
@@ -50,7 +53,9 @@ jobs:
       - uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # PRs only validate that the image builds — do that natively on amd64.
+          # The full multi-arch image is built (and pushed) on main/tags.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN go mod download
 COPY . .
 ARG VERSION=docker
 # TARGETOS/TARGETARCH are injected by buildx for each target platform. They're
-# empty under a plain `docker build` (legacy builder / BuildKit off), so set
-# GOARCH only when TARGETARCH is non-empty (${VAR:+…}) — otherwise Go defaults
-# to the native host arch and the local build still works.
+# empty under a plain `docker build` (legacy builder / BuildKit off), so fall
+# back to the native arch via `go env` — keeping GOARCH= a literal assignment
+# prefix (a VAR=val produced by expansion is NOT treated as an assignment).
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} ${TARGETARCH:+GOARCH=${TARGETARCH}} go build -trimpath \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -trimpath \
       -ldflags "-s -w -X main.version=${VERSION}" \
       -o /out/noctra ./cmd/noctra
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,13 @@
 
 # ── Build stage ───────────────────────────────────────────────────────────────
 # Compile the static Noctra binary. CGO is disabled so the result runs on
-# any Linux without libc surprises.
-FROM golang:1.23-bookworm AS build
+# any Linux without libc surprises — and so the compiler can cross-compile.
+#
+# Pin the build stage to BUILDPLATFORM (the native builder arch) and let Go
+# cross-compile to TARGETARCH. For a multi-arch build this keeps the Go
+# toolchain running natively instead of emulating the compiler under QEMU for
+# the non-native arch — much faster, with an identical static result.
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS build
 WORKDIR /src
 
 # Dependency layer first for caching. Noctra is stdlib-only today (no
@@ -13,7 +18,10 @@ RUN go mod download
 
 COPY . .
 ARG VERSION=docker
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+# TARGETOS/TARGETARCH are injected by buildx for each target platform.
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath \
       -ldflags "-s -w -X main.version=${VERSION}" \
       -o /out/noctra ./cmd/noctra
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,13 @@ RUN go mod download
 
 COPY . .
 ARG VERSION=docker
-# TARGETOS/TARGETARCH are injected by buildx for each target platform.
+# TARGETOS/TARGETARCH are injected by buildx for each target platform. They're
+# empty under a plain `docker build` (legacy builder / BuildKit off), so set
+# GOARCH only when TARGETARCH is non-empty (${VAR:+…}) — otherwise Go defaults
+# to the native host arch and the local build still works.
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} ${TARGETARCH:+GOARCH=${TARGETARCH}} go build -trimpath \
       -ldflags "-s -w -X main.version=${VERSION}" \
       -o /out/noctra ./cmd/noctra
 


### PR DESCRIPTION
Closes ENG-208.

The `docker` workflow takes 3+ min because it builds `linux/amd64,linux/arm64` with the **arm64 half emulated under QEMU** — and it does so on every PR, not just on push.

## Changes

**Dockerfile — cross-compile instead of emulate**
- `FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS build` + `ARG TARGETOS TARGETARCH` → `GOOS=$TARGETOS GOARCH=$TARGETARCH go build`.
- The Go toolchain now runs natively on the builder for *both* target arches; only the runtime stage (apt + `npm install`) still emulates arm64. CGO is already off, so the static binary is byte-for-byte equivalent.

**docker.yml — amd64-only on PRs**
- `platforms: ${{ '{{' }} github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' {{ '}}' }}` — PRs validate the build natively on amd64 (no QEMU at all); the full multi-arch image is still built and pushed on `main`/tags.
- `setup-qemu-action` gated to non-PR runs (only needed for the emulated arm64 push build).
- GHA layer cache (`type=gha, mode=max`) unchanged, so the apt/npm layers stay cached across builds.

## Verification

- Binary cross-compiles cleanly for `amd64`/`arm64`/`armv7` with the exact build flags (correct `file` arch output for each).
- This PR's own `docker` run exercises the new amd64-only PR path; the multi-arch push path runs on merge to `main`.

## Optional follow-up (noted in the ticket)

Bigger win, more complex: build each arch on a **native runner** (`ubuntu-latest` + `ubuntu-24.04-arm`) via a matrix and merge a manifest list — removes QEMU from the runtime stage entirely. Left out here to keep this low-risk.

Branch intentionally not `noctra/`-prefixed so the live watcher ignores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)