### PR TITLE
Copilot backend: headless auth fix + show backend in notifications + logs paging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Almost everything in `internal/agent` is **backend-agnostic** and shared: the pr
 1. **Invocation** — `claudeArgs` (`claude --print`) vs `codexArgs` (`codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`) vs `copilotArgs` (`copilot --allow-all-tools --no-ask-user -p <prompt>`). All go through the shared `runCLI` (timeout → `ErrTimedOut`, DEBUG header, log streaming).
 2. **Rate-limit parsing** — `HasRateLimit` is per-backend (`claudeRateLimitRe` / `codexRateLimitRe` / `copilotRateLimitRe`) since the CLIs phrase usage/quota errors differently.
 
-The required-CLI set is backend-aware: `git` + `gh` + the selected agent CLI (`config.RequiredCLIs` / `CheckCLIs`; `doctor` and the wizard surface it). Codex auth is a one-time `codex login` on the host (or `OPENAI_API_KEY`); Copilot auth is via `gh auth login` (or `GH_TOKEN`) — Noctra doesn't manage either.
+The required-CLI set is backend-aware: `git` + `gh` + the selected agent CLI (`config.RequiredCLIs` / `CheckCLIs`; `doctor` and the wizard surface it). Codex auth is a one-time `codex login` on the host (or `OPENAI_API_KEY`); Copilot auth is via `gh auth login` (or `GH_TOKEN`). Unlike the others, the Copilot CLI does **not** read gh's credential store when run headless (e.g. under systemd) — it only checks `COPILOT_GITHUB_TOKEN`/`GH_TOKEN`/`GITHUB_TOKEN`. So `copilotEnv` (in `agent/copilot.go`) bridges the gap: when no token env is set it mints one via `gh auth token` and injects `GH_TOKEN` into the child, making copilot work wherever gh is authed. Copilot also requires **Node 22+**.
 
 ## Package map
 

--- a/cmd/noctra/main.go
+++ b/cmd/noctra/main.go
@@ -314,7 +314,10 @@ func logsArgs(follow bool) []string {
 	if follow {
 		args = append(args, "-f")
 	} else {
-		args = append(args, "-n", "200")
+		// --no-pager dumps straight to stdout (newest line last) instead of
+		// opening the journalctl pager at the TOP of the 200 lines, which forces
+		// scrolling to reach the latest entry.
+		args = append(args, "--no-pager", "-n", "200")
 	}
 	return args
 }

--- a/cmd/noctra/main_test.go
+++ b/cmd/noctra/main_test.go
@@ -64,6 +64,9 @@ func TestLogsArgs_Default(t *testing.T) {
 	if slices.Contains(args, "-f") {
 		t.Error("-f should not be present when follow is false")
 	}
+	if !slices.Contains(args, "--no-pager") {
+		t.Error("default (no follow) should include --no-pager so the latest line shows without scrolling")
+	}
 }
 
 func TestLogsArgs_Follow(t *testing.T) {

--- a/internal/agent/backend_test.go
+++ b/internal/agent/backend_test.go
@@ -1,6 +1,9 @@
 package agent
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 )
@@ -105,6 +108,37 @@ func TestCopilotArgs_UsesAllowAllToolsAndPromptFlag(t *testing.T) {
 	i := slices.Index(args, "-p")
 	if i < 0 || i+1 >= len(args) || args[i+1] != "do the thing" {
 		t.Errorf("copilotArgs did not pass prompt after -p: %v", args)
+	}
+}
+
+func TestCopilotEnv_SkipsWhenTokenAlreadySet(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "already-here")
+	if env := copilotEnv(context.Background()); env != nil {
+		t.Errorf("expected nil (inherit os.Environ) when a token env is set, got %v", env)
+	}
+}
+
+func TestCopilotEnv_InjectsGhTokenWhenNoneSet(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	// Fake `gh` on PATH that prints a token for `gh auth token`.
+	dir := t.TempDir()
+	gh := filepath.Join(dir, "gh")
+	if err := os.WriteFile(gh, []byte("#!/bin/sh\nif [ \"$1\" = auth ] && [ \"$2\" = token ]; then echo faketoken123; fi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	env := copilotEnv(context.Background())
+	if env == nil {
+		t.Fatal("expected env with injected GH_TOKEN, got nil")
+	}
+	if !slices.Contains(env, "GH_TOKEN=faketoken123") {
+		t.Errorf("expected GH_TOKEN=faketoken123 in env, got %v", env)
 	}
 }
 

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -2,7 +2,10 @@ package agent
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"regexp"
+	"strings"
 )
 
 // copilotBackend runs GitHub's Copilot CLI (`copilot`) in its non-interactive
@@ -22,8 +25,35 @@ func (copilotBackend) CLI() string   { return "copilot" }
 // Run invokes `copilot --allow-all-tools --no-ask-user -p <prompt>` in opts.Workdir.
 // UseAgentTeams is Claude-only and is ignored here.
 func (b copilotBackend) Run(ctx context.Context, opts RunOptions) error {
-	// nil env → inherit os.Environ (so GH_TOKEN / gh auth state flow through).
-	return runCLI(ctx, b.CLI(), copilotArgs(opts), nil, opts)
+	return runCLI(ctx, b.CLI(), copilotArgs(opts), copilotEnv(ctx), opts)
+}
+
+// copilotEnv bridges a GitHub token into the Copilot CLI's environment. Copilot
+// authenticates from COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN, or an
+// interactive `copilot /login`. In a headless systemd service none of those env
+// vars are set and — unlike an interactive shell — copilot does NOT fall back to
+// reading gh's credential store, so it dies immediately with "No authentication
+// information found." even on a host where `gh` itself is authenticated (PRs
+// still work because gh reads its own store). When no token env is present we
+// mint one from `gh auth token` and inject GH_TOKEN, so copilot works wherever
+// gh does — the same auth Noctra already relies on for PR creation. Returns nil
+// (inherit os.Environ unchanged) when a token is already set or gh can't supply
+// one, leaving copilot to surface its own auth guidance.
+func copilotEnv(ctx context.Context) []string {
+	for _, k := range []string{"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		if os.Getenv(k) != "" {
+			return nil // already authenticated via env
+		}
+	}
+	out, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
+	if err != nil {
+		return nil
+	}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return nil
+	}
+	return append(os.Environ(), "GH_TOKEN="+token)
 }
 
 // copilotArgs builds the argv for a Copilot CLI run. `-p` is the one-shot

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -379,7 +379,8 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	logger.Info("✅ PR created", "url", prURL)
 	p.bumpSuccess()
