### PR TITLE
fix: make tag-on-merge release automation actually work

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -22,6 +22,12 @@ permissions:
   pages: write
   id-token: write
 
+# Serialize releases so two PRs merged back-to-back can't both compute the same
+# "next version" off a stale tag list and race to push the same tag.
+concurrency:
+  group: tag-on-merge
+  cancel-in-progress: false
+
 jobs:
   tag-on-merge:
     if: github.event.pull_request.merged == true
@@ -29,36 +35,41 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # Check out the actual merge commit, not the default refs/pull/N/merge
+          # synthetic ref. We tag HEAD and GoReleaser builds HEAD, so both must be
+          # the merged commit or GoReleaser fails to find the tag on the commit it builds.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Check for release labels
         id: check-label
         run: |
           labels='${{ toJson(github.event.pull_request.labels[*].name) }}'
-          
-          major=$(echo "$labels" | jq 'contains(["release:major"])')
-          minor=$(echo "$labels" | jq 'contains(["release:minor"])')
-          patch=$(echo "$labels" | jq 'contains(["release:patch"])')
-          
-          count=$(($(echo "$major" | grep -c true) + $(echo "$minor" | grep -c true) + $(echo "$patch" | grep -c true)))
-          
+
+          # Count release:* labels in a single jq pass. The previous approach piped
+          # each boolean through `grep -c true`, but grep exits non-zero when it finds
+          # no match, and GitHub runs steps under `bash -e` — so the no-label (and
+          # single-label!) cases aborted the step before the count was ever checked.
+          count=$(echo "$labels" | jq '[.[] | select(. == "release:major" or . == "release:minor" or . == "release:patch")] | length')
+
           if [ "$count" -eq 0 ]; then
-            echo "no_release=true" >> $GITHUB_OUTPUT
+            echo "no_release=true" >> "$GITHUB_OUTPUT"
             echo "No release label found — skipping tag and release"
             exit 0
           fi
-          
+
           if [ "$count" -gt 1 ]; then
             echo "Multiple release:* labels found. Expected exactly one (release:major, release:minor, or release:patch). Failing."
             exit 1
           fi
-          
-          if [ "$major" = "true" ]; then
-            echo "bump_type=major" >> $GITHUB_OUTPUT
-          elif [ "$minor" = "true" ]; then
-            echo "bump_type=minor" >> $GITHUB_OUTPUT
-          elif [ "$patch" = "true" ]; then
-            echo "bump_type=patch" >> $GITHUB_OUTPUT
+
+          if echo "$labels" | jq -e 'contains(["release:major"])' >/dev/null; then
+            echo "bump_type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$labels" | jq -e 'contains(["release:minor"])' >/dev/null; then
+            echo "bump_type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "bump_type=patch" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Compute next version
@@ -111,8 +122,9 @@ jobs:
           tag="${{ steps.version.outputs.next_version }}"
           git config user.name "Noctra Bot"
           git config user.email "noctra-bot@users.noreply.github.com"
-          git tag -a "$tag" -m "Release $tag" "${{ github.event.pull_request.merge_commit_sha }}"
-          echo "Created annotated tag: $tag"
+          # HEAD is the merge commit (we checked it out by SHA above), so tag it directly.
+          git tag -a "$tag" -m "Release $tag"
+          echo "Created annotated tag: $tag at $(git rev-parse HEAD)"
 
       - name: Push tag
         if: steps.check-label.outputs.no_release != 'true'


### PR DESCRIPTION
## Why

The release-on-merge workflow (`tag-on-merge.yml`, ENG-211 / #142) has **failed on every PR merge since it was introduced** — including #142 itself, #149, and #148 — so no release has been cut despite merges landing on `main`.

```
2026-06-14T22:18:58Z  failure  ENG-215 (#148)
2026-06-14T22:17:33Z  failure  ENG-214 (#149)
2026-06-14T18:26:18Z  failure  ENG-211 (#142, its own introduction)
```

## Bugs fixed

**1. Label check aborted under `bash -e`.**
The release-label count was built from `grep -c true`, but `grep` exits non-zero when it finds no match, and GitHub runs `run:` steps under `bash -e`. That aborted the step before the count was ever evaluated — in **both** the no-label case (should skip cleanly) and the valid single-label case (two of the three greps never match). Replaced with one `jq` pass that always exits 0; bump detection uses `jq -e` inside `if` conditions (exempt from `set -e`).

**2. GoReleaser built an untagged commit.**
On `pull_request: closed`, `actions/checkout` defaults to the synthetic `refs/pull/N/merge` ref, but the tag was created on `merge_commit_sha`. GoReleaser then built a commit that carried no tag and would fail. Now we check out `merge_commit_sha` and tag `HEAD`, so the built and tagged commit are identical.

**Hardening:** added a `concurrency: tag-on-merge` group so back-to-back merges can't race on the same computed next version, and only the three valid `release:major|minor|patch` labels count toward the bump (a stray `release:*` no longer slips through to a patch release).

## Testing

Simulated the label-check step locally under `bash -e` across `[]`, single-label, multi-label, and unrelated-label inputs — all behave correctly (skip / bump / fail-on-multiple).

This PR carries the **`release:patch`** label, so merging it is the live end-to-end test: it should cut **v0.5.4** via the now-fixed workflow.

> Note: GitHub resolves `pull_request` workflows from the base branch. After this merges, `main` will contain the fix, so the merged run should use the corrected file. If GitHub happens to use the pre-merge file, the next `release:*`-labeled PR will release for certain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)