### PR TITLE
ENG-216: Hardening: review-gate resilience, rate-limit coverage, and self-collision safety

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -23,9 +23,11 @@ type Client struct{}
 // New returns a ready-to-use Client.
 func New() *Client { return &Client{} }
 
+const noctraPRBodyMarker = "Implemented by [Noctra]"
+
 // ListNoctraPRs returns every open PR that Noctra created across the
-// given repositories (any branch matching the `noctra/` prefix authored
-// by the current `gh` user).
+// given repositories (authored by the current `gh` user, with a `noctra/`
+// branch and Noctra's generated PR body marker).
 //
 // repoURLs are the git URLs of the repos Noctra has cloned (plus the
 // REPO_PATH fallback). Each is reduced to `owner/name` before being passed to
@@ -45,7 +47,7 @@ func (c *Client) ListNoctraPRs(ctx context.Context, repoURLs []string) ([]PR, er
 			"--repo", ownerRepo,
 			"--author", "@me",
 			"--state", "open",
-			"--json", "url,number,title,headRefName",
+			"--json", "url,number,title,headRefName,body",
 		)
 		cmd.Stderr = &stderr
 		stdout, err := cmd.Output()
@@ -61,11 +63,14 @@ func (c *Client) ListNoctraPRs(ctx context.Context, repoURLs []string) ([]PR, er
 		}
 
 		for _, pr := range prs {
-			if strings.HasPrefix(pr.HeadRefName, "noctra/") {
+			if strings.HasPrefix(pr.HeadRefName, "noctra/") && strings.Contains(pr.Body, noctraPRBodyMarker) {
 				// Remember the remote this PR was found through so the iterate
 				// path can re-resolve over the same transport (e.g. SSH).
 				pr.RepoURL = raw
 				out = append(out, pr)
+			} else if strings.HasPrefix(pr.HeadRefName, "noctra/") {
+				slog.Warn("github: skipping noctra-prefixed PR without Noctra body marker",
+					"repo", ownerRepo, "pr", pr.Number, "branch", pr.HeadRefName)
 			}
 		}
 	}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -3,6 +3,8 @@ package github
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -28,6 +30,34 @@ func TestCheckLogs_NonActionsReturnsSentinel(t *testing.T) {
 	_, err := New().CheckLogs(context.Background(), Check{DetailsURL: "https://circleci.com/gh/me/repo/123"})
 	if !errors.Is(err, ErrNotActionsRun) {
 		t.Errorf("expected ErrNotActionsRun, got %v", err)
+	}
+}
+
+func TestListNoctraPRsRequiresBodyMarker(t *testing.T) {
+	dir := t.TempDir()
+	gh := filepath.Join(dir, "gh")
+	if err := os.WriteFile(gh, []byte(`#!/bin/sh
+cat <<'JSON'
+[
+  {"url":"https://github.com/me/repo/pull/1","number":1,"title":"owned","headRefName":"noctra/eng-1","body":"*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) using Claude Code*"},
+  {"url":"https://github.com/me/repo/pull/2","number":2,"title":"manual","headRefName":"noctra/eng-2","body":"manual PR"},
+  {"url":"https://github.com/me/repo/pull/3","number":3,"title":"other","headRefName":"feat/eng-3","body":"*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra)*"}
+]
+JSON
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	got, err := New().ListNoctraPRs(context.Background(), []string{"me/repo"})
+	if err != nil {
+		t.Fatalf("ListNoctraPRs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d PRs, want 1: %+v", len(got), got)
+	}
+	if got[0].Number != 1 || got[0].RepoURL != "me/repo" {
+		t.Fatalf("PR = %+v, want number 1 with repo URL", got[0])
 	}
 }
 

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -23,6 +23,7 @@ type PR struct {
 	Number      int    `json:"number"`
 	Title       string `json:"title"`
 	HeadRefName string `json:"headRefName"`
+	Body        string `json:"body"`
 
 	// RepoURL is the git remote URL of the clone this PR was discovered from
 	// (set by ListNoctraPRs, not from gh's JSON). It preserves the clone's

--- a/internal/pipeline/git_test.go
+++ b/internal/pipeline/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -95,5 +96,30 @@ func TestBranchAhead(t *testing.T) {
 	}
 	if changed, _ := workingTreeChanged(ctx, dir); changed {
 		t.Fatal("working tree should be clean after the commit (the bug scenario)")
+	}
+}
+
+func TestBoundedReviewDiffTruncatesWithNotice(t *testing.T) {
+	diff := strings.Repeat("a", maxReviewDiffBytes+1000)
+	got := boundedReviewDiff(diff)
+	if len(got) >= len(diff) {
+		t.Fatalf("bounded diff length = %d, want less than original %d", len(got), len(diff))
+	}
+	if !strings.Contains(got, "diff truncated for review") {
+		t.Fatalf("bounded diff missing truncation notice: %q", got)
+	}
+	if !strings.HasPrefix(got, "aaa") || !strings.HasSuffix(got, "aaa") {
+		t.Fatal("bounded diff should preserve both head and tail")
+	}
+}
+
+func TestBoundedReviewDiffPreservesUTF8(t *testing.T) {
+	diff := strings.Repeat("🙂", maxReviewDiffBytes/4+1000)
+	got := boundedReviewDiff(diff)
+	if !strings.Contains(got, "diff truncated for review") {
+		t.Fatal("expected truncation notice")
+	}
+	if strings.ToValidUTF8(got, "") != got {
+		t.Fatal("bounded diff should not split UTF-8 runes")
 	}
 }

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -18,6 +18,11 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/review"
 )
 
+// maxReviewDiffBytes caps the diff sent to the optional Gemini review gate.
+// Review prompts only need enough context to catch obvious issues; an
+// unbounded diff can make the gate slow, expensive, or exceed model limits.
+const maxReviewDiffBytes = 60000
+
 // process is one ticket's full lifecycle: resolve repo → worktree → run
 // Claude → check output → (optional) Gemini review → commit/push → create PR
 // → update Linear. Each failure mode posts a Linear comment and moves the
@@ -250,7 +255,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 		logger.Info("running gemini review gate")
 		for i := 0; i <= p.cfg.MaxReviewRetries; i++ {
 			reviewAttempts = i + 1
-			diff := gitDiff(ctx, wt.Path)
+			diff := boundedReviewDiff(gitDiff(ctx, wt.Path))
 			r, err := p.review.Review(ctx, issue.Title, issue.Description, diff)
 			if err != nil {
 				if errors.Is(err, review.ErrUnavailable) {
@@ -292,14 +297,47 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 - Run tests after fixing to make sure nothing broke.`, r.Body)
 
 				logger.Info("asking the agent to fix review issues")
-				if err := p.agent.Run(ctx, agent.RunOptions{
+				fixOffset := agent.OffsetBefore(logFile)
+				fixErr := p.agent.Run(ctx, agent.RunOptions{
 					Workdir:       wt.Path,
 					Prompt:        fixPrompt,
 					LogFile:       logFile,
 					Timeout:       p.cfg.AgentTimeout,
 					UseAgentTeams: p.cfg.UseAgentTeams,
-				}); err != nil {
-					logger.Warn("fix-pass exited with error", "err", err)
+				})
+
+				if p.isKilled(id) {
+					logger.Info("fix-pass killed by user")
+					repo.CleanupWorktree(context.Background(), resolved.Path, p.cfg.WorktreeBase, id)
+					return
+				}
+				if ctx.Err() != nil {
+					logger.Info("fix-pass cancelled (shutdown)", "reason", ctx.Err())
+					repo.CleanupWorktree(context.Background(), resolved.Path, p.cfg.WorktreeBase, id)
+					return
+				}
+
+				fixOutput := agent.ReadAfter(logFile, fixOffset)
+				switch classifyAgentRun(p.agent, fixErr, fixOutput) {
+				case agentRunTimedOut:
+					logger.Warn("fix-pass timed out", "timeout", p.cfg.AgentTimeout)
+					p.bumpFailed(id)
+					p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
+						"⏰ **Noctra: Agent timed out**\n\n%s timed out after %s while fixing Gemini review feedback.\n\nTicket moved back to **%s**.",
+						p.agent.Label(), p.cfg.AgentTimeout, p.cfg.TriggerState))
+					repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
+					return
+				case agentRunRateLimited:
+					logger.Warn("usage/rate limit detected during fix-pass — triggering shutdown")
+					p.bumpFailed(id)
+					p.flagRateLimit()
+					p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
+						"🛑 **Noctra: Rate limit detected**\n\nThe agent hit a usage or rate limit while fixing Gemini review feedback.\n\nTicket moved back to **%s**. Noctra is shutting down to avoid further limit hits.",
+						p.cfg.TriggerState))
+					repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
+					return
+				case agentRunFailed:
+					logger.Warn("fix-pass exited with error", "err", fixErr)
 				}
 				_ = runIn(ctx, wt.Path, "git", "add", "-A")
 			}
