### PR TITLE
ENG-215: Attribute the coding-agent backend on commits via Co-authored-by (show in GitHub Contributors)

### DIFF
--- a/internal/agent/backend.go
+++ b/internal/agent/backend.go
@@ -43,6 +43,12 @@ type Backend interface {
 	Label() string
 	// CLI is the executable Noctra requires on PATH for this backend.
 	CLI() string
+	// CoAuthor returns the "Name <email>" value for a Co-authored-by git
+	// trailer attributing commits to this backend. Backends with a real
+	// GitHub account behind the email (e.g. Copilot) get an avatar and
+	// Contributors-graph entry; others render as a plain name on the commit.
+	// Returns "" if no trailer should be added.
+	CoAuthor() string
 	// Run invokes the CLI in opts.Workdir, streaming stdout+stderr to
 	// opts.LogFile. It returns ErrTimedOut (wrapped) on per-attempt timeout
 	// and the underlying error on any other non-zero exit.

--- a/internal/agent/backend_test.go
+++ b/internal/agent/backend_test.go
@@ -160,6 +160,26 @@ func TestCopilotEnv_SkipsClassicPAT(t *testing.T) {
 	}
 }
 
+func TestBackend_CoAuthor(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"claude", "Claude <noreply@anthropic.com>"},
+		{"codex", "Codex <noreply@openai.com>"},
+		{"copilot", "Copilot <223556219+Copilot@users.noreply.github.com>"},
+	}
+	for _, tc := range cases {
+		b, err := New(tc.name)
+		if err != nil {
+			t.Fatalf("New(%q) error: %v", tc.name, err)
+		}
+		if got := b.CoAuthor(); got != tc.want {
+			t.Errorf("%s.CoAuthor() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
 func TestHasRateLimit_PerBackend(t *testing.T) {
 	claude, _ := New("claude")
 	codex, _ := New("codex")

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -10,9 +10,10 @@ import (
 // print mode. This is Noctra's default and original backend.
 type claudeBackend struct{}
 
-func (claudeBackend) Name() string  { return "claude" }
-func (claudeBackend) Label() string { return "Claude Code" }
-func (claudeBackend) CLI() string   { return "claude" }
+func (claudeBackend) Name() string     { return "claude" }
+func (claudeBackend) Label() string    { return "Claude Code" }
+func (claudeBackend) CLI() string      { return "claude" }
+func (claudeBackend) CoAuthor() string { return "Claude <noreply@anthropic.com>" }
 
 // Run invokes `claude --print` in opts.Workdir. When UseAgentTeams is set the
 // experimental agent-teams flag is exported into the child environment.

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -15,9 +15,10 @@ import (
 // If a future Codex release renames flags, only codexArgs needs to change.
 type codexBackend struct{}
 
-func (codexBackend) Name() string  { return "codex" }
-func (codexBackend) Label() string { return "OpenAI Codex" }
-func (codexBackend) CLI() string   { return "codex" }
+func (codexBackend) Name() string     { return "codex" }
+func (codexBackend) Label() string    { return "OpenAI Codex" }
+func (codexBackend) CLI() string      { return "codex" }
+func (codexBackend) CoAuthor() string { return "Codex <noreply@openai.com>" }
 
 // Run invokes `codex exec` in opts.Workdir. UseAgentTeams is Claude-only and
 // is ignored here.

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -19,9 +19,10 @@ import (
 // change.
 type copilotBackend struct{}
 
-func (copilotBackend) Name() string  { return "copilot" }
-func (copilotBackend) Label() string { return "GitHub Copilot" }
-func (copilotBackend) CLI() string   { return "copilot" }
+func (copilotBackend) Name() string     { return "copilot" }
+func (copilotBackend) Label() string    { return "GitHub Copilot" }
+func (copilotBackend) CLI() string      { return "copilot" }
+func (copilotBackend) CoAuthor() string { return "Copilot <223556219+Copilot@users.noreply.github.com>" }
 
 // Run invokes `copilot --allow-all-tools --no-ask-user -p <prompt>` in opts.Workdir.
 // UseAgentTeams is Claude-only and is ignored here.

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -19,10 +19,12 @@ import (
 // change.
 type copilotBackend struct{}
 
-func (copilotBackend) Name() string     { return "copilot" }
-func (copilotBackend) Label() string    { return "GitHub Copilot" }
-func (copilotBackend) CLI() string      { return "copilot" }
-func (copilotBackend) CoAuthor() string { return "Copilot <223556219+Copilot@users.noreply.github.com>" }
+func (copilotBackend) Name() string  { return "copilot" }
+func (copilotBackend) Label() string { return "GitHub Copilot" }
+func (copilotBackend) CLI() string   { return "copilot" }
+func (copilotBackend) CoAuthor() string {
+	return "Copilot <223556219+Copilot@users.noreply.github.com>"
+}
 
 // Run invokes `copilot --allow-all-tools --no-ask-user -p <prompt>` in opts.Workdir.
 // UseAgentTeams is Claude-only and is ignored here.

--- a/internal/pipeline/commit_test.go
+++ b/internal/pipeline/commit_test.go
@@ -32,6 +32,14 @@ func TestAppendCoAuthorTrailer(t *testing.T) {
 		}
 	})
 
+	t.Run("trims trailing whitespace before trailer", func(t *testing.T) {
+		got := appendCoAuthorTrailer(base+"\n\n", "Claude <noreply@anthropic.com>")
+		want := base + "\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+		if got != want {
+			t.Errorf("trailing whitespace not trimmed:\ngot:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
 	t.Run("iterate commit message", func(t *testing.T) {
 		iterBase := "fix: address PR feedback on ENG-1\n\nFollow-up commit by Noctra (addressing review)."
 		got := appendCoAuthorTrailer(iterBase, "Codex <noreply@openai.com>")

--- a/internal/pipeline/commit_test.go
+++ b/internal/pipeline/commit_test.go
@@ -1,0 +1,42 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAppendCoAuthorTrailer(t *testing.T) {
+	base := "feat: implement ENG-1 — title\n\nImplemented by Noctra using Claude Code\n\nLinear: https://linear.app/t/ENG-1"
+
+	t.Run("appends trailer when non-empty", func(t *testing.T) {
+		got := appendCoAuthorTrailer(base, "Claude <noreply@anthropic.com>")
+		want := base + "\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+		if got != want {
+			t.Errorf("got:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
+	t.Run("returns unchanged when empty", func(t *testing.T) {
+		got := appendCoAuthorTrailer(base, "")
+		if got != base {
+			t.Errorf("expected message unchanged for empty coAuthor, got:\n%s", got)
+		}
+	})
+
+	t.Run("trailer is last line", func(t *testing.T) {
+		got := appendCoAuthorTrailer(base, "Copilot <223556219+Copilot@users.noreply.github.com>")
+		lines := strings.Split(got, "\n")
+		last := lines[len(lines)-1]
+		if last != "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" {
+			t.Errorf("trailer should be last line, got %q", last)
+		}
+	})
+
+	t.Run("iterate commit message", func(t *testing.T) {
+		iterBase := "fix: address PR feedback on ENG-1\n\nFollow-up commit by Noctra (addressing review)."
+		got := appendCoAuthorTrailer(iterBase, "Codex <noreply@openai.com>")
+		if !strings.HasSuffix(got, "\n\nCo-authored-by: Codex <noreply@openai.com>") {
+			t.Errorf("iterate commit should end with trailer, got:\n%s", got)
+		}
+	})
+}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -345,8 +345,10 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		return
 	}
 	if staged {
-		commitMsg := fmt.Sprintf("fix: address PR feedback on %s\n\nFollow-up commit by Noctra (%s).",
-			identifier, engagementSummary(ch))
+		commitMsg := appendCoAuthorTrailer(
+			fmt.Sprintf("fix: address PR feedback on %s\n\nFollow-up commit by Noctra (%s).",
+				identifier, engagementSummary(ch)),
+			p.agent.CoAuthor())
 		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
 			logger.Error("git commit failed", "err", err)
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -518,5 +518,5 @@ func appendCoAuthorTrailer(msg, coAuthor string) string {
 	if coAuthor == "" {
 		return msg
 	}
-	return msg + "\n\nCo-authored-by: " + coAuthor
+	return strings.TrimRight(msg, " \t\n\r") + "\n\nCo-authored-by: " + coAuthor
 }

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -314,9 +314,10 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// Commit only if there's staged work — if Claude already committed its own
 	// changes, the staged set is empty and a plain `git commit` would fail with
 	// "nothing to commit" and bounce a valid implementation (ENG-182).
-	commitMsg := fmt.Sprintf(
-		"feat: implement %s — %s\n\nImplemented by Noctra using %s\n\nLinear: %s",
-		id, issue.Title, p.agent.Label(), issue.URL)
+	commitMsg := appendCoAuthorTrailer(
+		fmt.Sprintf("feat: implement %s — %s\n\nImplemented by Noctra using %s\n\nLinear: %s",
+			id, issue.Title, p.agent.Label(), issue.URL),
+		p.agent.CoAuthor())
 
 	staged, err := hasStagedChanges(ctx, wt.Path)
 	if err != nil {
@@ -507,4 +508,15 @@ func runIn(ctx context.Context, dir, name string, args ...string) error {
 		return fmt.Errorf("%s %s: %w (%s)", name, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// appendCoAuthorTrailer appends a Co-authored-by trailer to a commit message
+// body when the backend declares one. The trailer is separated from the body
+// by a blank line, following git's trailer convention. Returns the message
+// unchanged when coAuthor is empty.
+func appendCoAuthorTrailer(msg, coAuthor string) string {
+	if coAuthor == "" {
+		return msg
+	}
+	return msg + "\n\nCo-authored-by: " + coAuthor
 }


### PR DESCRIPTION
## ENG-215: Attribute the coding-agent backend on commits via Co-authored-by (show in GitHub Contributors)

**Linear:** https://linear.app/amazz/issue/ENG-215/attribute-the-coding-agent-backend-on-commits-via-co-authored-by-show

## What was implemented

Added `Co-authored-by` git trailers to commits Noctra creates, attributing the active coding-agent backend.

**Changes:**

1. **`internal/agent/backend.go`** — Added `CoAuthor() string` to the `Backend` interface, returning the `Name <email>` value for the trailer.

2. **`internal/agent/claude.go`** — `CoAuthor()` returns `"Claude <noreply@anthropic.com>"` (Anthropic's documented Claude Code trailer).

3. **`internal/agent/codex.go`** — `CoAuthor()` returns `"Codex <noreply@openai.com>"` (name-only identity; no linked GitHub account, so it renders as a plain name on commits — no avatar/Contributors-graph entry).

4. **`internal/agent/copilot.go`** — `CoAuthor()` returns `"Copilot <223556219+Copilot@users.noreply.github.com>"` (real GitHub bot account — gets avatar + Contributors-graph entry).

5. **`internal/pipeline/process.go`** — Initial dispatch commit message now uses `appendCoAuthorTrailer()` to append the backend's trailer. Added the shared `appendCoAuthorTrailer(msg, coAuthor)` helper that appends `Co-authored-by: <value>` separated by a blank line, or returns the message unchanged when `coAuthor` is empty.

6. **`internal/pipeline/iterate.go`** — PR iteration follow-up commit message also uses `appendCoAuthorTrailer()`.

7. **`internal/agent/backend_test.go`** — Added `TestBackend_CoAuthor` verifying the trailer value for all three backends.

8. **`internal/pipeline/commit_test.go`** — New test file covering `appendCoAuthorTrailer`: non-empty trailer appended, empty trailer is no-op, trailer is last line, and iterate-style commit messages.

**Duplicate trailer prevention:** The trailer is only appended when Noctra creates the commit (inside the `if staged` block). When the agent self-commits its changes (e.g., Copilot adds its own `Co-authored-by`), `hasStagedChanges` returns false and Noctra doesn't create a second commit — no duplicate trailer possible.

All tests pass (`go test ./...`), `go vet` clean.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*