### PR TITLE
ENG-211: Label-driven automatic version tagging on PR merge

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,138 @@
+name: tag-on-merge
+
+# Automatically tag and release when a PR is merged to main with a release:* label.
+# This workflow:
+#  1. Reads the merged PR's labels
+#  2. Recognizes release:major / release:minor / release:patch
+#  3. Computes the next semver from the latest v* tag
+#  4. Creates and pushes an annotated tag
+#  5. Invokes GoReleaser to publish the release
+#
+# Why GoReleaser is called here (not via release.yml trigger):
+# Tags pushed with GITHUB_TOKEN don't trigger other workflows (GitHub policy to prevent loops).
+# So tag-on-merge calls GoReleaser directly, keeping release.yml for manual tag pushes.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  tag-on-merge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for release labels
+        id: check-label
+        run: |
+          labels='${{ toJson(github.event.pull_request.labels[*].name) }}'
+          
+          major=$(echo "$labels" | jq 'contains(["release:major"])')
+          minor=$(echo "$labels" | jq 'contains(["release:minor"])')
+          patch=$(echo "$labels" | jq 'contains(["release:patch"])')
+          
+          count=$(($(echo "$major" | grep -c true) + $(echo "$minor" | grep -c true) + $(echo "$patch" | grep -c true)))
+          
+          if [ "$count" -eq 0 ]; then
+            echo "no_release=true" >> $GITHUB_OUTPUT
+            echo "No release label found — skipping tag and release"
+            exit 0
+          fi
+          
+          if [ "$count" -gt 1 ]; then
+            echo "Multiple release:* labels found. Expected exactly one (release:major, release:minor, or release:patch). Failing."
+            exit 1
+          fi
+          
+          if [ "$major" = "true" ]; then
+            echo "bump_type=major" >> $GITHUB_OUTPUT
+          elif [ "$minor" = "true" ]; then
+            echo "bump_type=minor" >> $GITHUB_OUTPUT
+          elif [ "$patch" = "true" ]; then
+            echo "bump_type=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Compute next version
+        if: steps.check-label.outputs.no_release != 'true'
+        id: version
+        run: |
+          # Get latest v* tag, sorted by version
+          latest_tag=$(git tag --sort=-v:refname --list 'v*' | head -1)
+          
+          if [ -z "$latest_tag" ]; then
+            echo "No existing v* tags found. Starting from v0.0.0"
+            current="0.0.0"
+          else
+            current="${latest_tag#v}"
+          fi
+          
+          # Parse semver
+          IFS='.' read -r major minor patch <<< "$current"
+          
+          # Apply bump
+          bump_type="${{ steps.check-label.outputs.bump_type }}"
+          if [ "$bump_type" = "major" ]; then
+            major=$((major + 1))
+            minor=0
+            patch=0
+          elif [ "$bump_type" = "minor" ]; then
+            minor=$((minor + 1))
+            patch=0
+          elif [ "$bump_type" = "patch" ]; then
+            patch=$((patch + 1))
+          fi
+          
+          next_version="v${major}.${minor}.${patch}"
+          echo "next_version=$next_version" >> $GITHUB_OUTPUT
+          echo "Computed next version: $next_version (from $current, bump: $bump_type)"
+
+      - name: Check if tag already exists
+        if: steps.check-label.outputs.no_release != 'true'
+        run: |
+          tag="${{ steps.version.outputs.next_version }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists. Refusing to overwrite."
+            exit 1
+          fi
+          echo "Tag $tag does not exist — safe to create"
+
+      - name: Create annotated tag
+        if: steps.check-label.outputs.no_release != 'true'
+        run: |
+          tag="${{ steps.version.outputs.next_version }}"
+          git config user.name "Noctra Bot"
+          git config user.email "noctra-bot@users.noreply.github.com"
+          git tag -a "$tag" -m "Release $tag" "${{ github.event.pull_request.merge_commit_sha }}"
+          echo "Created annotated tag: $tag"
+
+      - name: Push tag
+        if: steps.check-label.outputs.no_release != 'true'
+        run: |
+          tag="${{ steps.version.outputs.next_version }}"
+          git push origin "$tag"
+          echo "Pushed tag: $tag"
+
+      - name: Set up Go
+        if: steps.check-label.outputs.no_release != 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.23"
+
+      - name: Run GoReleaser
+        if: steps.check-label.outputs.no_release != 'true'
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,4 +145,37 @@ The startup banner (`pipeline.banner`) prints the resolved runtime config — re
 
 ## Releasing
 
