### PR TITLE
ENG-230: Per-ticket agent backend selection via a Linear label (fallback to AGENT_BACKEND)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -301,7 +302,14 @@ func (c *Config) AllCandidateCLIs() []string {
 			seen[cli] = true
 		}
 	}
+	// Collect agent CLIs into a sorted slice so the output order is
+	// deterministic (Go map iteration is randomized).
+	sorted := make([]string, 0, len(agentCLIs))
 	for _, cli := range agentCLIs {
+		sorted = append(sorted, cli)
+	}
+	slices.Sort(sorted)
+	for _, cli := range sorted {
 		if !seen[cli] {
 			clis = append(clis, cli)
 			seen[cli] = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -288,6 +288,28 @@ func (c *Config) RequiredCLIs() []string {
 	return clis
 }
 
+// AllCandidateCLIs returns the base CLIs plus every agent backend's CLI.
+// Used by the doctor to surface missing backends that per-ticket label
+// selection could request at runtime (e.g. "agent:codex" on a ticket when
+// only claude is installed).
+func (c *Config) AllCandidateCLIs() []string {
+	seen := map[string]bool{}
+	clis := make([]string, 0, len(baseCLIs)+len(agentCLIs))
+	for _, cli := range baseCLIs {
+		if !seen[cli] {
+			clis = append(clis, cli)
+			seen[cli] = true
+		}
+	}
+	for _, cli := range agentCLIs {
+		if !seen[cli] {
+			clis = append(clis, cli)
+			seen[cli] = true
+		}
+	}
+	return clis
+}
+
 // CheckCLIs returns the subset of RequiredCLIs that are missing from PATH.
 // `Validate` hard-errors on config; this is the softer PATH check used by
 // `run`/`cleanup` and the setup wizard's status block.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -545,6 +545,39 @@ AGENT_BACKEND="gemini"
 	}
 }
 
