### PR TITLE
fix: startup banner still spelled "Nightshift" (ENG-204 follow-up)

### DIFF
--- a/cmd/noctra/main.go
+++ b/cmd/noctra/main.go
@@ -55,12 +55,11 @@ const (
 // bannerArt is the figlet "standard" font rendering of "Noctra".
 // Defined as a regular string (not raw) because the font uses backticks.
 var bannerArt = "" +
-	"  _   _ _       _     _       _     _  __ _   \n" +
-	" | \\ | (_) __ _| |__ | |_ ___| |__ (_)/ _| |_ \n" +
-	" |  \\| | |/ _` | '_ \\| __/ __| '_ \\| | |_| __|\n" +
-	" | |\\  | | (_| | | | | |_\\__ \\ | | | |  _| |_ \n" +
-	" |_| \\_|_|\\__, |_| |_|\\__|___/_| |_|_|_|  \\__|\n" +
-	"           |___/                                \n"
+	" _   _            _             \n" +
+	"| \\ | | ___   ___| |_ _ __ __ _ \n" +
+	"|  \\| |/ _ \\ / __| __| '__/ _` |\n" +
+	"| |\\  | (_) | (__| |_| | | (_| |\n" +
+	"|_| \\_|\\___/ \\___|\\__|_|  \\__,_|\n"
 
 func main() {
 	if err := realMain(); err != nil {


### PR DESCRIPTION
Follow-up to the rename (ENG-204). `noctra version` / the startup banner still printed the **Nightshift** ASCII art:

```
  _   _ _       _     _       _     _  __ _
 | \ | (_) __ _| |__ | |_ ___| |__ (_)/ _| |_
 ...
```

The rename's find-replace updated the `bannerArt` *comment* to "Noctra" but couldn't touch the art itself — it's drawn with pipes/underscores, so there was no literal `nightshift` string to match. Replaced it with the figlet **standard** font rendering of "Noctra" (same font the original used):

```
 _   _            _
| \ | | ___   ___| |_ _ __ __ _
|  \| |/ _ \ / __| __| '__/ _` |
| |\  | (_) | (__| |_| | | (_| |
|_| \_|\___/ \___|\__|_|  \__,_|
```

`go build`/`vet`/`test` pass; verified the rendered banner spells "Noctra".

🤖 Generated with [Claude Code](https://claude.com/claude-code)