@@ -471,6 +509,60 @@ func gitDiff(ctx context.Context, workdir string) string {
 	cmd2.Dir = workdir
 	out2, _ := cmd2.Output()
 	return string(out2)
+}
+
+func boundedReviewDiff(diff string) string {
+	if len(diff) <= maxReviewDiffBytes {
+		return diff
+	}
+	headLen := maxReviewDiffBytes / 2
+	tailLen := maxReviewDiffBytes - headLen
+	headEnd := safeForwardBoundary(diff, headLen)
+	tailStart := safeBackwardBoundary(diff, len(diff)-tailLen)
+	return fmt.Sprintf("%s\n\n... (diff truncated for review: showing first %d and last %d bytes of %d total bytes) ...\n\n%s",
+		diff[:headEnd], headEnd, len(diff)-tailStart, len(diff), diff[tailStart:])
+}
+
+func safeForwardBoundary(s string, end int) int {
+	if end >= len(s) {
+		return len(s)
+	}
+	for end > 0 && s[end]&0xC0 == 0x80 {
+		end--
+	}
+	return end
+}
+
+func safeBackwardBoundary(s string, start int) int {
+	if start <= 0 {
+		return 0
+	}
+	for start < len(s) && s[start]&0xC0 == 0x80 {
+		start++
+	}
+	return start
+}
+
+type agentRunStatus int
+
+const (
+	agentRunOK agentRunStatus = iota
+	agentRunTimedOut
+	agentRunRateLimited
+	agentRunFailed
+)
+
+func classifyAgentRun(b agent.Backend, runErr error, output string) agentRunStatus {
+	if errors.Is(runErr, agent.ErrTimedOut) {
+		return agentRunTimedOut
+	}
+	if rateLimited(b, runErr, output) {
+		return agentRunRateLimited
+	}
+	if runErr != nil {
+		return agentRunFailed
+	}
+	return agentRunOK
 }
 
 // ghCreatePR runs `gh pr create` and returns the URL printed by gh.

