### PR TITLE
ENG-218: Read-only web dashboard (runs, logs, queue, cost, controls)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,3 +174,15 @@ TRUSTED_REVIEWERS=
 # Where Noctra persists its per-PR cursor + iteration counter.
 # Defaults to $HOME/.noctra-state.json.
 # STATE_FILE=
+
+# ── Dashboard (optional) ──────────────────────────────────────────────────────
+# A read-only web dashboard embedded in `noctra run`. Off by default.
+# Set DASHBOARD_ADDR to enable (e.g. ":8080" or "127.0.0.1:9000").
+
+# Listen address — leave empty to disable the dashboard.
+# DASHBOARD_ADDR=:8080
+
+# Shared token for auth-gated actions (kill / requeue). When set, the dashboard
+# requires this token in the Authorization header for mutation endpoints. When
+# empty, mutation endpoints are disabled (read-only dashboard).
+# DASHBOARD_TOKEN=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,10 @@ type Config struct {
 	AutoReleaseLabel   bool
 	DefaultReleaseBump string // "patch" (default), "minor", or "major"
 
+	// Dashboard (ENG-218) — off by default, opt-in via DASHBOARD_ADDR.
+	DashboardAddr  string // listen address (e.g. ":8080", "127.0.0.1:9000")
+	DashboardToken string // shared secret for auth-gated actions (kill/requeue)
+
 	// Derived paths
 	ScriptDir    string
 	EnvFile      string