+func TestAllCandidateCLIs_ContainsAllBackends(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	clis := cfg.AllCandidateCLIs()
+	// Must contain the base CLIs (git, gh) and all agent CLIs.
+	want := map[string]bool{"git": false, "gh": false, "claude": false, "codex": false, "copilot": false}
+	for _, c := range clis {
+		if _, ok := want[c]; ok {
+			want[c] = true
+		}
+	}
+	for k, found := range want {
+		if !found {
+			t.Errorf("AllCandidateCLIs() missing %q", k)
+		}
+	}
+	// No duplicates.
+	seen := map[string]bool{}
+	for _, c := range clis {
+		if seen[c] {
+			t.Errorf("AllCandidateCLIs() has duplicate %q", c)
+		}
+		seen[c] = true
+	}
+}
+
 // initBareRepo creates a minimal-looking git repo (just a .git directory) so
 // isGitRepo returns true without us shelling out to git in tests.
 func initBareRepo(t *testing.T) string {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -45,6 +45,24 @@ func gather(scriptDir string) []check {
 		checks = append(checks, checkCLI(cli))
 	}
 
+	// ── Optional agent CLIs (per-ticket label selection) ─────────────────────
+	// Tickets can override the default backend with an "agent:<name>" label,
+	// so non-default agent CLIs are surfaced as advisory (always marked OK).
+	if loadErr == nil {
+		defaultCLI := cfg.AgentCLI()
+		for _, cli := range cfg.AllCandidateCLIs() {
+			if cli == defaultCLI || cli == "git" || cli == "gh" {
+				continue // already checked above
+			}
+			c := checkCLI(cli)
+			if !c.ok {
+				c.ok = true // advisory, not a hard failure
+				c.detail = "not installed (optional — needed if a ticket uses agent:" + cli + " label)"
+			}
+			checks = append(checks, c)
+		}
+	}
+
 	// ── gh auth ──────────────────────────────────────────────────────────────
 	checks = append(checks, checkGHAuth())
 

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -77,7 +77,7 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 func (c *Client) FetchTriggerIssues(ctx context.Context, stateName string) ([]Issue, error) {
 	query := `query($state: String!) {
 	  teams { nodes { issues(filter: { state: { name: { eq: $state } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name description content } comments(last: 50) { nodes { body user { name } } } }
+	    nodes { id identifier title description url project { name description content } comments(last: 50) { nodes { body user { name } } } labels { nodes { name } } }
 	  } } }
 	}`
 
@@ -239,7 +239,7 @@ func (c *Client) Comment(ctx context.Context, issueID, body string) error {
 // to UUIDs for the `issue(id:)` argument.
 func (c *Client) GetIssueByIdentifier(ctx context.Context, identifier string) (Issue, error) {
 	query := `query($id: String!) {
-	  issue(id: $id) { id identifier title description url project { name } state { name type } assignee { name } }
+	  issue(id: $id) { id identifier title description url project { name } state { name type } assignee { name } labels { nodes { name } } }
 	}`
 
 	var resp struct {
@@ -318,7 +318,7 @@ func (c *Client) SearchIssues(ctx context.Context, term string, limit int) ([]Is
 func (c *Client) FetchLabeledIssues(ctx context.Context, labelName string) ([]Issue, error) {
 	query := `query($label: String!) {
 	  teams { nodes { issues(filter: { labels: { name: { eq: $label } } }, orderBy: updatedAt, first: 20) {
-	    nodes { id identifier title description url project { name description content } comments(last: 50) { nodes { body user { name } } } }
+	    nodes { id identifier title description url project { name description content } comments(last: 50) { nodes { body user { name } } } labels { nodes { name } } }
 	  } } }
 	}`
 

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -66,6 +66,16 @@ type User struct {
 	Name string `json:"name"`
 }
 
+// Label is a Linear label attached to an issue.
+type Label struct {
+	Name string `json:"name"`
+}
+
+// LabelConnection is the GraphQL connection wrapper around an issue's labels.
+type LabelConnection struct {
+	Nodes []Label `json:"nodes"`
+}
+
 // Comment is a single Linear comment. Body is Markdown; User is the author
 // (nil for app/integration comments). Only populated by queries that request
 // comments — the trigger fetches — and empty otherwise.
@@ -82,7 +92,8 @@ type CommentConnection struct {
 // Issue is the subset of a Linear issue Noctra acts on. State and Assignee
 // are only populated by the read queries that request them (e.g.
 // GetIssueByIdentifier); they are nil otherwise. Comments is only populated by
-// the trigger fetches (FetchTriggerIssues / FetchLabeledIssues).
+// the trigger fetches (FetchTriggerIssues / FetchLabeledIssues). Labels is
+// populated by the trigger fetches and GetIssueByIdentifier.
 type Issue struct {
 	ID          string            `json:"id"`
 	Identifier  string            `json:"identifier"`
@@ -93,6 +104,7 @@ type Issue struct {
 	State       *WorkflowState    `json:"state,omitempty"`
 	Assignee    *User             `json:"assignee,omitempty"`
 	Comments    CommentConnection `json:"comments,omitempty"`
+	Labels      LabelConnection   `json:"labels,omitempty"`
 }
 
 // systemCommentMarkers identify comments that Noctra (or the Linear↔GitHub
@@ -178,4 +190,23 @@ func (i Issue) AssigneeName() string {
 		return ""
 	}
 	return i.Assignee.Name
+}
+
+// BackendLabelPrefix is the label-name prefix that selects a per-ticket
+// coding-agent backend (e.g. "agent:codex" → backend "codex").
+const BackendLabelPrefix = "agent:"
+
+// BackendLabel extracts the backend name from the issue's labels by looking
+// for one prefixed with "agent:" (e.g. "agent:codex" → "codex"). Returns ""
+// when no such label is present or the suffix is empty/whitespace-only.
+func (i Issue) BackendLabel() string {
+	for _, l := range i.Labels.Nodes {
+		name := strings.ToLower(strings.TrimSpace(l.Name))
+		if strings.HasPrefix(name, BackendLabelPrefix) {
+			if v := strings.TrimSpace(strings.TrimPrefix(name, BackendLabelPrefix)); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
 }

--- a/internal/linear/types_test.go
+++ b/internal/linear/types_test.go
@@ -81,3 +81,39 @@ func TestProjectRepoDirective_NilSafe(t *testing.T) {
 		t.Errorf("nil project: got (%q,%q)", r, b)
 	}
 }
+
+func TestBackendLabel(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels []Label
+		want   string
+	}{
+		{"no labels", nil, ""},
+		{"unrelated labels", []Label{{Name: "bug"}, {Name: "noctra"}}, ""},
+		{"agent:codex", []Label{{Name: "agent:codex"}}, "codex"},
+		{"agent:claude", []Label{{Name: "priority"}, {Name: "agent:claude"}}, "claude"},
+		{"agent:copilot", []Label{{Name: "agent:copilot"}}, "copilot"},
+		// Case-insensitive + trimmed.
+		{"Agent:Codex", []Label{{Name: "Agent:Codex"}}, "codex"},
+		{"spaces", []Label{{Name: " agent: claude "}}, "claude"},
+		// Empty suffix ignored.
+		{"agent: (empty)", []Label{{Name: "agent:"}}, ""},
+		{"agent: (spaces)", []Label{{Name: "agent:   "}}, ""},
+		// First match wins.
+		{"first wins", []Label{{Name: "agent:codex"}, {Name: "agent:claude"}}, "codex"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			issue := Issue{Labels: LabelConnection{Nodes: c.labels}}
+			if got := issue.BackendLabel(); got != c.want {
+				t.Errorf("BackendLabel() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestBackendLabel_EmptyIssue(t *testing.T) {
+	if got := (Issue{}).BackendLabel(); got != "" {
+		t.Errorf("empty issue BackendLabel() = %q, want empty", got)
+	}
+}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -167,12 +167,41 @@ func countEvents(events []watch.Event) (comments, reviews int) {
 	return
 }
 
+// resolveIterateBackend picks the coding-agent backend for a PR iteration.
+// Priority: persisted state → issue's current labels → pipeline default.
+func (p *Pipeline) resolveIterateBackend(ctx context.Context, prURL, identifier string) agent.Backend {
+	// 1. Persisted state — the backend the PR was created with.
+	if cursor := p.store.Get(prURL); cursor.AgentBackend != "" {
+		if b, err := agent.New(cursor.AgentBackend); err == nil {
+			return b
+		}
+		slog.Warn("persisted backend invalid — trying labels",
+			"id", identifier, "backend", cursor.AgentBackend)
+	}
+
+	// 2. Re-derive from the issue's current labels.
+	if issue, err := p.linear.GetIssueByIdentifier(ctx, identifier); err == nil {
+		if label := issue.BackendLabel(); label != "" {
+			if b, err := agent.New(label); err == nil {
+				return b
+			}
+		}
+	}
+
+	// 3. Pipeline default.
+	return p.agent
+}
+
 // iteratePR is one re-engagement on an open PR. Resolves the repo, resumes
 // the existing remote branch, builds a fix prompt from the new feedback,
 // runs Claude, and pushes the follow-up commit.
 func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier string) {
 	logger := slog.With("id", identifier, "pr", ch.PR.URL)
 	logger.Info("re-engaging on PR", "events", len(ch.Events), "ci_failed", ch.CIFailure != nil)
+
+	// Select the backend for this iteration — persisted state (from when the
+	// PR was created) takes priority so follow-up commits use the same backend.
+	backend := p.resolveIterateBackend(ctx, ch.PR.URL, identifier)
 
 	// Heads-up Telegram (always — not gated by TELEGRAM_VERBOSE).
 	p.telegram.Send(ctx, fmt.Sprintf("🔄 *%s* — %s on PR #%d", notify.EscapeMarkdown(identifier), engagementSummary(ch), ch.PR.Number))
@@ -271,9 +300,9 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	_ = agent.AttemptHeader(logFile)
 	offset := agent.OffsetBefore(logFile)
 
-	logger.Info("running agent", "backend", p.agent.Name(), "log", logFile)
+	logger.Info("running agent", "backend", backend.Name(), "log", logFile)
 
-	runErr := p.agent.Run(ctx, agent.RunOptions{
+	runErr := backend.Run(ctx, agent.RunOptions{
 		Workdir:       wt.Path,
 		Prompt:        prompt,
 		LogFile:       logFile,
@@ -306,7 +335,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	// Rate limit is only classified on a failed run (see rateLimited), so a
 	// successful iteration whose transcript merely mentions "rate limit" (file
 	// content / diff) doesn't trigger a false shutdown.
-	if rateLimited(p.agent, runErr, output) {
+	if rateLimited(backend, runErr, output) {
 		logger.Warn("rate limit detected during iteration")
 		p.flagRateLimit()
 		return
@@ -348,7 +377,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		commitMsg := appendCoAuthorTrailer(
 			fmt.Sprintf("fix: address PR feedback on %s\n\nFollow-up commit by Noctra (%s).",
 				identifier, engagementSummary(ch)),
-			p.agent.CoAuthor())
+			backend.CoAuthor())
 		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
 			logger.Error("git commit failed", "err", err)
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -171,12 +171,14 @@ func countEvents(events []watch.Event) (comments, reviews int) {
 // Priority: persisted state → issue's current labels → pipeline default.
 func (p *Pipeline) resolveIterateBackend(ctx context.Context, prURL, identifier string) agent.Backend {
 	// 1. Persisted state — the backend the PR was created with.
-	if cursor := p.store.Get(prURL); cursor.AgentBackend != "" {
-		if b, err := agent.New(cursor.AgentBackend); err == nil {
-			return b
+	if p.store != nil {
+		if cursor := p.store.Get(prURL); cursor.AgentBackend != "" {
+			if b, err := agent.New(cursor.AgentBackend); err == nil {
+				return b
+			}
+			slog.Warn("persisted backend invalid — trying labels",
+				"id", identifier, "backend", cursor.AgentBackend)
 		}
-		slog.Warn("persisted backend invalid — trying labels",
-			"id", identifier, "backend", cursor.AgentBackend)
 	}
 
 	// 2. Re-derive from the issue's current labels.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -415,7 +415,7 @@ func (p *Pipeline) banner() {
 	if p.telegram.Enabled {
 		notifyMode = "Telegram"
 	}
-	agentMode := fmt.Sprintf("%s (%s)", p.agent.Label(), p.agent.CLI())
+	agentMode := fmt.Sprintf("per-ticket via label (default: %s)", p.agent.Label())
 	if p.cfg.UseAgentTeams {
 		agentMode += " + agent teams"
 	}

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -16,12 +16,33 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/notify"
 	"github.com/ahmadAlMezaal/noctra/internal/repo"
 	"github.com/ahmadAlMezaal/noctra/internal/review"
+	"github.com/ahmadAlMezaal/noctra/internal/state"
 )
 
 // maxReviewDiffBytes caps the diff sent to the optional Gemini review gate.
 // Review prompts only need enough context to catch obvious issues; an
 // unbounded diff can make the gate slow, expensive, or exceed model limits.
 const maxReviewDiffBytes = 60000
+
+// resolveBackend returns the coding-agent backend for a ticket. If the issue
+// carries an "agent:<name>" label, that backend is used; otherwise the
+// pipeline's default (p.agent) is returned. An unknown label value degrades
+// to the default with a warning — never a hard failure.
+func (p *Pipeline) resolveBackend(issue linear.Issue) agent.Backend {
+	label := issue.BackendLabel()
+	if label == "" {
+		return p.agent
+	}
+	b, err := agent.New(label)
+	if err != nil {
+		slog.Warn("unknown backend label — using default",
+			"id", issue.Identifier, "label", label, "default", p.agent.Name(), "err", err)
+		return p.agent
+	}
+	slog.Info("per-ticket backend from label",
+		"id", issue.Identifier, "backend", b.Name(), "label", label)
+	return b
+}
 
 // process is one ticket's full lifecycle: resolve repo → worktree → run
 // Claude → check output → (optional) Gemini review → commit/push → create PR
@@ -31,6 +52,10 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	id := issue.Identifier
 	logger := slog.With("id", id)
 	logger.Info("starting", "title", issue.Title)
+
+	// Select the coding-agent backend for this ticket — an "agent:<name>"
+	// label overrides the configured default.
+	backend := p.resolveBackend(issue)
 
 	if p.cfg.TelegramVerbose {
 		p.telegram.Send(ctx, fmt.Sprintf("🎯 *%s* — %s\nNoctra picked it up — working on it.",
@@ -110,7 +135,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	})
 
 	logger.Info("running agent",
-		"backend", p.agent.Name(),
+		"backend", backend.Name(),
 		"log", logFile,
 		"timeout", p.cfg.AgentTimeout,
 		"agent_teams", p.cfg.UseAgentTeams)
@@ -119,7 +144,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// BLOCKED / rate-limit checks only inspect this attempt's output.
 	offset := agent.OffsetBefore(logFile)
 
-	runErr := p.agent.Run(ctx, agent.RunOptions{
+	runErr := backend.Run(ctx, agent.RunOptions{
 		Workdir:       wt.Path,
 		Prompt:        prompt,
 		LogFile:       logFile,
@@ -162,7 +187,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// legitimately writing the words "rate limit" into a file got its completed
 	// work discarded (ENG-178 — Codex built the Noctra landing page, whose
 	// copy advertises "rate-limit detection"; three good runs were thrown away).
-	if rateLimited(p.agent, runErr, output) {
+	if rateLimited(backend, runErr, output) {
 		logger.Warn("usage/rate limit detected — triggering shutdown")
 		p.bumpFailed(id)
 		p.flagRateLimit()
@@ -298,7 +323,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 				logger.Info("asking the agent to fix review issues")
 				fixOffset := agent.OffsetBefore(logFile)
-				fixErr := p.agent.Run(ctx, agent.RunOptions{
+				fixErr := backend.Run(ctx, agent.RunOptions{
 					Workdir:       wt.Path,
 					Prompt:        fixPrompt,
 					LogFile:       logFile,
@@ -318,13 +343,13 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 				}
 
 				fixOutput := agent.ReadAfter(logFile, fixOffset)
-				switch classifyAgentRun(p.agent, fixErr, fixOutput) {
+				switch classifyAgentRun(backend, fixErr, fixOutput) {
 				case agentRunTimedOut:
 					logger.Warn("fix-pass timed out", "timeout", p.cfg.AgentTimeout)
 					p.bumpFailed(id)
 					p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
 						"⏰ **Noctra: Agent timed out**\n\n%s timed out after %s while fixing Gemini review feedback.\n\nTicket moved back to **%s**.",
-						p.agent.Label(), p.cfg.AgentTimeout, p.cfg.TriggerState))
+						backend.Label(), p.cfg.AgentTimeout, p.cfg.TriggerState))
 					repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 					return
 				case agentRunRateLimited:
@@ -354,8 +379,8 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// "nothing to commit" and bounce a valid implementation (ENG-182).
 	commitMsg := appendCoAuthorTrailer(
 		fmt.Sprintf("feat: implement %s — %s\n\nImplemented by Noctra using %s\n\nLinear: %s",
-			id, issue.Title, p.agent.Label(), issue.URL),
-		p.agent.CoAuthor())
+			id, issue.Title, backend.Label(), issue.URL),
+		backend.CoAuthor())
 
 	staged, err := hasStagedChanges(ctx, wt.Path)
 	if err != nil {
@@ -401,7 +426,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	prBody := fmt.Sprintf(
 		"## %s: %s\n\n**Linear:** %s\n\n## What was implemented\n\n%s\n%s\n---\n\n*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using %s*",
-		id, issue.Title, issue.URL, summary, reviewSection, p.agent.Label())
+		id, issue.Title, issue.URL, summary, reviewSection, backend.Label())
 
 	// ── gh pr create ─────────────────────────────────────────────────────────
 	prURL, err := ghCreatePR(ctx, resolved.Path,
@@ -419,7 +444,18 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	logger.Info("✅ PR created", "url", prURL)
 	p.bumpSuccess()
 	p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — %s\nPR ready (via %s): %s",
-		id, notify.EscapeMarkdown(issue.Title), notify.EscapeMarkdown(p.agent.Label()), prURL))
+		id, notify.EscapeMarkdown(issue.Title), notify.EscapeMarkdown(backend.Label()), prURL))
+
+	// Persist the chosen backend so auto-iterate uses the same one for
+	// follow-up commits on this PR.
+	if p.store != nil {
+		if err := p.store.Update(prURL, func(r *state.PRState) {
+			r.TicketID = id
+			r.AgentBackend = backend.Name()
+		}); err != nil {
+			logger.Warn("could not persist backend in PR state", "err", err)
+		}
+	}
 
 	// ── Move to In Review + remove trigger label ────────────────────────────
 	if p.cfg.TriggerMode == "label" && p.labelID != "" {
@@ -432,7 +468,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	}
 	if err := p.linear.Comment(ctx, issue.ID, fmt.Sprintf(
 		"🌙 **Noctra created a PR** (via %s)\n\n**PR:** %s\n\nMoved to **%s**. Ready for your review!",
-		p.agent.Label(), prURL, p.cfg.InReviewState)); err != nil {
+		backend.Label(), prURL, p.cfg.InReviewState)); err != nil {
 		logger.Warn("could not post Linear comment", "err", err)
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,6 +23,11 @@ type PRState struct {
 	// Used to route comments on Linear when re-engaging or capping.
 	TicketID string `json:"ticket_id,omitempty"`
 
+	// AgentBackend is the coding-agent backend the PR was created with
+	// (e.g. "claude", "codex", "copilot"). Persisted so the auto-iterate
+	// path uses the same backend for follow-up commits on this PR.
+	AgentBackend string `json:"agent_backend,omitempty"`
+
 	// LastCommentAt is the createdAt of the most recent issue-conversation
 	// comment the watcher has already processed for this PR. Anything with
 	// a later timestamp is "new" and worth acting on. Tracking by timestamp


### PR DESCRIPTION
## ENG-230: Per-ticket agent backend selection via a Linear label (fallback to AGENT_BACKEND)

**Linear:** https://linear.app/amazz/issue/ENG-230/per-ticket-agent-backend-selection-via-a-linear-label-fallback-to

## What was implemented

Implemented per-ticket agent backend selection via Linear labels (`agent:claude` / `agent:codex` / `agent:copilot`), falling back to the configured `AGENT_BACKEND` when no label is present.

**Changes across 10 files (230 lines added, 20 removed):**

1. **`internal/linear/types.go`** — Added `Label`, `LabelConnection` types and a `Labels` field on `Issue`. Added `BackendLabelPrefix` constant (`"agent:"`) and `Issue.BackendLabel()` method that extracts the backend name from an `agent:<name>` label (case-insensitive, trimmed).

2. **`internal/linear/operations.go`** — Added `labels { nodes { name } }` to the GraphQL queries in `FetchTriggerIssues`, `FetchLabeledIssues`, and `GetIssueByIdentifier` so issue labels are always fetched.

3. **`internal/pipeline/process.go`** — Added `resolveBackend()` helper that picks the backend from the issue's `agent:*` label (or falls back to the pipeline default with a warning on unknown labels). Replaced all `p.agent` references in `process()` with the per-ticket `backend` local variable (~8 call sites: Run, Name, Label, CoAuthor, HasRateLimit, classifyAgentRun). After PR creation, persists the chosen backend name in `state.PRState.AgentBackend` via `p.store.Update`.

4. **`internal/pipeline/iterate.go`** — Added `resolveIterateBackend()` that reads the persisted backend from `PRState`, falls back to re-deriving from the issue's current labels via `GetIssueByIdentifier`, then to the pipeline default. Replaced all `p.agent` references in `iteratePR()` with the resolved `backend`.

5. **`internal/state/state.go`** — Added `AgentBackend` field to `PRState` (JSON: `agent_backend`) so the chosen backend survives restarts and is used for follow-up commits on auto-iterate.

6. **`internal/config/config.go`** — Added `AllCandidateCLIs()` method that returns base CLIs + all agent backend CLIs (for doctor's advisory checks).

7. **`internal/doctor/doctor.go`** — After checking the required CLIs, now also checks all non-default agent CLIs as advisory (marked OK even if missing, with a hint about the `agent:` label that would need them).

8. **`internal/pipeline/pipeline.go`** — Updated the startup banner to show `"per-ticket via label (default: <backend>)"` instead of just the default backend.

9. **Tests** — Added `TestBackendLabel` (10 cases covering normal, case-insensitive, empty suffix, first-wins) and `TestBackendLabel_EmptyIssue` in `types_test.go`. Added `TestAllCandidateCLIs_ContainsAllBackends` in `config_test.go`. All existing tests continue to pass.

**Key decisions:**
- Unknown backend labels degrade to the default with a warning, never a hard failure.
- The `p.store` nil guard prevents crashes when `AutoIteratePRs` is disabled.
- The iterate backend resolution priority (persisted state → issue labels → default) ensures consistency even if the label is removed after dispatch.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*