--- a/internal/pipeline/ratelimit_test.go
+++ b/internal/pipeline/ratelimit_test.go
@@ -39,3 +39,23 @@ func TestRateLimited_OnlyOnFailure(t *testing.T) {
 		t.Error("failed run without markers should not be classified as rate-limited")
 	}
 }
+
+func TestClassifyAgentRun_FixPassTimeoutAndRateLimit(t *testing.T) {
+	codex, err := agent.New("codex")
+	if err != nil {
+		t.Fatalf("New(codex): %v", err)
+	}
+
+	if got := classifyAgentRun(codex, agent.ErrTimedOut, ""); got != agentRunTimedOut {
+		t.Fatalf("timeout classify = %v, want %v", got, agentRunTimedOut)
+	}
+	if got := classifyAgentRun(codex, errors.New("exit status 1"), "Error: rate limit reached"); got != agentRunRateLimited {
+		t.Fatalf("rate limit classify = %v, want %v", got, agentRunRateLimited)
+	}
+	if got := classifyAgentRun(codex, errors.New("exit status 1"), "syntax error"); got != agentRunFailed {
+		t.Fatalf("generic failure classify = %v, want %v", got, agentRunFailed)
+	}
+	if got := classifyAgentRun(codex, nil, "Error: rate limit reached"); got != agentRunOK {
+		t.Fatalf("successful transcript classify = %v, want %v", got, agentRunOK)
+	}
+}