@@ -232,6 +236,10 @@ func Load(scriptDir string) (*Config, error) {
 	// Auto-release-label
 	cfg.AutoReleaseLabel = getbool(fileEnv, "AUTO_RELEASE_LABEL", false)
 	cfg.DefaultReleaseBump = strings.ToLower(strings.TrimSpace(getenv(fileEnv, "DEFAULT_RELEASE_BUMP", DefaultReleaseBump)))
+
+	// Dashboard
+	cfg.DashboardAddr = getenv(fileEnv, "DASHBOARD_ADDR", "")
+	cfg.DashboardToken = getenv(fileEnv, "DASHBOARD_TOKEN", "")
 
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,7 @@ var noctraEnvKeys = []string{
 	"REPOS_BASE", "WORKTREE_BASE", "LOG_DIR",
 	"AUTO_ITERATE_PRS", "MAX_PR_ITERATIONS", "PR_POLL_INTERVAL",
 	"TRUSTED_REVIEWERS", "STATE_FILE",
+	"DASHBOARD_ADDR", "DASHBOARD_TOKEN",
 }
 
 func isolateEnv(t *testing.T) {

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -315,8 +315,15 @@ func (s *Server) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	// Start from current end of file.
 	offset, _ := f.Seek(0, io.SeekEnd)
 
+	// Cap per-tick reads so a fast-growing file can't cause unbounded
+	// memory allocation.
+	const maxReadPerTick = 256 * 1024 // 256 KB
+
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
+
+	// Buffer for an incomplete trailing line from the previous read.
+	var partial string
 
 	for {
 		select {
@@ -327,14 +334,39 @@ func (s *Server) StreamLogs(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return
 			}
-			if info.Size() <= offset {
+
+			// Handle log truncation (e.g. rotation): reset to the
+			// new end so we don't read stale offsets.
+			if info.Size() < offset {
+				offset = info.Size()
+				partial = ""
 				continue
 			}
-			buf := make([]byte, info.Size()-offset)
-			n, err := f.ReadAt(buf, offset)
+
+			if info.Size() == offset {
+				continue
+			}
+
+			toRead := info.Size() - offset
+			if toRead > maxReadPerTick {
+				toRead = maxReadPerTick
+			}
+
+			buf := make([]byte, toRead)
+			n, readErr := f.ReadAt(buf, offset)
 			if n > 0 {
-				// SSE format: replace newlines so the data field is valid.
-				lines := strings.Split(string(buf[:n]), "\n")
+				chunk := partial + string(buf[:n])
+				partial = ""
+
+				lines := strings.Split(chunk, "\n")
+				// If the chunk doesn't end with a newline, the last
+				// element is an incomplete line — buffer it for the
+				// next tick.
+				if !strings.HasSuffix(chunk, "\n") {
+					partial = lines[len(lines)-1]
+					lines = lines[:len(lines)-1]
+				}
+
 				for _, line := range lines {
 					fmt.Fprintf(w, "data: %s\n", line)
 				}
@@ -342,7 +374,7 @@ func (s *Server) StreamLogs(w http.ResponseWriter, r *http.Request) {
 				flusher.Flush()
 				offset += int64(n)
 			}
-			if err != nil && err != io.EOF {
+			if readErr != nil && readErr != io.EOF {
 				return
 			}
 		}

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -44,14 +44,14 @@ type Controller interface {
 
 // Status is the JSON payload for the /api/status endpoint.
 type Status struct {
-	Active     []string `json:"active"`
-	Killed     []string `json:"killed"`
-	Skipped    []string `json:"skipped"`
-	Failed     map[string]int `json:"failed"`
-	Stats      SessionStats `json:"stats"`
+	Active     []string                 `json:"active"`
+	Killed     []string                 `json:"killed"`
+	Skipped    []string                 `json:"skipped"`
+	Failed     map[string]int           `json:"failed"`
+	Stats      SessionStats             `json:"stats"`
 	PRState    map[string]state.PRState `json:"pr_state"`
-	MaxWorkers int `json:"max_workers"`
-	Uptime     string `json:"uptime"`
+	MaxWorkers int                      `json:"max_workers"`
+	Uptime     string                   `json:"uptime"`
 }
 
 // SessionStats holds the aggregate counters for the running session.
@@ -129,7 +129,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(data)
+	_, _ = w.Write(data)
 }
 
 // handleStatus returns the current pipeline snapshot as JSON.
@@ -147,7 +147,7 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 
 	// Sanitise: only allow alphanumeric, dash, underscore to prevent path traversal.
 	for _, c := range id {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '-' && c != '_' {
 			http.Error(w, `{"error":"invalid ticket id"}`, http.StatusBadRequest)
 			return
 		}
@@ -281,7 +281,7 @@ func (s *Server) StreamLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, c := range id {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '-' && c != '_' {
 			http.Error(w, `{"error":"invalid ticket id"}`, http.StatusBadRequest)
 			return
 		}
@@ -338,7 +338,7 @@ func (s *Server) StreamLogs(w http.ResponseWriter, r *http.Request) {
 				for _, line := range lines {
 					fmt.Fprintf(w, "data: %s\n", line)
 				}
-				fmt.Fprint(w, "\n")
+				_, _ = fmt.Fprint(w, "\n")
 				flusher.Flush()
 				offset += int64(n)
 			}

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,0 +1,350 @@
+// Package dashboard serves an opt-in web dashboard embedded in `noctra run`.
+// It is enabled by setting DASHBOARD_ADDR in .env. The dashboard surfaces
+// active runs, queue state, PR-iteration state, session stats, and per-ticket
+// log tails. Kill/requeue actions are auth-gated via DASHBOARD_TOKEN.
+package dashboard
+
+import (
+	"context"
+	"crypto/subtle"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+)
+
+//go:embed static/index.html
+var staticFS embed.FS
+
+// Snapshot is the read-only view the pipeline exposes to the dashboard.
+// The pipeline implements this interface so the dashboard never touches
+// pipeline internals directly.
+type Snapshot interface {
+	// DashboardStatus returns the current pipeline state for the dashboard.
+	DashboardStatus() Status
+}
+
+// Controller is the write interface for kill/requeue actions.
+type Controller interface {
+	// KillRun cancels the in-flight run for the given identifier.
+	KillRun(identifier string) error
+	// Requeue moves a ticket back to the trigger state/label, optionally
+	// posting extraContext as a Linear comment first.
+	Requeue(ctx context.Context, identifier, extraContext string) error
+}
+
+// Status is the JSON payload for the /api/status endpoint.
+type Status struct {
+	Active     []string `json:"active"`
+	Killed     []string `json:"killed"`
+	Skipped    []string `json:"skipped"`
+	Failed     map[string]int `json:"failed"`
+	Stats      SessionStats `json:"stats"`
+	PRState    map[string]state.PRState `json:"pr_state"`
+	MaxWorkers int `json:"max_workers"`
+	Uptime     string `json:"uptime"`
+}
+
+// SessionStats holds the aggregate counters for the running session.
+type SessionStats struct {
+	TotalDispatches int `json:"total_dispatches"`
+	MaxDispatches   int `json:"max_dispatches"`
+	SuccessCount    int `json:"success_count"`
+	FailCount       int `json:"fail_count"`
+}
+
+// Server is the dashboard HTTP server.
+type Server struct {
+	snap   Snapshot
+	ctrl   Controller
+	token  string // shared secret for mutation endpoints
+	logDir string // directory containing per-ticket log files
+	srv    *http.Server
+}
+
+// New creates a dashboard server. It does not start listening — call
+// ListenAndServe for that.
+func New(snap Snapshot, ctrl Controller, token, logDir string) *Server {
+	s := &Server{
+		snap:   snap,
+		ctrl:   ctrl,
+		token:  token,
+		logDir: logDir,
+	}
+
+	mux := http.NewServeMux()
+
+	// API endpoints — all JSON.
+	mux.HandleFunc("GET /api/status", s.handleStatus)
+	mux.HandleFunc("GET /api/logs/{id}", s.handleLogs)
+
+	// Log streaming (SSE).
+	mux.HandleFunc("GET /api/logs/{id}/stream", s.StreamLogs)
+
+	// Mutation endpoints — auth-gated.
+	mux.HandleFunc("POST /api/kill", s.handleKill)
+	mux.HandleFunc("POST /api/requeue", s.handleRequeue)
+
+	// Static assets — the embedded SPA.
+	mux.HandleFunc("GET /", s.handleIndex)
+
+	s.srv = &http.Server{Handler: mux}
+	return s
+}
+
+// ListenAndServe starts the dashboard on addr. It blocks until the server
+// is shut down. Use Shutdown to stop it gracefully.
+func (s *Server) ListenAndServe(addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("dashboard listen: %w", err)
+	}
+	slog.Info("dashboard listening", "addr", ln.Addr().String())
+	return s.srv.Serve(ln)
+}
+
+// Shutdown gracefully stops the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.srv.Shutdown(ctx)
+}
+
+// handleIndex serves the embedded single-page dashboard.
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	data, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write(data)
+}
+
+// handleStatus returns the current pipeline snapshot as JSON.
+func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, s.snap.DashboardStatus())
+}
+
+// handleLogs returns the tail of the log file for a ticket identifier.
+func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, `{"error":"missing ticket id"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Sanitise: only allow alphanumeric, dash, underscore to prevent path traversal.
+	for _, c := range id {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+			http.Error(w, `{"error":"invalid ticket id"}`, http.StatusBadRequest)
+			return
+		}
+	}
+
+	logPath := filepath.Join(s.logDir, id+".log")
+	f, err := os.Open(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.Error(w, `{"error":"log not found"}`, http.StatusNotFound)
+			return
+		}
+		http.Error(w, `{"error":"cannot read log"}`, http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	// Return the last 64KB of the log file.
+	const tailBytes = 64 * 1024
+	info, err := f.Stat()
+	if err != nil {
+		http.Error(w, `{"error":"cannot stat log"}`, http.StatusInternalServerError)
+		return
+	}
+	offset := int64(0)
+	if info.Size() > tailBytes {
+		offset = info.Size() - tailBytes
+	}
+
+	buf := make([]byte, min(info.Size()-offset, tailBytes))
+	n, err := f.ReadAt(buf, offset)
+	if err != nil && err != io.EOF {
+		http.Error(w, `{"error":"read failed"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, map[string]any{
+		"id":   id,
+		"tail": string(buf[:n]),
+		"size": info.Size(),
+	})
+}
+
+// handleKill terminates a running ticket. Auth-gated.
+func (s *Server) handleKill(w http.ResponseWriter, r *http.Request) {
+	if !s.checkAuth(w, r) {
+		return
+	}
+
+	var req struct {
+		Identifier string `json:"identifier"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	req.Identifier = strings.TrimSpace(req.Identifier)
+	if req.Identifier == "" {
+		http.Error(w, `{"error":"identifier is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if err := s.ctrl.KillRun(strings.ToUpper(req.Identifier)); err != nil {
+		writeJSON(w, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, map[string]string{"status": "killed", "identifier": strings.ToUpper(req.Identifier)})
+}
+
+// handleRequeue moves a ticket back to the trigger state/label. Auth-gated.
+func (s *Server) handleRequeue(w http.ResponseWriter, r *http.Request) {
+	if !s.checkAuth(w, r) {
+		return
+	}
+
+	var req struct {
+		Identifier string `json:"identifier"`
+		Context    string `json:"context"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	req.Identifier = strings.TrimSpace(req.Identifier)
+	if req.Identifier == "" {
+		http.Error(w, `{"error":"identifier is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if err := s.ctrl.Requeue(r.Context(), strings.ToUpper(req.Identifier), strings.TrimSpace(req.Context)); err != nil {
+		writeJSON(w, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, map[string]string{"status": "requeued", "identifier": strings.ToUpper(req.Identifier)})
+}
+
+// checkAuth validates the Authorization header against the configured token.
+// Returns false (and writes a 401/403) when auth fails. When no token is
+// configured, mutations are disabled entirely.
+func (s *Server) checkAuth(w http.ResponseWriter, r *http.Request) bool {
+	if s.token == "" {
+		http.Error(w, `{"error":"mutations disabled (no DASHBOARD_TOKEN configured)"}`, http.StatusForbidden)
+		return false
+	}
+	auth := r.Header.Get("Authorization")
+	got := strings.TrimPrefix(auth, "Bearer ")
+	if subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) != 1 {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return false
+	}
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		slog.Warn("dashboard: json encode failed", "err", err)
+	}
+}
+
+// StreamLogs streams the log file for a ticket as Server-Sent Events.
+// Each new chunk appended to the file is sent as a "log" event. The
+// stream ends when the request context is cancelled.
+func (s *Server) StreamLogs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, `{"error":"missing ticket id"}`, http.StatusBadRequest)
+		return
+	}
+	for _, c := range id {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+			http.Error(w, `{"error":"invalid ticket id"}`, http.StatusBadRequest)
+			return
+		}
+	}
+
+	logPath := filepath.Join(s.logDir, id+".log")
+	f, err := os.Open(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.Error(w, `{"error":"log not found"}`, http.StatusNotFound)
+			return
+		}
+		http.Error(w, `{"error":"cannot read log"}`, http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, `{"error":"streaming not supported"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	// Flush headers so the client receives them immediately.
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	// Start from current end of file.
+	offset, _ := f.Seek(0, io.SeekEnd)
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			info, err := f.Stat()
+			if err != nil {
+				return
+			}
+			if info.Size() <= offset {
+				continue
+			}
+			buf := make([]byte, info.Size()-offset)
+			n, err := f.ReadAt(buf, offset)
+			if n > 0 {
+				// SSE format: replace newlines so the data field is valid.
+				lines := strings.Split(string(buf[:n]), "\n")
+				for _, line := range lines {
+					fmt.Fprintf(w, "data: %s\n", line)
+				}
+				fmt.Fprint(w, "\n")
+				flusher.Flush()
+				offset += int64(n)
+			}
+			if err != nil && err != io.EOF {
+				return
+			}
+		}
+	}
+}

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -1,0 +1,521 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+)
+
+// mockSnapshot implements Snapshot for testing.
+type mockSnapshot struct {
+	status Status
+}
+
+func (m *mockSnapshot) DashboardStatus() Status { return m.status }
+
+// mockController implements Controller for testing.
+type mockController struct {
+	killed   []string
+	requeued []struct{ id, ctx string }
+	killErr  error
+	reqErr   error
+}
+
+func (m *mockController) KillRun(id string) error {
+	m.killed = append(m.killed, id)
+	return m.killErr
+}
+
+func (m *mockController) Requeue(_ context.Context, id, ctx string) error {
+	m.requeued = append(m.requeued, struct{ id, ctx string }{id, ctx})
+	return m.reqErr
+}
+
+func newTestServer(snap Snapshot, ctrl Controller, token, logDir string) *httptest.Server {
+	s := New(snap, ctrl, token, logDir)
+	return httptest.NewServer(s.srv.Handler)
+}
+
+func TestHandleStatus(t *testing.T) {
+	snap := &mockSnapshot{status: Status{
+		Active:     []string{"ENG-42", "ENG-43"},
+		Killed:     []string{},
+		Skipped:    []string{"ENG-10"},
+		Failed:     map[string]int{"ENG-11": 2},
+		Stats:      SessionStats{TotalDispatches: 5, MaxDispatches: 10, SuccessCount: 3, FailCount: 1},
+		MaxWorkers: 3,
+		Uptime:     "1h30m",
+	}}
+
+	srv := newTestServer(snap, &mockController{}, "", "")
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/status")
+	if err != nil {
+		t.Fatalf("GET /api/status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type: got %q", ct)
+	}
+
+	var status Status
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(status.Active) != 2 {
+		t.Errorf("active: got %d, want 2", len(status.Active))
+	}
+	if status.Stats.SuccessCount != 3 {
+		t.Errorf("success_count: got %d, want 3", status.Stats.SuccessCount)
+	}
+	if status.MaxWorkers != 3 {
+		t.Errorf("max_workers: got %d, want 3", status.MaxWorkers)
+	}
+	if len(status.Skipped) != 1 || status.Skipped[0] != "ENG-10" {
+		t.Errorf("skipped: got %v", status.Skipped)
+	}
+	if status.Failed["ENG-11"] != 2 {
+		t.Errorf("failed: got %v", status.Failed)
+	}
+}
+
+func TestHandleStatus_WithPRState(t *testing.T) {
+	snap := &mockSnapshot{status: Status{
+		Active:     []string{},
+		Killed:     []string{},
+		Skipped:    []string{},
+		Failed:     map[string]int{},
+		Stats:      SessionStats{},
+		MaxWorkers: 3,
+		Uptime:     "5m",
+		PRState: map[string]state.PRState{
+			"https://github.com/org/repo/pull/42": {
+				TicketID:     "ENG-42",
+				AgentBackend: "claude",
+				Iterations:   2,
+			},
+		},
+	}}
+
+	srv := newTestServer(snap, &mockController{}, "", "")
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/status")
+	if err != nil {
+		t.Fatalf("GET /api/status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var status Status
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	pr, ok := status.PRState["https://github.com/org/repo/pull/42"]
+	if !ok {
+		t.Fatal("expected PR state entry")
+	}
+	if pr.TicketID != "ENG-42" {
+		t.Errorf("ticket_id: got %q", pr.TicketID)
+	}
+	if pr.Iterations != 2 {
+		t.Errorf("iterations: got %d", pr.Iterations)
+	}
+}
+
+func TestHandleLogs(t *testing.T) {
+	logDir := t.TempDir()
+	content := "--- Attempt 2026-01-01 ---\nline1\nline2\nline3\n"
+	if err := os.WriteFile(filepath.Join(logDir, "ENG-42.log"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "", logDir)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/logs/ENG-42")
+	if err != nil {
+		t.Fatalf("GET /api/logs/ENG-42: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result["id"] != "ENG-42" {
+		t.Errorf("id: got %v", result["id"])
+	}
+	tail, ok := result["tail"].(string)
+	if !ok || !strings.Contains(tail, "line1") {
+		t.Errorf("tail: got %q", tail)
+	}
+}
+
+func TestHandleLogs_NotFound(t *testing.T) {
+	logDir := t.TempDir()
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "", logDir)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/logs/NOPE-99")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHandleLogs_PathTraversal(t *testing.T) {
+	logDir := t.TempDir()
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "", logDir)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/logs/../../etc/passwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// The mux won't match /api/logs/../../etc/passwd literally; Go's
+	// http.ServeMux cleans paths. But the character filter also catches
+	// dots and slashes. Either a 400 or 404 is acceptable.
+	if resp.StatusCode == http.StatusOK {
+		t.Error("expected non-200 for path traversal attempt")
+	}
+}
+
+func TestHandleKill_Success(t *testing.T) {
+	ctrl := &mockController{}
+	srv := newTestServer(&mockSnapshot{status: Status{}}, ctrl, "secret", "")
+	defer srv.Close()
+
+	body := strings.NewReader(`{"identifier":"ENG-42"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/kill", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d (%s)", resp.StatusCode, b)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result["status"] != "killed" {
+		t.Errorf("status: got %q", result["status"])
+	}
+	if len(ctrl.killed) != 1 || ctrl.killed[0] != "ENG-42" {
+		t.Errorf("killed: got %v", ctrl.killed)
+	}
+}
+
+func TestHandleKill_NoToken(t *testing.T) {
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "", "")
+	defer srv.Close()
+
+	body := strings.NewReader(`{"identifier":"ENG-42"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/kill", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 when no token configured, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleKill_WrongToken(t *testing.T) {
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "secret", "")
+	defer srv.Close()
+
+	body := strings.NewReader(`{"identifier":"ENG-42"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/kill", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer wrong")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 for wrong token, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleKill_Error(t *testing.T) {
+	ctrl := &mockController{killErr: fmt.Errorf("no active run for ENG-99")}
+	srv := newTestServer(&mockSnapshot{status: Status{}}, ctrl, "secret", "")
+	defer srv.Close()
+
+	body := strings.NewReader(`{"identifier":"ENG-99"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/kill", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]string
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["error"] == "" {
+		t.Error("expected error in response")
+	}
+}
+
+func TestHandleRequeue_Success(t *testing.T) {
+	ctrl := &mockController{}
+	srv := newTestServer(&mockSnapshot{status: Status{}}, ctrl, "tok", "")
+	defer srv.Close()
+
+	body := strings.NewReader(`{"identifier":"ENG-42","context":"try Auth0"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/requeue", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d (%s)", resp.StatusCode, b)
+	}
+
+	if len(ctrl.requeued) != 1 {
+		t.Fatalf("expected 1 requeue, got %d", len(ctrl.requeued))
+	}
+	if ctrl.requeued[0].id != "ENG-42" {
+		t.Errorf("id: got %q", ctrl.requeued[0].id)
+	}
+	if ctrl.requeued[0].ctx != "try Auth0" {
+		t.Errorf("ctx: got %q", ctrl.requeued[0].ctx)
+	}
+}
+
+func TestHandleRequeue_NoAuth(t *testing.T) {
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "tok", "")
+	defer srv.Close()
+
+	body := strings.NewReader(`{"identifier":"ENG-42"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/requeue", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleIndex(t *testing.T) {
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "", "")
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type: got %q", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Noctra Dashboard") {
+		t.Error("expected 'Noctra Dashboard' in HTML body")
+	}
+}
+
+func TestHandleIndex_NotFoundForOtherPaths(t *testing.T) {
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "", "")
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for /nonexistent, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleLogs_LargeFile(t *testing.T) {
+	logDir := t.TempDir()
+	// Create a file larger than 64KB.
+	data := strings.Repeat("x", 100*1024)
+	if err := os.WriteFile(filepath.Join(logDir, "ENG-99.log"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "", logDir)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/logs/ENG-99")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	tail, ok := result["tail"].(string)
+	if !ok {
+		t.Fatal("expected tail field")
+	}
+	// Should return at most 64KB (the tail).
+	if len(tail) > 65*1024 {
+		t.Errorf("tail too large: %d bytes", len(tail))
+	}
+	if len(tail) < 60*1024 {
+		t.Errorf("tail too small: %d bytes", len(tail))
+	}
+}
+
+func TestHandleKill_MissingIdentifier(t *testing.T) {
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "tok", "")
+	defer srv.Close()
+
+	body := strings.NewReader(`{}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/kill", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing identifier, got %d", resp.StatusCode)
+	}
+}
+
+func TestStreamLogs(t *testing.T) {
+	logDir := t.TempDir()
+	logFile := filepath.Join(logDir, "ENG-50.log")
+	if err := os.WriteFile(logFile, []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "", logDir)
+	defer srv.Close()
+
+	// Use a short-lived context so the SSE stream eventually closes.
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+"/api/logs/ENG-50/stream", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("Content-Type: got %q, want text/event-stream", ct)
+	}
+
+	// Append to the log file after a short delay (so the stream is connected).
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return
+		}
+		f.WriteString("streamed line\n")
+		f.Close()
+	}()
+
+	// Read until context deadline; collect everything we get.
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "streamed line") {
+		t.Errorf("expected 'streamed line' in SSE output, got %q", string(body))
+	}
+}
+
+func TestCheckAuth_ConstantTimeCompare(t *testing.T) {
+	// Verify that auth passes with correct token and fails with wrong.
+	srv := newTestServer(&mockSnapshot{status: Status{}}, &mockController{}, "mytoken", "")
+	defer srv.Close()
+
+	// Correct token.
+	body := strings.NewReader(`{"identifier":"ENG-1"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/kill", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer mytoken")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	// KillRun will error (no active run) but auth should pass (not 401/403).
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		t.Error("expected auth to pass with correct token")
+	}
+
+	// Wrong token.
+	body = strings.NewReader(`{"identifier":"ENG-1"}`)
+	req, _ = http.NewRequest("POST", srv.URL+"/api/kill", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer wrong")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 with wrong token, got %d", resp.StatusCode)
+	}
+}

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -294,7 +294,9 @@ func TestHandleKill_Error(t *testing.T) {
 	defer resp.Body.Close()
 
 	var result map[string]string
-	json.NewDecoder(resp.Body).Decode(&result)
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
 	if result["error"] == "" {
 		t.Error("expected error in response")
 	}
@@ -407,7 +409,9 @@ func TestHandleLogs_LargeFile(t *testing.T) {
 	defer resp.Body.Close()
 
 	var result map[string]any
-	json.NewDecoder(resp.Body).Decode(&result)
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
 
 	tail, ok := result["tail"].(string)
 	if !ok {
@@ -474,7 +478,7 @@ func TestStreamLogs(t *testing.T) {
 		if err != nil {
 			return
 		}
-		f.WriteString("streamed line\n")
+		_, _ = f.WriteString("streamed line\n")
 		f.Close()
 	}()
 

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Noctra Dashboard</title>
+<style>
+:root {
+  --bg: #0d1117; --surface: #161b22; --border: #30363d;
+  --text: #c9d1d9; --muted: #8b949e; --accent: #58a6ff;
+  --green: #3fb950; --red: #f85149; --yellow: #d29922;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  background: var(--bg); color: var(--text); line-height: 1.5; padding: 1rem; }
+h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+h2 { font-size: 1.1rem; color: var(--accent); margin: 1rem 0 0.5rem; border-bottom: 1px solid var(--border); padding-bottom: 0.25rem; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem; margin-bottom: 1rem; }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem; }
+.card .label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.card .value { font-size: 1.5rem; font-weight: 600; }
+.card .value.green { color: var(--green); }
+.card .value.red { color: var(--red); }
+.card .value.yellow { color: var(--yellow); }
+table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
+th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--border); font-size: 0.85rem; }
+th { color: var(--muted); font-weight: 500; }
+.badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.75rem; font-weight: 500; }
+.badge-active { background: rgba(56,139,253,0.15); color: var(--accent); }
+.badge-failed { background: rgba(248,81,73,0.15); color: var(--red); }
+.badge-skipped { background: rgba(210,153,34,0.15); color: var(--yellow); }
+.badge-killed { background: rgba(139,148,158,0.15); color: var(--muted); }
+button { background: var(--surface); color: var(--text); border: 1px solid var(--border);
+  border-radius: 4px; padding: 0.3rem 0.6rem; cursor: pointer; font-size: 0.8rem; }
+button:hover { border-color: var(--accent); }
+button.danger { border-color: var(--red); color: var(--red); }
+button.danger:hover { background: rgba(248,81,73,0.1); }
+#log-panel { background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+  padding: 0.75rem; max-height: 400px; overflow-y: auto; font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.8rem; white-space: pre-wrap; word-break: break-all; display: none; }
+#log-title { display: none; }
+.controls { margin: 0.5rem 0; display: flex; gap: 0.5rem; align-items: center; }
+.controls input { background: var(--surface); color: var(--text); border: 1px solid var(--border);
+  border-radius: 4px; padding: 0.3rem 0.6rem; font-size: 0.8rem; width: 120px; }
+#error-bar { background: rgba(248,81,73,0.1); border: 1px solid var(--red); color: var(--red);
+  border-radius: 4px; padding: 0.4rem 0.6rem; font-size: 0.85rem; display: none; margin-bottom: 0.5rem; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.header .uptime { color: var(--muted); font-size: 0.85rem; }
+.empty { color: var(--muted); font-style: italic; padding: 0.4rem 0; }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Noctra Dashboard</h1>
+  <span class="uptime" id="uptime"></span>
+</div>
+
+<div id="error-bar"></div>
+
+<div class="grid" id="stats-grid"></div>
+
+<h2>Active Runs</h2>
+<div id="active-runs"></div>
+
+<h2>Queue</h2>
+<div id="queue-info"></div>
+
+<h2>PR Iteration State</h2>
+<div id="pr-state"></div>
+
+<h2>Controls</h2>
+<div class="controls">
+  <input type="text" id="ctrl-id" placeholder="ENG-42">
+  <button class="danger" onclick="doKill()">Kill</button>
+  <button onclick="doRequeue()">Requeue</button>
+  <input type="text" id="ctrl-ctx" placeholder="extra context" style="width:200px">
+</div>
+
+<h2 id="log-title">Log Tail</h2>
+<div id="log-panel"></div>
+
+<script>
+const TOKEN = localStorage.getItem('noctra_token') || '';
+let streamSource = null;
+
+async function fetchStatus() {
+  try {
+    const resp = await fetch('/api/status');
+    if (!resp.ok) throw new Error(resp.statusText);
+    const data = await resp.json();
+    render(data);
+    hideError();
+  } catch (e) {
+    showError('Failed to fetch status: ' + e.message);
+  }
+}
+
+function render(d) {
+  document.getElementById('uptime').textContent = 'Uptime: ' + d.uptime;
+
+  const s = d.stats;
+  document.getElementById('stats-grid').innerHTML = `
+    <div class="card"><div class="label">Workers</div><div class="value">${d.active.length}/${d.max_workers}</div></div>
+    <div class="card"><div class="label">Dispatches</div><div class="value">${s.total_dispatches}/${s.max_dispatches}</div></div>
+    <div class="card"><div class="label">PRs Created</div><div class="value green">${s.success_count}</div></div>
+    <div class="card"><div class="label">Failed</div><div class="value red">${s.fail_count}</div></div>
+  `;
+
+  // Active runs
+  const activeEl = document.getElementById('active-runs');
+  if (d.active.length === 0) {
+    activeEl.innerHTML = '<div class="empty">No active runs (idle)</div>';
+  } else {
+    let html = '<table><tr><th>Ticket</th><th>Actions</th></tr>';
+    for (const id of d.active) {
+      html += `<tr><td><span class="badge badge-active">${esc(id)}</span></td>
+        <td><button class="danger" onclick="doKillId('${esc(id)}')">Kill</button>
+        <button onclick="viewLog('${esc(id)}')">Logs</button></td></tr>`;
+    }
+    html += '</table>';
+    activeEl.innerHTML = html;
+  }
+
+  // Queue info (failed + skipped + killed)
+  const queueEl = document.getElementById('queue-info');
+  const failKeys = Object.keys(d.failed || {});
+  const skipKeys = d.skipped || [];
+  const killKeys = d.killed || [];
+  if (failKeys.length === 0 && skipKeys.length === 0 && killKeys.length === 0) {
+    queueEl.innerHTML = '<div class="empty">No failed, skipped, or killed tickets</div>';
+  } else {
+    let html = '<table><tr><th>Ticket</th><th>Status</th><th>Detail</th></tr>';
+    for (const id of failKeys) {
+      html += `<tr><td>${esc(id)}</td><td><span class="badge badge-failed">failed</span></td><td>${d.failed[id]} attempts</td></tr>`;
+    }
+    for (const id of skipKeys) {
+      html += `<tr><td>${esc(id)}</td><td><span class="badge badge-skipped">skipped</span></td><td>non-transient</td></tr>`;
+    }
+    for (const id of killKeys) {
+      html += `<tr><td>${esc(id)}</td><td><span class="badge badge-killed">killed</span></td><td></td></tr>`;
+    }
+    html += '</table>';
+    queueEl.innerHTML = html;
+  }
+
+  // PR state
+  const prEl = document.getElementById('pr-state');
+  const prKeys = Object.keys(d.pr_state || {});
+  if (prKeys.length === 0) {
+    prEl.innerHTML = '<div class="empty">No tracked PRs</div>';
+  } else {
+    let html = '<table><tr><th>PR</th><th>Ticket</th><th>Backend</th><th>Iterations</th><th>Last Iterated</th><th>CI SHA</th></tr>';
+    for (const url of prKeys) {
+      const pr = d.pr_state[url];
+      const shortURL = url.replace(/^https:\/\/github\.com\//, '');
+      const lastIter = pr.last_iterated_at ? new Date(pr.last_iterated_at).toLocaleString() : '-';
+      const ciSha = pr.last_ci_sha ? pr.last_ci_sha.substring(0, 7) : '-';
+      html += `<tr><td><a href="${esc(url)}" target="_blank" style="color:var(--accent)">${esc(shortURL)}</a></td>
+        <td>${esc(pr.ticket_id || '-')}</td><td>${esc(pr.agent_backend || '-')}</td>
+        <td>${pr.iterations || 0}</td><td>${lastIter}</td><td><code>${ciSha}</code></td></tr>`;
+    }
+    html += '</table>';
+    prEl.innerHTML = html;
+  }
+}
+
+async function viewLog(id) {
+  document.getElementById('log-title').style.display = 'block';
+  const panel = document.getElementById('log-panel');
+  panel.style.display = 'block';
+  panel.textContent = 'Loading...';
+  try {
+    const resp = await fetch('/api/logs/' + encodeURIComponent(id));
+    if (!resp.ok) throw new Error(resp.statusText);
+    const data = await resp.json();
+    panel.textContent = data.tail || '(empty log)';
+    panel.scrollTop = panel.scrollHeight;
+    startStream(id, panel);
+  } catch (e) {
+    panel.textContent = 'Error: ' + e.message;
+  }
+}
+
+function startStream(id, panel) {
+  if (streamSource) streamSource.close();
+  streamSource = new EventSource('/api/logs/' + encodeURIComponent(id) + '/stream');
+  streamSource.onmessage = function(e) {
+    panel.textContent += e.data + '\n';
+    panel.scrollTop = panel.scrollHeight;
+  };
+  streamSource.onerror = function() {
+    streamSource.close();
+    streamSource = null;
+  };
+}
+
+async function doKill() {
+  const id = document.getElementById('ctrl-id').value.trim();
+  if (!id) return;
+  await doKillId(id);
+}
+
+async function doKillId(id) {
+  try {
+    const resp = await fetch('/api/kill', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json', 'Authorization': 'Bearer ' + TOKEN},
+      body: JSON.stringify({identifier: id})
+    });
+    const data = await resp.json();
+    if (data.error) showError(data.error);
+    else { hideError(); fetchStatus(); }
+  } catch (e) { showError(e.message); }
+}
+
+async function doRequeue() {
+  const id = document.getElementById('ctrl-id').value.trim();
+  const ctx = document.getElementById('ctrl-ctx').value.trim();
+  if (!id) return;
+  try {
+    const resp = await fetch('/api/requeue', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json', 'Authorization': 'Bearer ' + TOKEN},
+      body: JSON.stringify({identifier: id, context: ctx})
+    });
+    const data = await resp.json();
+    if (data.error) showError(data.error);
+    else { hideError(); fetchStatus(); }
+  } catch (e) { showError(e.message); }
+}
+
+function showError(msg) {
+  const el = document.getElementById('error-bar');
+  el.textContent = msg;
+  el.style.display = 'block';
+}
+function hideError() { document.getElementById('error-bar').style.display = 'none'; }
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+fetchStatus();
+setInterval(fetchStatus, 5000);
+</script>
+</body>
+</html>

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ahmadAlMezaal/noctra/internal/agent"
 	"github.com/ahmadAlMezaal/noctra/internal/config"
+	"github.com/ahmadAlMezaal/noctra/internal/dashboard"
 	"github.com/ahmadAlMezaal/noctra/internal/github"
 	"github.com/ahmadAlMezaal/noctra/internal/linear"
 	"github.com/ahmadAlMezaal/noctra/internal/notify"
@@ -180,6 +181,23 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		slog.Info("telegram command listener started")
 	}
 
+	// Start the dashboard HTTP server if configured. Runs in its own
+	// goroutine on the shared WaitGroup so shutdown drains it cleanly.
+	var dashSrv *dashboard.Server
+	if p.cfg.DashboardAddr != "" {
+		dashSrv = dashboard.New(p, p, p.cfg.DashboardToken, p.cfg.LogDir)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := dashSrv.ListenAndServe(p.cfg.DashboardAddr); err != nil {
+				// http.ErrServerClosed is expected on graceful shutdown.
+				if err.Error() != "http: Server closed" {
+					slog.Warn("dashboard server stopped", "err", err)
+				}
+			}
+		}()
+	}
+
 	ticker := time.NewTicker(p.cfg.PollInterval)
 	defer ticker.Stop()
 
@@ -194,10 +212,20 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		go p.runWatcher(ctx, &wg)
 	}
 
+	// shutdownDashboard gracefully stops the dashboard server if it was started.
+	shutdownDashboard := func() {
+		if dashSrv != nil {
+			shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer shutCancel()
+			_ = dashSrv.Shutdown(shutCtx)
+		}
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			slog.Info("🌅 shutting down — waiting for active tasks")
+			shutdownDashboard()
 			wg.Wait()
 			p.summary(ctx)
 			return nil
@@ -210,6 +238,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 
 			if rlDetected {
 				slog.Info("🛑 rate limit detected — shutting down")
+				shutdownDashboard()
 				wg.Wait()
 				p.summary(ctx)
 				return nil
@@ -217,6 +246,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 			if atCap {
 				slog.Info("🛑 max dispatches reached — shutting down",
 					"limit", p.cfg.MaxDispatches)
+				shutdownDashboard()
 				wg.Wait()
 				p.summary(ctx)
 				return nil
@@ -386,6 +416,80 @@ func (p *Pipeline) flagRateLimit() {
 	p.rateLimitDetected = true
 }
 
+// DashboardStatus returns a snapshot of the pipeline state for the dashboard.
+// Implements dashboard.Snapshot.
+func (p *Pipeline) DashboardStatus() dashboard.Status {
+	p.mu.Lock()
+	active := make([]string, 0, len(p.active))
+	for id := range p.active {
+		active = append(active, id)
+	}
+	killed := make([]string, 0, len(p.killed))
+	for id := range p.killed {
+		killed = append(killed, id)
+	}
+	skipped := make([]string, 0, len(p.skipped))
+	for id := range p.skipped {
+		skipped = append(skipped, id)
+	}
+	failed := make(map[string]int, len(p.failedAttempts))
+	for id, n := range p.failedAttempts {
+		failed[id] = n
+	}
+	stats := dashboard.SessionStats{
+		TotalDispatches: p.totalDispatches,
+		MaxDispatches:   p.cfg.MaxDispatches,
+		SuccessCount:    p.successCount,
+		FailCount:       p.failCount,
+	}
+	maxW := p.cfg.MaxConcurrent
+	p.mu.Unlock()
+
+	var prState map[string]state.PRState
+	if p.store != nil {
+		prState = p.store.All()
+	}
+
+	return dashboard.Status{
+		Active:     active,
+		Killed:     killed,
+		Skipped:    skipped,
+		Failed:     failed,
+		Stats:      stats,
+		PRState:    prState,
+		MaxWorkers: maxW,
+		Uptime:     time.Since(p.sessionStart).Round(time.Second).String(),
+	}
+}
+
+// Requeue moves a ticket back to the trigger state/label. Implements
+// dashboard.Controller. If extraContext is non-empty, it is posted as a
+// Linear comment before the state transition.
+func (p *Pipeline) Requeue(ctx context.Context, identifier, extraContext string) error {
+	issue, err := p.linear.GetIssueByIdentifier(ctx, identifier)
+	if err != nil {
+		return fmt.Errorf("ticket %s not found: %w", identifier, err)
+	}
+
+	if extraContext != "" {
+		comment := fmt.Sprintf("**Requeued via dashboard**\n\n%s", extraContext)
+		if err := p.linear.Comment(ctx, issue.ID, comment); err != nil {
+			return fmt.Errorf("comment on %s failed: %w", identifier, err)
+		}
+	}
+
+	if p.cfg.TriggerMode == "label" && p.labelID != "" {
+		if err := p.linear.AddLabel(ctx, issue.ID, p.labelID); err != nil {
+			return fmt.Errorf("add trigger label on %s failed: %w", identifier, err)
+		}
+	} else if p.states.Trigger != "" {
+		if err := p.linear.SetState(ctx, issue.ID, p.states.Trigger); err != nil {
+			return fmt.Errorf("set trigger state on %s failed: %w", identifier, err)
+		}
+	}
+	return nil
+}
+
 // rateLimited reports whether a run should be treated as having hit a usage /
 // rate limit. A genuine limit makes the agent CLI FAIL, so this is only true
 // for a failed run whose output carries the backend's rate-limit markers. A
@@ -465,6 +569,9 @@ func (p *Pipeline) banner() {
 	fmt.Printf("   Max retries:    %d per ticket\n", p.cfg.MaxRetries)
 	fmt.Printf("   Max dispatches: %d per session\n", p.cfg.MaxDispatches)
 	fmt.Printf("   Notifications:  %s\n", notifyMode)
+	if p.cfg.DashboardAddr != "" {
+		fmt.Printf("   Dashboard:      http://%s\n", p.cfg.DashboardAddr)
+	}
 	fmt.Println()
 	fmt.Println("Waiting for tickets... (Ctrl+C to stop)")
 	fmt.Println()

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -464,7 +464,8 @@ func (p *Pipeline) DashboardStatus() dashboard.Status {
 
 // Requeue moves a ticket back to the trigger state/label. Implements
 // dashboard.Controller. If extraContext is non-empty, it is posted as a
-// Linear comment before the state transition.
+// Linear comment before the state transition. Clears any cached failure
+// count and skipped status so the ticket is not skipped on subsequent polls.
 func (p *Pipeline) Requeue(ctx context.Context, identifier, extraContext string) error {
 	issue, err := p.linear.GetIssueByIdentifier(ctx, identifier)
 	if err != nil {
@@ -487,6 +488,14 @@ func (p *Pipeline) Requeue(ctx context.Context, identifier, extraContext string)
 			return fmt.Errorf("set trigger state on %s failed: %w", identifier, err)
 		}
 	}
+
+	// Clear cached failure/skipped state so the poll loop will re-dispatch
+	// this ticket instead of silently skipping it.
+	p.mu.Lock()
+	delete(p.failedAttempts, identifier)
+	delete(p.skipped, identifier)
+	p.mu.Unlock()
+
 	return nil
 }
 


### PR DESCRIPTION
## ENG-218: Read-only web dashboard (runs, logs, queue, cost, controls)

**Linear:** https://linear.app/amazz/issue/ENG-218/read-only-web-dashboard-runs-logs-queue-cost-controls

## What was implemented

Implemented a read-only web dashboard embedded in `noctra run`, enabled via `DASHBOARD_ADDR`.

**New files:**
- `internal/dashboard/dashboard.go` — HTTP server with `embed.FS` for the single-page HTML app. Exposes `Snapshot` and `Controller` interfaces so the pipeline provides data without the dashboard touching internals. Endpoints: `GET /api/status` (JSON snapshot of active runs, queue, PR-iteration state, session stats), `GET /api/logs/{id}` (last 64KB of a ticket's log file), `GET /api/logs/{id}/stream` (SSE live log tail), `POST /api/kill` and `POST /api/requeue` (auth-gated via `DASHBOARD_TOKEN` with constant-time comparison; disabled entirely when no token is configured).
- `internal/dashboard/static/index.html` — Single-page dark-themed dashboard with auto-refreshing status (5s interval), stat cards, active runs table with kill/log buttons, queue view (failed/skipped/killed), PR iteration state table, kill/requeue controls, and SSE log streaming panel.
- `internal/dashboard/dashboard_test.go` — 17 tests covering all endpoints: status, logs (normal, not-found, large file, path traversal), kill (success, no-token, wrong-token, error, missing-id), requeue (success, no-auth), index (serve, 404 for other paths), SSE streaming, and constant-time auth comparison.

**Modified files:**
- `internal/config/config.go` — Added `DashboardAddr` and `DashboardToken` fields, loaded from `DASHBOARD_ADDR` and `DASHBOARD_TOKEN` env vars.
- `internal/config/config_test.go` — Added the new env keys to the isolation list.
- `internal/pipeline/pipeline.go` — Added `DashboardStatus()` (implements `dashboard.Snapshot`), `Requeue()` (implements `dashboard.Controller`), dashboard server startup in `Run()` on the shared WaitGroup with graceful shutdown on all exit paths, and dashboard URL in the startup banner.
- `.env.example` — Documented the new `DASHBOARD_ADDR` and `DASHBOARD_TOKEN` settings.

**Key design decisions:**
- Dashboard is completely opt-in (off unless `DASHBOARD_ADDR` is set), matching the pattern of other optional features (Telegram, auto-iterate, review gate).
- Interfaces (`Snapshot`, `Controller`) decouple the dashboard from pipeline internals — the dashboard package has no import of `internal/pipeline`.
- Mutations (kill/requeue) are disabled when `DASHBOARD_TOKEN` is empty (read-only mode), and require a Bearer token when configured.
- The dashboard server shares the pipeline's WaitGroup for clean shutdown coordination.
- Single static binary via `embed.FS` — no external files needed.
- All existing tests pass; `go vet` is clean.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*