### PR TITLE
ENG-219: Reply to and resolve PR review threads on GitHub

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -330,8 +330,8 @@ func (c *Client) fetchUnresolvedThreads(ctx context.Context, owner, repo string,
 	var stderr strings.Builder
 	cmd := exec.CommandContext(ctx, "gh", "api", "graphql",
 		"-f", "query="+query,
-		"-F", "owner="+owner,
-		"-F", "repo="+repo,
+		"-f", "owner="+owner,
+		"-f", "repo="+repo,
 		"-F", fmt.Sprintf("number=%d", number),
 	)
 	cmd.Stderr = &stderr

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -257,4 +258,182 @@ func ExtractOwnerRepo(raw string) (string, error) {
 
 func looksLikeOwnerRepo(s string) bool {
 	return strings.Count(s, "/") == 1 && !strings.HasPrefix(s, "/") && !strings.HasSuffix(s, "/")
+}
+
+// reviewThread is an unresolved review thread on a PR, fetched via GraphQL.
+type reviewThread struct {
+	ID                     string // GraphQL node ID (used to resolve the thread)
+	FirstCommentDatabaseID int64  // REST API ID of the first comment (used to reply)
+}
+
+// ReplyAndResolveThreads replies to and resolves all unresolved review threads
+// on a PR with a short note referencing the new commit SHA. Best-effort:
+// individual failures are logged, never returned. Mirrors the existing
+// "non-fatal on failure" posture for inline-comment fetches.
+func (c *Client) ReplyAndResolveThreads(ctx context.Context, prURL, sha string) {
+	owner, repo, number, err := parsePRURL(prURL)
+	if err != nil {
+		slog.Warn("github: cannot parse PR URL for thread resolution", "url", prURL, "err", err)
+		return
+	}
+
+	threads, err := c.fetchUnresolvedThreads(ctx, owner, repo, number)
+	if err != nil {
+		slog.Warn("github: fetch review threads failed", "url", prURL, "err", err)
+		return
+	}
+
+	if len(threads) == 0 {
+		return
+	}
+
+	replyBody := fmt.Sprintf("Addressed in %s.", sha)
+
+	resolved := 0
+	for _, t := range threads {
+		if t.FirstCommentDatabaseID > 0 {
+			if err := c.replyToThread(ctx, owner, repo, number, t.FirstCommentDatabaseID, replyBody); err != nil {
+				slog.Warn("github: reply to review thread failed", "thread", t.ID, "err", err)
+			}
+		}
+		if err := c.resolveThread(ctx, t.ID); err != nil {
+			slog.Warn("github: resolve review thread failed", "thread", t.ID, "err", err)
+		} else {
+			resolved++
+		}
+	}
+
+	slog.Info("github: review threads addressed", "url", prURL, "total", len(threads), "resolved", resolved)
+}
+
+// fetchUnresolvedThreads queries the GitHub GraphQL API for all unresolved
+// review threads on a PR. Returns only threads that are not yet resolved.
+func (c *Client) fetchUnresolvedThreads(ctx context.Context, owner, repo string, number int) ([]reviewThread, error) {
+	query := `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes {
+              databaseId
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	var stderr strings.Builder
+	cmd := exec.CommandContext(ctx, "gh", "api", "graphql",
+		"-f", "query="+query,
+		"-F", "owner="+owner,
+		"-F", "repo="+repo,
+		"-F", fmt.Sprintf("number=%d", number),
+	)
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api graphql: %w (%s)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	return decodeReviewThreads(stdout)
+}
+
+// decodeReviewThreads parses the GraphQL response for review threads and
+// returns only the unresolved ones.
+func decodeReviewThreads(data []byte) ([]reviewThread, error) {
+	var resp struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						Nodes []struct {
+							ID         string `json:"id"`
+							IsResolved bool   `json:"isResolved"`
+							Comments   struct {
+								Nodes []struct {
+									DatabaseID int64 `json:"databaseId"`
+								} `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("decode review threads: %w", err)
+	}
+
+	var threads []reviewThread
+	for _, n := range resp.Data.Repository.PullRequest.ReviewThreads.Nodes {
+		if n.IsResolved {
+			continue
+		}
+		var commentID int64
+		if len(n.Comments.Nodes) > 0 {
+			commentID = n.Comments.Nodes[0].DatabaseID
+		}
+		threads = append(threads, reviewThread{
+			ID:                     n.ID,
+			FirstCommentDatabaseID: commentID,
+		})
+	}
+	return threads, nil
+}
+
+// replyToThread posts a reply on a review comment thread via the REST API.
+func (c *Client) replyToThread(ctx context.Context, owner, repo string, prNumber int, commentID int64, body string) error {
+	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%d/comments/%d/replies", owner, repo, prNumber, commentID)
+	var stderr strings.Builder
+	cmd := exec.CommandContext(ctx, "gh", "api", "--method", "POST", apiPath,
+		"-f", "body="+body,
+	)
+	cmd.Stderr = &stderr
+	if _, err := cmd.Output(); err != nil {
+		return fmt.Errorf("gh api POST %s: %w (%s)", apiPath, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// resolveThread resolves a review thread via the GitHub GraphQL API.
+func (c *Client) resolveThread(ctx context.Context, threadID string) error {
+	mutation := `mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}`
+
+	var stderr strings.Builder
+	cmd := exec.CommandContext(ctx, "gh", "api", "graphql",
+		"-f", "query="+mutation,
+		"-f", "threadId="+threadID,
+	)
+	cmd.Stderr = &stderr
+	if _, err := cmd.Output(); err != nil {
+		return fmt.Errorf("gh api graphql resolveReviewThread: %w (%s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// parsePRURL extracts owner, repo name, and PR number from a GitHub PR URL
+// like https://github.com/owner/repo/pull/42.
+func parsePRURL(prURL string) (owner, repo string, number int, err error) {
+	u, err := url.Parse(prURL)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("parse PR URL %q: %w", prURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" || parts[0] == "" || parts[1] == "" || parts[3] == "" {
+		return "", "", 0, fmt.Errorf("unexpected PR URL shape: %q", prURL)
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return "", "", 0, fmt.Errorf("PR number is not an integer in %q: %w", prURL, err)
+	}
+	return parts[0], parts[1], n, nil
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -209,10 +209,10 @@ func TestDetailsIsOpen(t *testing.T) {
 
 func TestParsePRURL(t *testing.T) {
 	cases := []struct {
-		in              string
-		owner, repo     string
-		number          int
-		wantErr         bool
+		in          string
+		owner, repo string
+		number      int
+		wantErr     bool
 	}{
 		{"https://github.com/me/auth/pull/42", "me", "auth", 42, false},
 		{"https://github.com/org/repo/pull/1", "org", "repo", 1, false},

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -206,3 +206,212 @@ func TestDetailsIsOpen(t *testing.T) {
 		t.Error("State=MERGED should not be open")
 	}
 }
+
+func TestParsePRURL(t *testing.T) {
+	cases := []struct {
+		in              string
+		owner, repo     string
+		number          int
+		wantErr         bool
+	}{
+		{"https://github.com/me/auth/pull/42", "me", "auth", 42, false},
+		{"https://github.com/org/repo/pull/1", "org", "repo", 1, false},
+		{"https://github.com/me/auth/pull/12/files", "me", "auth", 12, false},
+
+		{"https://github.com/me/auth/issues/12", "", "", 0, true},
+		{"https://github.com/me/auth", "", "", 0, true},
+		{"https://github.com/me", "", "", 0, true},
+		{"https://github.com/me/auth/pull/abc", "", "", 0, true},
+		{"", "", "", 0, true},
+	}
+	for _, c := range cases {
+		owner, repo, number, err := parsePRURL(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("parsePRURL(%q): err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if owner != c.owner || repo != c.repo || number != c.number {
+			t.Errorf("parsePRURL(%q) = (%q, %q, %d), want (%q, %q, %d)",
+				c.in, owner, repo, number, c.owner, c.repo, c.number)
+		}
+	}
+}
+
+func TestDecodeReviewThreads(t *testing.T) {
+	data := []byte(`{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "nodes": [
+            {
+              "id": "PRRT_thread1",
+              "isResolved": false,
+              "comments": {"nodes": [{"databaseId": 100}]}
+            },
+            {
+              "id": "PRRT_thread2",
+              "isResolved": true,
+              "comments": {"nodes": [{"databaseId": 200}]}
+            },
+            {
+              "id": "PRRT_thread3",
+              "isResolved": false,
+              "comments": {"nodes": [{"databaseId": 300}]}
+            }
+          ]
+        }
+      }
+    }
+  }
+}`)
+	threads, err := decodeReviewThreads(data)
+	if err != nil {
+		t.Fatalf("decodeReviewThreads: %v", err)
+	}
+	if len(threads) != 2 {
+		t.Fatalf("got %d threads, want 2 (only unresolved)", len(threads))
+	}
+	if threads[0].ID != "PRRT_thread1" || threads[0].FirstCommentDatabaseID != 100 {
+		t.Errorf("thread[0] = %+v", threads[0])
+	}
+	if threads[1].ID != "PRRT_thread3" || threads[1].FirstCommentDatabaseID != 300 {
+		t.Errorf("thread[1] = %+v", threads[1])
+	}
+}
+
+func TestDecodeReviewThreads_Empty(t *testing.T) {
+	data := []byte(`{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {"nodes": []}
+      }
+    }
+  }
+}`)
+	threads, err := decodeReviewThreads(data)
+	if err != nil {
+		t.Fatalf("decodeReviewThreads: %v", err)
+	}
+	if len(threads) != 0 {
+		t.Errorf("got %d threads, want 0", len(threads))
+	}
+}
+
+func TestDecodeReviewThreads_NoComments(t *testing.T) {
+	data := []byte(`{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "nodes": [
+            {
+              "id": "PRRT_orphan",
+              "isResolved": false,
+              "comments": {"nodes": []}
+            }
+          ]
+        }
+      }
+    }
+  }
+}`)
+	threads, err := decodeReviewThreads(data)
+	if err != nil {
+		t.Fatalf("decodeReviewThreads: %v", err)
+	}
+	if len(threads) != 1 {
+		t.Fatalf("got %d threads, want 1", len(threads))
+	}
+	if threads[0].FirstCommentDatabaseID != 0 {
+		t.Errorf("expected 0 comment ID for orphan thread, got %d", threads[0].FirstCommentDatabaseID)
+	}
+}
+
+func TestReplyAndResolveThreads(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "gh-calls.log")
+
+	gh := filepath.Join(dir, "gh")
+	// Use a @@@ delimiter between calls because GraphQL queries contain
+	// newlines, which would make line-counting unreliable.
+	script := `#!/bin/sh
+printf '%s\n@@@\n' "$*" >> ` + logFile + `
+case "$*" in
+  *reviewThreads*)
+    cat <<'JSON'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "nodes": [
+            {
+              "id": "PRRT_abc",
+              "isResolved": false,
+              "comments": {"nodes": [{"databaseId": 42}]}
+            },
+            {
+              "id": "PRRT_def",
+              "isResolved": true,
+              "comments": {"nodes": [{"databaseId": 99}]}
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+JSON
+    exit 0
+    ;;
+esac
+echo "{}"
+`
+	if err := os.WriteFile(gh, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	New().ReplyAndResolveThreads(context.Background(), "https://github.com/me/repo/pull/7", "abc1234")
+
+	log, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+
+	// Split on the @@@ delimiter to get one entry per gh invocation.
+	entries := strings.Split(strings.TrimSpace(string(log)), "@@@")
+	// Filter empty entries from trailing delimiters.
+	var calls []string
+	for _, e := range entries {
+		if s := strings.TrimSpace(e); s != "" {
+			calls = append(calls, s)
+		}
+	}
+
+	// Expect 3 calls: 1 GraphQL fetch + 1 REST reply + 1 GraphQL resolve.
+	// (The resolved thread PRRT_def is skipped.)
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 gh calls, got %d:\n%s", len(calls), string(log))
+	}
+
+	// First call: GraphQL query for threads.
+	if !strings.Contains(calls[0], "api graphql") || !strings.Contains(calls[0], "reviewThreads") {
+		t.Errorf("call 1: expected GraphQL thread fetch, got: %s", calls[0])
+	}
+
+	// Second call: REST reply to comment 42.
+	if !strings.Contains(calls[1], "repos/me/repo/pulls/7/comments/42/replies") {
+		t.Errorf("call 2: expected REST reply, got: %s", calls[1])
+	}
+	if !strings.Contains(calls[1], "Addressed in abc1234") {
+		t.Errorf("call 2: expected SHA in reply body, got: %s", calls[1])
+	}
+
+	// Third call: GraphQL resolve.
+	if !strings.Contains(calls[2], "resolveReviewThread") || !strings.Contains(calls[2], "PRRT_abc") {
+		t.Errorf("call 3: expected GraphQL resolve, got: %s", calls[2])
+	}
+}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -400,6 +400,10 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		}
 		sha := gitHeadShort(ctx, wt.Path)
 		logger.Info("pushed follow-up commit", "sha", sha, "branch", wt.Branch)
+
+		// Reply to and resolve addressed review threads (best-effort).
+		p.gh.ReplyAndResolveThreads(ctx, ch.PR.URL, sha)
+
 		// Completion heads-up (always — mirrors the 🔄 start ping and the
 		// ✅ "PR ready" ping the main ticket flow sends on success).
 		p.telegram.Send(ctx, fmt.Sprintf("✅ *%s* — pushed follow-up to PR #%d (%s)",


### PR DESCRIPTION
## ENG-219: Reply to and resolve PR review threads on GitHub

**Linear:** https://linear.app/amazz/issue/ENG-219/reply-to-and-resolve-pr-review-threads-on-github

## What was implemented

Implemented ENG-219: reply to and resolve PR review threads on GitHub after a successful `iteratePR` push.

**Changes:**

- **`internal/github/client.go`**: Added `ReplyAndResolveThreads(ctx, prURL, sha)` — a best-effort orchestrator that fetches all unresolved review threads on a PR via GraphQL, posts an "Addressed in `<sha>`." reply to each via the REST API, and resolves each thread via the `resolveReviewThread` GraphQL mutation. Individual failures are logged, never returned — matching the existing non-fatal posture for inline-comment fetches. Supporting internals: `parsePRURL`, `fetchUnresolvedThreads`, `decodeReviewThreads`, `replyToThread`, `resolveThread`.

- **`internal/pipeline/iterate.go`**: After a successful push in `iteratePR`, calls `p.gh.ReplyAndResolveThreads(ctx, ch.PR.URL, sha)` to reply to and resolve all unresolved review threads referencing the new commit.

- **`internal/github/client_test.go`**: Added `TestParsePRURL` (table-driven URL parsing), `TestDecodeReviewThreads` / `TestDecodeReviewThreads_Empty` / `TestDecodeReviewThreads_NoComments` (GraphQL response decoding), and `TestReplyAndResolveThreads` (integration test with a fake `gh` script verifying the correct sequence of GraphQL + REST calls).

**Design decisions:**
- Resolves **all** unresolved threads (not just those matching the current batch of events), since the agent was given all outstanding feedback and pushed a fix addressing it.
- Uses GraphQL for thread discovery and resolution (the only API that exposes thread node IDs and `resolveReviewThread`), and REST for posting replies (simpler than the GraphQL comment mutation).
- The `reviewThread` type is unexported — it's an internal implementation detail of the thread resolution flow.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*