--- a/internal/review/gemini.go
+++ b/internal/review/gemini.go
@@ -121,10 +121,10 @@ func (g *Gate) reviewAPI(ctx context.Context, prompt string) (Result, error) {
 		return Result{}, err
 	}
 
-	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent",
+	endpoint := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent",
 		url.PathEscape(g.Model))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return Result{}, err
 	}
@@ -244,7 +244,8 @@ var verdictLineRe = regexp.MustCompile(`(?i)(?:\*\*)?\s*VERDICT\s*:?\s*(PASS|FAI
 
 func reviewVerdict(text string) string {
 	for _, line := range strings.Split(text, "\n") {
-		m := verdictLineRe.FindStringSubmatch(line)
+		normalized := strings.ReplaceAll(line, "*", "")
+		m := verdictLineRe.FindStringSubmatch(normalized)
 		if len(m) == 2 {
 			return strings.ToUpper(m[1])
 		}

--- a/internal/review/gemini.go
+++ b/internal/review/gemini.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -119,18 +121,20 @@ func (g *Gate) reviewAPI(ctx context.Context, prompt string) (Result, error) {
 		return Result{}, err
 	}
 
-	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s",
-		g.Model, g.APIKey)
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent",
+		url.PathEscape(g.Model))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return Result{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", g.APIKey)
 
 	resp, err := g.HTTP.Do(req)
 	if err != nil {
-		return Result{}, fmt.Errorf("gemini request: %w", err)
+		return Result{Skipped: true, Passed: true, Body: fmt.Sprintf("Gemini API request failed: %v", err)},
+			fmt.Errorf("%w: gemini request: %v", ErrUnavailable, err)
 	}
 	defer resp.Body.Close()
 
@@ -138,8 +142,19 @@ func (g *Gate) reviewAPI(ctx context.Context, prompt string) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body := strings.TrimSpace(string(raw))
+		if body == "" {
+			body = resp.Status
+		}
+		return Result{Skipped: true, Passed: true, Body: fmt.Sprintf("Gemini API unavailable (%s): %s", resp.Status, body)},
+			fmt.Errorf("%w: gemini API returned %s", ErrUnavailable, resp.Status)
+	}
 
 	var parsed struct {
+		PromptFeedback struct {
+			BlockReason string `json:"blockReason"`
+		} `json:"promptFeedback"`
 		Candidates []struct {
 			Content struct {
 				Parts []struct {
@@ -151,8 +166,14 @@ func (g *Gate) reviewAPI(ctx context.Context, prompt string) (Result, error) {
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return Result{}, fmt.Errorf("decode gemini response: %w", err)
 	}
+	if parsed.PromptFeedback.BlockReason != "" {
+		body := "Gemini API safety-blocked the review prompt: " + parsed.PromptFeedback.BlockReason
+		return Result{Skipped: true, Passed: true, Body: body},
+			fmt.Errorf("%w: %s", ErrUnavailable, body)
+	}
 	if len(parsed.Candidates) == 0 || len(parsed.Candidates[0].Content.Parts) == 0 {
-		return Result{}, errors.New("gemini response had no candidates")
+		return Result{Skipped: true, Passed: true, Body: "Gemini API returned no review candidates."},
+			fmt.Errorf("%w: gemini response had no candidates", ErrUnavailable)
 	}
 
 	text := parsed.Candidates[0].Content.Parts[0].Text
@@ -211,9 +232,22 @@ func isCLIUnavailableMessage(msg string) bool {
 }
 
 func parseResult(text string) Result {
-	upper := strings.ToUpper(text)
+	verdict := reviewVerdict(text)
 	return Result{
-		Passed: strings.Contains(upper, "VERDICT: PASS"),
-		Body:   text,
+		Passed:  verdict == "PASS" || verdict == "",
+		Skipped: verdict == "",
+		Body:    text,
 	}
+}
+
+var verdictLineRe = regexp.MustCompile(`(?i)(?:\*\*)?\s*VERDICT\s*:?\s*(PASS|FAIL)\b`)
+
+func reviewVerdict(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		m := verdictLineRe.FindStringSubmatch(line)
+		if len(m) == 2 {
+			return strings.ToUpper(m[1])
+		}
+	}
+	return ""
 }

--- a/internal/review/gemini_test.go
+++ b/internal/review/gemini_test.go
@@ -190,8 +190,10 @@ func TestParseResultToleratesVerdictFormatting(t *testing.T) {
 		skipped bool
 	}{
 		{name: "bolded", text: "**VERDICT: PASS**\nLooks good.", passed: true},
+		{name: "bolded label", text: "**VERDICT**: PASS\nLooks good.", passed: true},
 		{name: "missing space", text: "VERDICT:PASS\nLooks good.", passed: true},
 		{name: "fail", text: "**VERDICT: FAIL**\nNeeds work.", passed: false},
+		{name: "bolded fail label", text: "**VERDICT**: FAIL\nNeeds work.", passed: false},
 		{name: "unparseable", text: "Looks fine to me.", passed: true, skipped: true},
 	}
 	for _, tt := range tests {

--- a/internal/review/gemini_test.go
+++ b/internal/review/gemini_test.go
@@ -3,6 +3,8 @@ package review
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,6 +110,113 @@ func TestReviewAPIRequiresKeyForEnabled(t *testing.T) {
 	}
 	if !NewWithMode("cli", "", "").Enabled() {
 		t.Fatal("cli mode should be enabled without GEMINI_API_KEY")
+	}
+}
+
+func TestReviewAPISendsKeyInHeaderNotQuery(t *testing.T) {
+	var gotQuery, gotKey string
+	g := NewWithMode("api", "secret-key", "gemini-test")
+	g.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotQuery = req.URL.RawQuery
+		gotKey = req.Header.Get("x-goog-api-key")
+		return jsonResponse(200, `{"candidates":[{"content":{"parts":[{"text":"VERDICT: PASS\nok"}]}}]}`), nil
+	})}
+
+	res, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	if !res.Passed || res.Skipped {
+		t.Fatalf("result = %+v, want passed", res)
+	}
+	if gotQuery != "" {
+		t.Fatalf("query = %q, want no API key query params", gotQuery)
+	}
+	if gotKey != "secret-key" {
+		t.Fatalf("x-goog-api-key = %q, want secret-key", gotKey)
+	}
+}
+
+func TestReviewAPINon2xxIsUnavailable(t *testing.T) {
+	g := NewWithMode("api", "secret-key", "gemini-test")
+	g.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(429, `{"error":{"message":"quota exceeded"}}`), nil
+	})}
+
+	res, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if !res.Skipped || !res.Passed {
+		t.Fatalf("result = %+v, want skipped pass", res)
+	}
+}
+
+func TestReviewAPINoCandidatesIsUnavailable(t *testing.T) {
+	g := NewWithMode("api", "secret-key", "gemini-test")
+	g.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(200, `{}`), nil
+	})}
+
+	res, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if !res.Skipped || !res.Passed {
+		t.Fatalf("result = %+v, want skipped pass", res)
+	}
+}
+
+func TestReviewAPISafetyBlockIsUnavailable(t *testing.T) {
+	g := NewWithMode("api", "secret-key", "gemini-test")
+	g.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(200, `{"promptFeedback":{"blockReason":"SAFETY"}}`), nil
+	})}
+
+	res, err := g.Review(context.Background(), "Ticket", "Description", "diff")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if !res.Skipped || !res.Passed || !strings.Contains(res.Body, "SAFETY") {
+		t.Fatalf("result = %+v, want skipped safety body", res)
+	}
+}
+
+func TestParseResultToleratesVerdictFormatting(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		passed  bool
+		skipped bool
+	}{
+		{name: "bolded", text: "**VERDICT: PASS**\nLooks good.", passed: true},
+		{name: "missing space", text: "VERDICT:PASS\nLooks good.", passed: true},
+		{name: "fail", text: "**VERDICT: FAIL**\nNeeds work.", passed: false},
+		{name: "unparseable", text: "Looks fine to me.", passed: true, skipped: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseResult(tt.text)
+			if got.Passed != tt.passed || got.Skipped != tt.skipped {
+				t.Fatalf("parseResult(%q) = %+v, want passed=%v skipped=%v",
+					tt.text, got, tt.passed, tt.skipped)
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }
 

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -233,19 +233,16 @@ func (w *Watcher) diff(pr github.PR, d *github.Details, cursor state.PRState) PR
 	return out
 }
 
-// failedChecks returns the failing checks, but only once every check has
-// completed — while any check is still running we return nil so the watcher
-// waits for the full picture rather than reacting to a transient red.
+// failedChecks returns any checks that have reached a final failing state.
+// It does not wait for unrelated pending checks: a manual approval or stuck
+// queue should not indefinitely hide a real failure that is already final.
 func failedChecks(checks []github.Check) []github.Check {
 	if len(checks) == 0 {
 		return nil
 	}
 	var failed []github.Check
 	for _, c := range checks {
-		if !c.IsComplete() {
-			return nil
-		}
-		if c.IsFailure() {
+		if c.IsComplete() && c.IsFailure() {
 			failed = append(failed, c)
 		}
 	}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -157,7 +157,7 @@ func TestDiff_CIFailureAlreadyHandledForSHA(t *testing.T) {
 	}
 }
 
-func TestDiff_CIStillRunningIsIgnored(t *testing.T) {
+func TestDiff_CIFailureSurfacesEvenWithPendingCheck(t *testing.T) {
 	w := newTestWatcher(t, nil)
 	pr := github.PR{URL: "https://github.com/me/repo/pull/1"}
 	details := &github.Details{
@@ -169,8 +169,11 @@ func TestDiff_CIStillRunningIsIgnored(t *testing.T) {
 		},
 	}
 	ch := w.diff(pr, details, state.PRState{})
-	if ch.CIFailure != nil {
-		t.Error("should wait until all checks complete before acting on CI")
+	if ch.CIFailure == nil {
+		t.Fatal("expected completed failure even while another check is pending")
+	}
+	if len(ch.CIFailure.FailedChecks) != 1 || ch.CIFailure.FailedChecks[0].CheckName() != "build" {
+		t.Fatalf("failed checks = %+v, want build only", ch.CIFailure.FailedChecks)
 	}
 }
 


### PR DESCRIPTION
## ENG-216: Hardening: review-gate resilience, rate-limit coverage, and self-collision safety

**Linear:** https://linear.app/amazz/issue/ENG-216/hardening-review-gate-resilience-rate-limit-coverage-and-self

## What was implemented

Implemented ENG-216 hardening:
- Gemini API outages, non-2xx responses, safety blocks, and no-candidate responses now return `ErrUnavailable` and skip the review gate.
- Gemini API key is sent via `x-goog-api-key`, not a query parameter.
- Review verdict parsing now tolerates bolded verdicts and `VERDICT:PASS`; unparseable output skips the gate.
- Review diffs are capped at 60KB with a head+tail truncation notice.
- Review fix-pass runs now handle timeout and rate-limit output like the main run, including shutdown flagging on rate limits.
- CI watcher now surfaces completed failed checks even if unrelated checks are still pending.
- Auto-iterate now requires Noctra’s PR body marker in addition to `--author @me` and `noctra/` branch prefix to reduce self-collision risk.

Added tests for Gemini API/header/error behavior, verdict parsing, diff truncation, fix-pass classification, CI pending/failure behavior, and PR body-marker filtering.

Verification:
- `go test ./...` passed.
- `go vet ./...` passed.
- `git diff --check` passed.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using OpenAI Codex*