### PR TITLE
ENG-231: Noctra auto-applies a release:* label on PR creation (agent-suggested bump)

### DIFF
--- a/internal/agent/log.go
+++ b/internal/agent/log.go
@@ -74,12 +74,17 @@ func BlockedLine(output string) string {
 var releaseRe = regexp.MustCompile(`(?im)^RELEASE:\s*(.+)$`)
 
 // ReleaseBump extracts the semver bump suggestion from the agent output.
+// When multiple matches exist (e.g. the agent echoes the prompt instruction
+// before emitting its own RELEASE: line), the last match wins — mirroring the
+// betweenMarkers strategy for summary extraction.
 // Returns one of "patch", "minor", "major", "none", or "" (not found / unparseable).
 func ReleaseBump(output string) string {
-	m := releaseRe.FindStringSubmatch(output)
-	if m == nil {
+	matches := releaseRe.FindAllStringSubmatch(output, -1)
+	if len(matches) == 0 {
 		return ""
 	}
+	// Use the last match — the agent's actual answer, not an echoed instruction.
+	m := matches[len(matches)-1]
 	val := strings.ToLower(strings.TrimSpace(m[1]))
 	switch val {
 	case "patch", "minor", "major", "none":

--- a/internal/agent/log.go
+++ b/internal/agent/log.go
@@ -69,6 +69,43 @@ func BlockedLine(output string) string {
 	return m
 }
 
+// releaseRe matches the "RELEASE: <bump>" line the prompt asks the agent to
+// emit after its summary. Case-insensitive, anchored to start of line.
+var releaseRe = regexp.MustCompile(`(?im)^RELEASE:\s*(.+)$`)
+
+// ReleaseBump extracts the semver bump suggestion from the agent output.
+// Returns one of "patch", "minor", "major", "none", or "" (not found / unparseable).
+func ReleaseBump(output string) string {
+	m := releaseRe.FindStringSubmatch(output)
+	if m == nil {
+		return ""
+	}
+	val := strings.ToLower(strings.TrimSpace(m[1]))
+	switch val {
+	case "patch", "minor", "major", "none":
+		return val
+	}
+	return ""
+}
+
+// ReleaseLabel returns the GitHub label name for a given bump level, or ""
+// when the bump is "none" (intentionally skip release). An empty/unrecognized
+// bump falls back to defaultBump.
+func ReleaseLabel(bump, defaultBump string) string {
+	switch bump {
+	case "none":
+		return ""
+	case "patch", "minor", "major":
+		return "release:" + bump
+	default:
+		// Missing or unparseable — use the configured default.
+		if defaultBump == "" {
+			defaultBump = "patch"
+		}
+		return "release:" + defaultBump
+	}
+}
+
 // Summary markers the prompt asks the agent to wrap its final summary in (see
 // BuildPrompt). Extracting between these is backend-agnostic and deterministic:
 // it strips everything the CLI streams around the summary — Codex's diff dump

--- a/internal/agent/log_test.go
+++ b/internal/agent/log_test.go
@@ -137,6 +137,7 @@ func TestReleaseBump(t *testing.T) {
 		{"unparseable value", "RELEASE: yolo\n", ""},
 		{"empty value", "RELEASE: \n", ""},
 		{"after summary markers", SummaryStartMarker + "\nstuff\n" + SummaryEndMarker + "\nRELEASE: minor\n", "minor"},
+		{"echoed prompt then real answer", "End with RELEASE: patch | minor | major | none\n...\nRELEASE: minor\n", "minor"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/agent/log_test.go
+++ b/internal/agent/log_test.go
@@ -117,3 +117,59 @@ func TestExtractSummary_FallbackStripsUsageFooter(t *testing.T) {
 		t.Errorf("fallback should strip usage footer, got: %q", got)
 	}
 }
+
+func TestReleaseBump(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{"patch lowercase", "some output\nRELEASE: patch\n", "patch"},
+		{"minor lowercase", "RELEASE: minor\n", "minor"},
+		{"major lowercase", "RELEASE: major\n", "major"},
+		{"none", "RELEASE: none\n", "none"},
+		{"case insensitive key", "release: minor\n", "minor"},
+		{"case insensitive value", "RELEASE: MINOR\n", "minor"},
+		{"mixed case", "Release: Patch\n", "patch"},
+		{"with leading spaces in value", "RELEASE:   patch  \n", "patch"},
+		{"mid-output", "line one\nRELEASE: major\nline three\n", "major"},
+		{"missing", "no release line here\n", ""},
+		{"unparseable value", "RELEASE: yolo\n", ""},
+		{"empty value", "RELEASE: \n", ""},
+		{"after summary markers", SummaryStartMarker + "\nstuff\n" + SummaryEndMarker + "\nRELEASE: minor\n", "minor"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReleaseBump(tt.output)
+			if got != tt.want {
+				t.Errorf("ReleaseBump(%q) = %q, want %q", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReleaseLabel(t *testing.T) {
+	tests := []struct {
+		name        string
+		bump        string
+		defaultBump string
+		want        string
+	}{
+		{"patch", "patch", "patch", "release:patch"},
+		{"minor", "minor", "patch", "release:minor"},
+		{"major", "major", "patch", "release:major"},
+		{"none skips", "none", "patch", ""},
+		{"empty falls back to default patch", "", "patch", "release:patch"},
+		{"empty falls back to default minor", "", "minor", "release:minor"},
+		{"unknown falls back to default", "invalid", "major", "release:major"},
+		{"empty default falls back to patch", "", "", "release:patch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReleaseLabel(tt.bump, tt.defaultBump)
+			if got != tt.want {
+				t.Errorf("ReleaseLabel(%q, %q) = %q, want %q", tt.bump, tt.defaultBump, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -16,6 +16,9 @@ type BuildPromptInput struct {
 	// to do — actually unblocks a retry.
 	Comments []string
 	UseTeams bool
+	// AutoReleaseLabel enables the RELEASE: instruction in the prompt,
+	// asking the agent to suggest a semver bump level.
+	AutoReleaseLabel bool
 }
 
 // BuildPrompt returns the prompt sent to Claude for a ticket. Two flavors:
@@ -31,6 +34,16 @@ func BuildPrompt(in BuildPromptInput) string {
 	if len(in.Comments) > 0 {
 		discussion = "\n\n## Ticket discussion (human clarifications — treat as authoritative, newest wins):\n" +
 			strings.Join(in.Comments, "\n\n")
+	}
+
+	releaseInstruction := ""
+	if in.AutoReleaseLabel {
+		releaseInstruction = `
+
+After your summary (outside the markers), emit exactly one line:
+RELEASE: patch | minor | major | none
+
+Guidelines: none = docs/chore/internal-only, patch = bug fix, minor = new feature, major = breaking change.`
 	}
 
 	if in.UseTeams {
@@ -62,7 +75,7 @@ Provide a brief summary of what was implemented and any important decisions made
 ===NOCTRA SUMMARY===
 <your summary here>
 ===END NOCTRA SUMMARY===
-`, in.Identifier, in.Title, desc, discussion)
+%s`, in.Identifier, in.Title, desc, discussion, releaseInstruction)
 	}
 
 	return fmt.Sprintf(`You are implementing a Linear ticket.
@@ -89,5 +102,5 @@ Provide a brief summary of what was implemented and any important decisions made
 ===NOCTRA SUMMARY===
 <your summary here>
 ===END NOCTRA SUMMARY===
-`, in.Identifier, in.Title, desc, discussion)
+%s`, in.Identifier, in.Title, desc, discussion, releaseInstruction)
 }

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -49,3 +49,43 @@ func TestBuildPrompt_CommentsInTeamsFlavor(t *testing.T) {
 		t.Errorf("teams prompt missing the clarification comment:\n%s", out)
 	}
 }
+
+func TestBuildPrompt_ReleaseInstructionWhenEnabled(t *testing.T) {
+	out := BuildPrompt(BuildPromptInput{
+		Identifier:       "ENG-50",
+		Title:            "Add feature",
+		Description:      "Details.",
+		AutoReleaseLabel: true,
+	})
+	if !strings.Contains(out, "RELEASE: patch | minor | major | none") {
+		t.Errorf("prompt should include RELEASE instruction when AutoReleaseLabel=true:\n%s", out)
+	}
+}
+
+func TestBuildPrompt_NoReleaseInstructionWhenDisabled(t *testing.T) {
+	out := BuildPrompt(BuildPromptInput{
+		Identifier:       "ENG-51",
+		Title:            "Fix bug",
+		Description:      "Details.",
+		AutoReleaseLabel: false,
+	})
+	if strings.Contains(out, "RELEASE:") {
+		t.Errorf("prompt should NOT include RELEASE instruction when AutoReleaseLabel=false:\n%s", out)
+	}
+}
+
+func TestBuildPrompt_ReleaseInstructionInTeamsFlavor(t *testing.T) {
+	out := BuildPrompt(BuildPromptInput{
+		Identifier:       "ENG-52",
+		Title:            "Teams feature",
+		Description:      "Details.",
+		UseTeams:         true,
+		AutoReleaseLabel: true,
+	})
+	if !strings.Contains(out, "team of agents") {
+		t.Fatalf("expected the teams-flavor prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "RELEASE: patch | minor | major | none") {
+		t.Errorf("teams prompt should include RELEASE instruction when AutoReleaseLabel=true:\n%s", out)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,9 @@ const (
 	// Auto-iterate (ENG-173) — disabled by default; opt in via .env.
 	DefaultMaxPRIterations = 3
 	DefaultPRPollInterval  = 2 * time.Minute
+
+	// Auto-release-label (ENG-231) — disabled by default; opt in via .env.
+	DefaultReleaseBump = "patch"
 )
 
 // Config is Noctra's resolved runtime configuration.
@@ -142,6 +145,12 @@ type Config struct {
 	PRPollInterval   time.Duration
 	TrustedReviewers []string // GitHub logins/bots Noctra will act on (default: humans only)
 	StateFile        string   // where the per-PR cursor + iteration count is persisted
+
+	// Auto-release-label (ENG-231) — off by default. When enabled, Noctra
+	// applies a release:* label at PR creation derived from the agent's
+	// RELEASE: line in its output.
+	AutoReleaseLabel   bool
+	DefaultReleaseBump string // "patch" (default), "minor", or "major"
 
 	// Derived paths
 	ScriptDir    string
@@ -219,6 +228,10 @@ func Load(scriptDir string) (*Config, error) {
 	cfg.TrustedReviewers = getlist(fileEnv, "TRUSTED_REVIEWERS")
 	cfg.StateFile = getenv(fileEnv, "STATE_FILE", filepath.Join(home, ".noctra-state.json"))
 
+	// Auto-release-label
+	cfg.AutoReleaseLabel = getbool(fileEnv, "AUTO_RELEASE_LABEL", false)
+	cfg.DefaultReleaseBump = strings.ToLower(strings.TrimSpace(getenv(fileEnv, "DEFAULT_RELEASE_BUMP", DefaultReleaseBump)))
+
 	return cfg, nil
 }
 
@@ -253,6 +266,14 @@ func (c *Config) Validate() error {
 	case "api", "cli":
 	default:
 		errs = append(errs, fmt.Sprintf("GEMINI_MODE must be \"api\" or \"cli\", got %q", c.GeminiMode))
+	}
+
+	if c.AutoReleaseLabel {
+		switch c.DefaultReleaseBump {
+		case "patch", "minor", "major":
+		default:
+			errs = append(errs, fmt.Sprintf("DEFAULT_RELEASE_BUMP must be \"patch\", \"minor\", or \"major\", got %q", c.DefaultReleaseBump))
+		}
 	}
 
 	if c.RepoPath != "" && !isGitRepo(c.RepoPath) {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -424,6 +424,10 @@ func (p *Pipeline) banner() {
 		autoIterMode = fmt.Sprintf("On (cap %d, poll %s)",
 			p.cfg.MaxPRIterations, p.cfg.PRPollInterval)
 	}
+	autoReleaseMode := "Disabled"
+	if p.cfg.AutoReleaseLabel {
+		autoReleaseMode = fmt.Sprintf("On (default: %s)", p.cfg.DefaultReleaseBump)
+	}
 
 	// Repos are routed per-ticket from each Linear project's "Repo:" directive
 	// and cloned on demand, so there's no static list at startup — report the
@@ -454,6 +458,7 @@ func (p *Pipeline) banner() {
 	fmt.Printf("   Agent:          %s\n", agentMode)
 	fmt.Printf("   Review:         %s\n", reviewMode)
 	fmt.Printf("   Auto-iterate:   %s\n", autoIterMode)
+	fmt.Printf("   Release label:  %s\n", autoReleaseMode)
 	fmt.Printf("   Max concurrent: %d\n", p.cfg.MaxConcurrent)
 	fmt.Printf("   Poll interval:  %s\n", p.cfg.PollInterval)
 	fmt.Printf("   Agent timeout:  %s\n", p.cfg.AgentTimeout)

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -102,11 +102,12 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	// ── Run Claude ───────────────────────────────────────────────────────────
 	prompt := agent.BuildPrompt(agent.BuildPromptInput{
-		Identifier:  id,
-		Title:       issue.Title,
-		Description: issue.Description,
-		Comments:    issue.ClarificationComments(),
-		UseTeams:    p.cfg.UseAgentTeams,
+		Identifier:       id,
+		Title:            issue.Title,
+		Description:      issue.Description,
+		Comments:         issue.ClarificationComments(),
+		UseTeams:         p.cfg.UseAgentTeams,
+		AutoReleaseLabel: p.cfg.AutoReleaseLabel,
 	})
 
 	logger.Info("running agent",
@@ -416,6 +417,22 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 		return
 	}
 
+	// ── Auto-release label (ENG-231) ────────────────────────────────────────
+	if p.cfg.AutoReleaseLabel {
+		bump := agent.ReleaseBump(output)
+		label := agent.ReleaseLabel(bump, p.cfg.DefaultReleaseBump)
+		if label != "" {
+			if err := ghAddLabel(ctx, resolved.Path, prURL, label); err != nil {
+				// Degrade gracefully: label failure never blocks the PR.
+				logger.Warn("could not apply release label", "label", label, "err", err)
+			} else {
+				logger.Info("applied release label", "label", label, "agent_bump", bump)
+			}
+		} else {
+			logger.Info("release label skipped (agent suggested none)")
+		}
+	}
+
 	logger.Info("✅ PR created", "url", prURL)
 	p.bumpSuccess()
 	p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — %s\nPR ready (via %s): %s",
@@ -579,6 +596,19 @@ func ghCreatePR(ctx context.Context, repoPath, title, body, base, head string) (
 		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// ghAddLabel applies a label to an existing PR via `gh pr edit --add-label`.
+// prURL is the PR URL returned by ghCreatePR. Errors are returned to the
+// caller for logging but never block the PR.
+func ghAddLabel(ctx context.Context, repoPath, prURL, label string) error {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "edit", prURL, "--add-label", label)
+	cmd.Dir = repoPath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 // gitHeadShort returns the abbreviated HEAD commit SHA, or "" on error.


### PR DESCRIPTION
## ENG-231: Noctra auto-applies a release:* label on PR creation (agent-suggested bump)

**Linear:** https://linear.app/amazz/issue/ENG-231/noctra-auto-applies-a-release-label-on-pr-creation-agent-suggested

## What was implemented

Implemented ENG-231: auto-apply `release:*` label on PR creation based on agent-suggested semver bump.

**Config** (`internal/config/config.go`):
- Added `AUTO_RELEASE_LABEL` (bool, default off) and `DEFAULT_RELEASE_BUMP` (string, default "patch") with validation that rejects unknown bump values when the feature is enabled.

**Prompt** (`internal/agent/prompt.go`):
- Added `AutoReleaseLabel` field to `BuildPromptInput`. When true, both the normal and agent-teams prompt flavors append a `RELEASE: patch | minor | major | none` instruction after the summary markers, with brief guidelines for each level.

**Parser** (`internal/agent/log.go`):
- `ReleaseBump(output)` — regex-based parser (case-insensitive, line-anchored) that extracts and normalizes the bump from agent output. Returns "" for missing/unparseable values.
- `ReleaseLabel(bump, defaultBump)` — maps a bump to the `release:<level>` GitHub label name. Returns "" for "none" (intentional skip). Falls back to `defaultBump` for empty/unrecognized input.

**PR creation** (`internal/pipeline/process.go`):
- After `ghCreatePR` succeeds, when `AutoReleaseLabel` is enabled, parses the agent output for the RELEASE line, resolves the label, and applies it via `gh pr edit --add-label`. Label application failure logs a warning but never blocks the PR.
- Added `ghAddLabel` helper.

**Banner** (`internal/pipeline/pipeline.go`):
- Added "Release label" line showing "Disabled" or "On (default: <bump>)".

**Tests** (`internal/agent/log_test.go`, `internal/agent/prompt_test.go`):
- 13 test cases for `ReleaseBump` covering case-insensitivity, valid/invalid/missing values, and placement after summary markers.
- 8 test cases for `ReleaseLabel` covering all bump levels, "none" skip, and default fallback.
- 3 prompt tests verifying the RELEASE instruction appears only when `AutoReleaseLabel=true` (both normal and teams flavors).

RELEASE: minor

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*