-	p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — %s\nPR ready: %s", id, notify.EscapeMarkdown(issue.Title), prURL))
+	p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — %s\nPR ready (via %s): %s",
+		id, notify.EscapeMarkdown(issue.Title), notify.EscapeMarkdown(p.agent.Label()), prURL))
 
 	// ── Move to In Review + remove trigger label ────────────────────────────
 	if p.cfg.TriggerMode == "label" && p.labelID != "" {
@@ -391,8 +392,8 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 		logger.Warn("could not set in-review state", "err", err)
 	}
 	if err := p.linear.Comment(ctx, issue.ID, fmt.Sprintf(
-		"🌙 **Noctra created a PR**\n\n**PR:** %s\n\nMoved to **%s**. Ready for your review!",
-		prURL, p.cfg.InReviewState)); err != nil {
+		"🌙 **Noctra created a PR** (via %s)\n\n**PR:** %s\n\nMoved to **%s**. Ready for your review!",
+		p.agent.Label(), prURL, p.cfg.InReviewState)); err != nil {
 		logger.Warn("could not post Linear comment", "err", err)
 	}
 


### PR DESCRIPTION
## What

Fixes for running the new Copilot backend on the Pi (systemd, headless), plus two observability nits.

### 1. 🐛 Copilot fails headless with "No authentication information found" (the real blocker)
Confirmed on the Pi via `~/.noctra/logs/<id>.log`: the `@github/copilot` CLI authenticates only from `COPILOT_GITHUB_TOKEN`/`GH_TOKEN`/`GITHUB_TOKEN` or an interactive `copilot /login`. Unlike claude/codex (own stored login in `$HOME`) and unlike `gh` itself, it does **not** read gh's credential store when run headless under systemd — so it exits 1 immediately even though `gh pr create` works on the same host.

**Fix:** `copilotEnv` (in `agent/copilot.go`) mints a token via `gh auth token` and injects `GH_TOKEN` into the copilot child when no token env is set — so copilot works wherever gh is authenticated, no extra config. No-op when a token env is already present or gh can't supply one. Unit-tested with a fake `gh` on PATH.

### 2. Tell which agent opened the PR (Linear + Telegram)
The PR body/commit already named the agent; the Linear "created a PR" comment and Telegram success message did not. Both now read `… (via GitHub Copilot)` / `(via Claude Code)` / `(via Codex)`.

### 3. `noctra logs` opens at the top, not the latest
`logsArgs(false)` ran `journalctl -n 200` with no `--no-pager`, so it opened in the pager at the top. Added `--no-pager`.

## ⚠️ Operational note (not code)
The Pi runs **Node 20**; `@github/copilot` requires **Node 22+**. Upgrade the Pi's Node to 22 as well — this PR fixes auth but the Node floor is a separate host requirement.

## Test
`go build`, `go vet`, `go test ./...` all pass.