-Releases are automated with GoReleaser (`.goreleaser.yaml`) via `.github/workflows/release.yml`, triggered by pushing a `v*` tag. It cross-compiles linux `amd64`/`arm64`/`armv7` + darwin `amd64`/`arm64`, archives them with checksums, and publishes a GitHub Release. `main.version` is a `var` (not const) so the tag is stamped in via `-ldflags "-X main.version=..."`. Validate config changes locally with `goreleaser check` and `goreleaser release --snapshot --clean --skip=publish`.
+Releases are automated with GoReleaser (`.goreleaser.yaml`). Two paths:
+
+### Path 1: Label-driven (default on main)
+
+When a PR is merged to `main`, `.github/workflows/tag-on-merge.yml`:
+1. Checks for exactly one `release:major`, `release:minor`, or `release:patch` label
+2. No label → no-op (safe default)
+3. Multiple labels → fails (prevents mistakes)
+4. Computes the next semver from the latest `v*` tag (e.g., `v0.5.2` + `release:patch` → `v0.5.3`)
+5. Creates an annotated tag at the merge commit and pushes it
+6. Invokes GoReleaser directly to publish the release with cross-compiled binaries and checksums
+
+**Why GoReleaser runs in tag-on-merge:** Tags pushed with `GITHUB_TOKEN` don't trigger other workflows (GitHub policy). So rather than push a tag and hope `release.yml` fires, we call GoReleaser inline.
+
+**Advantages:** Explicit per-PR control, no manual tagging, safe (unlabeled PRs never release).
+
+### Path 2: Manual (always available)
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+`.github/workflows/release.yml` fires on any pushed `v*` tag and publishes a release via GoReleaser. This path is unchanged and always works — useful for hotfixes, backdates, or testing.
+
+### Config validation
+
+Validate GoReleaser config locally:
+```bash
+goreleaser check
+goreleaser release --snapshot --clean --skip=publish
+```
+
+`main.version` is a `var` (not const) so the tag is stamped in via `-ldflags "-X main.version=..."`.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,34 @@ git tag v2.0.0 && git push origin v2.0.0
 
 ---
 
+## Releasing
+
+Releases are published automatically with GoReleaser, creating cross-platform binaries (linux amd64/arm64/armv7 + darwin) and a checksums file.
+
+### Automatic on PR merge (recommended)
+
+Label your PR with one of:
+- `release:major` — bump major version (e.g., v0.5.2 → v1.0.0)
+- `release:minor` — bump minor version (e.g., v0.5.2 → v0.6.0)
+- `release:patch` — bump patch version (e.g., v0.5.2 → v0.5.3)
+
+When merged to `main`, `.github/workflows/tag-on-merge.yml` automatically:
+1. Detects the label (no label = no release, safe default)
+2. Computes the next semver from the latest tag
+3. Creates and pushes an annotated tag
+4. Runs GoReleaser to publish the release
+
+### Manual (always available)
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+`.github/workflows/release.yml` triggers on any `v*` tag push and publishes a release. Useful for hotfixes or testing.
+
+---
+
 ## Operating the service
 
 Running Noctra as a long-lived `systemd --user` service? The `Makefile` wraps the day-to-day operations so you don't have to remember the raw `systemctl` / build incantations (run `make help` to list everything):

--- a/README.md
+++ b/README.md
@@ -212,15 +212,6 @@ GOOS=linux GOARCH=arm GOARM=7 go build -o noctra ./cmd/noctra      # Pi 3 / 32-b
 scp noctra pi@your-pi:/srv/noctra/
 ```
 
-### Cutting a release
-
-Releases are automated by [GoReleaser](https://goreleaser.com) (`.goreleaser.yaml` + `.github/workflows/release.yml`). Push a semver tag and a GitHub Release with cross-compiled archives + checksums is published automatically:
-
-```bash
-git tag v2.0.0 && git push origin v2.0.0
-```
-
----
 
 ## Releasing
 


### PR DESCRIPTION
## ENG-211: Label-driven automatic version tagging on PR merge

**Linear:** https://linear.app/amazz/issue/ENG-211/label-driven-automatic-version-tagging-on-pr-merge

## What was implemented

Implemented label-driven automatic version tagging on PR merge (ENG-211). Created `.github/workflows/tag-on-merge.yml` that reads `release:major/minor/patch` labels on merged PRs, computes next semver from latest tag, creates annotated tags, and runs GoReleaser inline (avoiding GITHUB_TOKEN trigger suppression). Added three release labels via `gh`, updated README.md and CLAUDE.md with release documentation explaining both automatic (label-driven) and manual (direct tag push) release paths. All acceptance criteria met; tests passing.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using GitHub Copilot*