### PR TITLE
ENG-217: Budget/cost-aware management with graceful pause/resume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,26 @@ MAX_RETRIES=3
 # Max runtime (minutes) per agent — kills the process after this
 AGENT_TIMEOUT_MINUTES=45
 
+# ── Budget / Cost Management (optional) ────────────────────────────────────────
+# Daily caps — when a cap is hit, Noctra pauses dispatching and auto-resumes
+# at the next UTC midnight. Set to 0 (default) for unlimited.
+
+# Maximum tokens per day (across all agent runs). Parsed from CLI output when
+# available; not all backends report token counts.
+# MAX_DAILY_TOKENS=0
+
+# Maximum estimated cost per day in USD. Parsed from CLI output when available.
+# MAX_DAILY_USD=0
+
+# What to do when a rate limit is hit: "pause" (default) or "shutdown".
+#   pause    — pause dispatching for RATE_LIMIT_COOLDOWN seconds, then resume
+#   shutdown — exit the process (legacy behaviour, pre-ENG-217)
+RATE_LIMIT_STRATEGY=pause
+
+# Seconds to pause dispatching after a rate limit (default: 1800 = 30 minutes).
+# Only used when RATE_LIMIT_STRATEGY=pause.
+# RATE_LIMIT_COOLDOWN=1800
+
 # ── Telegram Notifications (optional) ─────────────────────────────────────────
 # Get notified on your phone when PRs are created, tickets fail, or limits are hit.
 

--- a/internal/agent/usage.go
+++ b/internal/agent/usage.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Usage holds token and cost information parsed from an agent CLI's output.
+// All fields are best-effort: backends that don't print usage stats yield zeros.
+type Usage struct {
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	CostUSD      float64
+}
+
+// Usage-parsing regexes — intentionally generous to cover the known CLI output
+// formats (Codex "tokens used: 167,195", Claude/Copilot session cost, etc.)
+// and any future format that follows common phrasing.
+var (
+	tokensUsedRe   = regexp.MustCompile(`(?i)tokens?\s+used[:\s]+([0-9,]+)`)
+	totalTokensRe  = regexp.MustCompile(`(?i)total\s+tokens?[:\s]+([0-9,]+)`)
+	inputTokensRe  = regexp.MustCompile(`(?i)input\s+tokens?[:\s]+([0-9,]+)`)
+	outputTokensRe = regexp.MustCompile(`(?i)output\s+tokens?[:\s]+([0-9,]+)`)
+	costRe         = regexp.MustCompile(`(?i)(?:total\s+)?cost[:\s]+\$([0-9,.]+)`)
+)
+
+// ParseUsage extracts token and cost information from agent CLI output.
+// Returns zero-valued fields for anything not found — callers should treat
+// zeros as "not reported" rather than "no usage".
+func ParseUsage(output string) Usage {
+	var u Usage
+
+	if m := inputTokensRe.FindStringSubmatch(output); len(m) > 1 {
+		u.InputTokens = parseCommaInt(m[1])
+	}
+	if m := outputTokensRe.FindStringSubmatch(output); len(m) > 1 {
+		u.OutputTokens = parseCommaInt(m[1])
+	}
+
+	// Total tokens: prefer an explicit "total tokens" line, fall back to the
+	// more common "tokens used" phrasing (Codex).
+	if m := totalTokensRe.FindStringSubmatch(output); len(m) > 1 {
+		u.TotalTokens = parseCommaInt(m[1])
+	} else if m := tokensUsedRe.FindStringSubmatch(output); len(m) > 1 {
+		u.TotalTokens = parseCommaInt(m[1])
+	}
+
+	// If we got input/output but no explicit total, sum them.
+	if u.TotalTokens == 0 && (u.InputTokens > 0 || u.OutputTokens > 0) {
+		u.TotalTokens = u.InputTokens + u.OutputTokens
+	}
+
+	if m := costRe.FindStringSubmatch(output); len(m) > 1 {
+		u.CostUSD, _ = strconv.ParseFloat(strings.ReplaceAll(m[1], ",", ""), 64)
+	}
+
+	return u
+}
+
+// parseCommaInt parses a number string that may contain commas (e.g. "167,195").
+func parseCommaInt(s string) int64 {
+	n, _ := strconv.ParseInt(strings.ReplaceAll(s, ",", ""), 10, 64)
+	return n
+}

--- a/internal/agent/usage_test.go
+++ b/internal/agent/usage_test.go
@@ -1,0 +1,88 @@
+package agent
+
+import "testing"
+
+func TestParseUsage_CodexTokensUsed(t *testing.T) {
+	output := "some output here\n\ntokens used: 167,195\n"
+	u := ParseUsage(output)
+	if u.TotalTokens != 167195 {
+		t.Errorf("TotalTokens: got %d, want 167195", u.TotalTokens)
+	}
+}
+
+func TestParseUsage_InputOutputTokens(t *testing.T) {
+	output := "Input tokens: 50,000\nOutput tokens: 12,345\n"
+	u := ParseUsage(output)
+	if u.InputTokens != 50000 {
+		t.Errorf("InputTokens: got %d, want 50000", u.InputTokens)
+	}
+	if u.OutputTokens != 12345 {
+		t.Errorf("OutputTokens: got %d, want 12345", u.OutputTokens)
+	}
+	if u.TotalTokens != 62345 {
+		t.Errorf("TotalTokens (sum): got %d, want 62345", u.TotalTokens)
+	}
+}
+
+func TestParseUsage_ExplicitTotal(t *testing.T) {
+	output := "Input tokens: 50,000\nOutput tokens: 12,345\nTotal tokens: 70,000\n"
+	u := ParseUsage(output)
+	if u.TotalTokens != 70000 {
+		t.Errorf("TotalTokens (explicit): got %d, want 70000", u.TotalTokens)
+	}
+}
+
+func TestParseUsage_Cost(t *testing.T) {
+	output := "Total cost: $1.23\n"
+	u := ParseUsage(output)
+	if u.CostUSD != 1.23 {
+		t.Errorf("CostUSD: got %f, want 1.23", u.CostUSD)
+	}
+}
+
+func TestParseUsage_CostWithComma(t *testing.T) {
+	output := "Cost: $1,234.56\n"
+	u := ParseUsage(output)
+	if u.CostUSD != 1234.56 {
+		t.Errorf("CostUSD: got %f, want 1234.56", u.CostUSD)
+	}
+}
+
+func TestParseUsage_NoUsageInfo(t *testing.T) {
+	output := "Agent completed work on ENG-42.\nAll tests pass.\n"
+	u := ParseUsage(output)
+	if u.TotalTokens != 0 || u.InputTokens != 0 || u.OutputTokens != 0 || u.CostUSD != 0 {
+		t.Errorf("expected zero usage for output without usage info, got %+v", u)
+	}
+}
+
+func TestParseUsage_CaseInsensitive(t *testing.T) {
+	output := "TOKENS USED: 42,000\nTOTAL COST: $5.00\n"
+	u := ParseUsage(output)
+	if u.TotalTokens != 42000 {
+		t.Errorf("TotalTokens: got %d, want 42000", u.TotalTokens)
+	}
+	if u.CostUSD != 5.0 {
+		t.Errorf("CostUSD: got %f, want 5.0", u.CostUSD)
+	}
+}
+
+func TestParseCommaInt(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"167195", 167195},
+		{"167,195", 167195},
+		{"1,234,567", 1234567},
+		{"0", 0},
+		{"", 0},
+		{"abc", 0},
+	}
+	for _, tt := range tests {
+		got := parseCommaInt(tt.input)
+		if got != tt.want {
+			t.Errorf("parseCommaInt(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -1,0 +1,218 @@
+// Package budget tracks token and cost usage across agent runs, enforces
+// configurable daily caps, and provides a pause/resume mechanism for the
+// pipeline when caps or rate limits are hit.
+package budget
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Config holds the daily usage caps. Zero values mean unlimited.
+type Config struct {
+	MaxDailyTokens int64
+	MaxDailyUSD    float64
+}
+
+// Stats is a snapshot of current usage and pause state, safe for display.
+type Stats struct {
+	SessionTokens  int64
+	SessionCostUSD float64
+	DailyTokens    int64
+	DailyCostUSD   float64
+	MaxDailyTokens int64
+	MaxDailyUSD    float64
+	Paused         bool
+	PausedUntil    time.Time
+	PauseReason    string
+}
+
+// HasCaps reports whether any budget cap is configured.
+func (s Stats) HasCaps() bool {
+	return s.MaxDailyTokens > 0 || s.MaxDailyUSD > 0
+}
+
+// Tracker tracks token/cost usage per session and per day, enforces daily caps,
+// and provides a concurrency-safe pause/resume mechanism. It is always safe to
+// use — when no caps are configured, Record and Exceeded are lightweight no-ops
+// (Exceeded always returns false), and Pause/IsPaused remain functional for
+// rate-limit pausing.
+type Tracker struct {
+	mu  sync.Mutex
+	cfg Config
+
+	sessionTokens  int64
+	sessionCostUSD float64
+	dailyTokens    int64
+	dailyCostUSD   float64
+	dayStart       time.Time
+
+	paused      bool
+	pausedUntil time.Time
+	pauseReason string
+
+	// now is a hook for testing — defaults to time.Now.
+	now func() time.Time
+}
+
+// New returns a Tracker with the given caps. A zero Config is valid (no caps).
+func New(cfg Config) *Tracker {
+	return &Tracker{
+		cfg:      cfg,
+		dayStart: todayUTC(time.Now()),
+		now:      time.Now,
+	}
+}
+
+// Record adds tokens and cost from one agent run to both session and daily
+// totals. Zero values (backend didn't report usage) are fine — they're a
+// no-op on the cumulative counters.
+func (t *Tracker) Record(tokens int64, costUSD float64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.maybeResetDaily()
+	t.sessionTokens += tokens
+	t.sessionCostUSD += costUSD
+	t.dailyTokens += tokens
+	t.dailyCostUSD += costUSD
+}
+
+// Exceeded reports whether any configured daily cap has been hit. Returns
+// false when no caps are configured.
+func (t *Tracker) Exceeded() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.maybeResetDaily()
+	return t.exceeded()
+}
+
+func (t *Tracker) exceeded() bool {
+	if t.cfg.MaxDailyTokens > 0 && t.dailyTokens >= t.cfg.MaxDailyTokens {
+		return true
+	}
+	if t.cfg.MaxDailyUSD > 0 && t.dailyCostUSD >= t.cfg.MaxDailyUSD {
+		return true
+	}
+	return false
+}
+
+// ExceededReason returns a human-readable explanation of which cap was hit,
+// or "" if no cap is exceeded.
+func (t *Tracker) ExceededReason() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.maybeResetDaily()
+	if t.cfg.MaxDailyTokens > 0 && t.dailyTokens >= t.cfg.MaxDailyTokens {
+		return fmt.Sprintf("daily token cap (%s/%s)",
+			formatTokens(t.dailyTokens), formatTokens(t.cfg.MaxDailyTokens))
+	}
+	if t.cfg.MaxDailyUSD > 0 && t.dailyCostUSD >= t.cfg.MaxDailyUSD {
+		return fmt.Sprintf("daily cost cap ($%.2f/$%.2f)",
+			t.dailyCostUSD, t.cfg.MaxDailyUSD)
+	}
+	return ""
+}
+
+// Pause sets the tracker into a paused state with a reason and an optional
+// auto-resume time. Pass a zero time for indefinite pause (e.g. manual resume).
+func (t *Tracker) Pause(reason string, until time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.paused = true
+	t.pauseReason = reason
+	t.pausedUntil = until
+}
+
+// IsPaused reports the current pause state. If the pausedUntil time has
+// passed, it auto-resumes and returns false. This is the primary check the
+// pipeline's poll loop calls before dispatching.
+func (t *Tracker) IsPaused() (paused bool, until time.Time, reason string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.maybeResetDaily()
+	if !t.paused {
+		return false, time.Time{}, ""
+	}
+	// Auto-resume when the pause timer expires.
+	if !t.pausedUntil.IsZero() && t.now().After(t.pausedUntil) {
+		t.paused = false
+		t.pauseReason = ""
+		t.pausedUntil = time.Time{}
+		return false, time.Time{}, ""
+	}
+	return true, t.pausedUntil, t.pauseReason
+}
+
+// Resume manually clears a pause. Intended for future /resume commands.
+func (t *Tracker) Resume() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.paused = false
+	t.pauseReason = ""
+	t.pausedUntil = time.Time{}
+}
+
+// Stats returns a point-in-time snapshot of usage and pause state.
+func (t *Tracker) Stats() Stats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.maybeResetDaily()
+	return Stats{
+		SessionTokens:  t.sessionTokens,
+		SessionCostUSD: t.sessionCostUSD,
+		DailyTokens:    t.dailyTokens,
+		DailyCostUSD:   t.dailyCostUSD,
+		MaxDailyTokens: t.cfg.MaxDailyTokens,
+		MaxDailyUSD:    t.cfg.MaxDailyUSD,
+		Paused:         t.paused,
+		PausedUntil:    t.pausedUntil,
+		PauseReason:    t.pauseReason,
+	}
+}
+
+// maybeResetDaily resets the daily counters when a new UTC day has started.
+// Must be called with t.mu held.
+func (t *Tracker) maybeResetDaily() {
+	today := todayUTC(t.now())
+	if today.After(t.dayStart) {
+		t.dailyTokens = 0
+		t.dailyCostUSD = 0
+		t.dayStart = today
+	}
+}
+
+// NextUTCMidnight returns the start of the next UTC day.
+func NextUTCMidnight() time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.UTC)
+}
+
+// todayUTC returns midnight UTC of the given time's date.
+func todayUTC(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// formatTokens renders a token count in a compact human form (e.g. "1.5M",
+// "250K", "1,234").
+func formatTokens(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		if n%1_000_000 == 0 {
+			return fmt.Sprintf("%dM", n/1_000_000)
+		}
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		if n%1_000 == 0 {
+			return fmt.Sprintf("%dK", n/1_000)
+		}
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+
+// FormatTokens is the exported version of formatTokens for use by callers
+// that build display strings (banner, Telegram).
+func FormatTokens(n int64) string { return formatTokens(n) }

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -131,17 +131,24 @@ func (t *Tracker) IsPaused() (paused bool, until time.Time, reason string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.maybeResetDaily()
+	t.maybeAutoResume()
 	if !t.paused {
 		return false, time.Time{}, ""
 	}
-	// Auto-resume when the pause timer expires.
+	return true, t.pausedUntil, t.pauseReason
+}
+
+// maybeAutoResume clears the pause state when the pausedUntil timer has
+// expired. Must be called with t.mu held.
+func (t *Tracker) maybeAutoResume() {
+	if !t.paused {
+		return
+	}
 	if !t.pausedUntil.IsZero() && t.now().After(t.pausedUntil) {
 		t.paused = false
 		t.pauseReason = ""
 		t.pausedUntil = time.Time{}
-		return false, time.Time{}, ""
 	}
-	return true, t.pausedUntil, t.pauseReason
 }
 
 // Resume manually clears a pause. Intended for future /resume commands.
@@ -154,10 +161,13 @@ func (t *Tracker) Resume() {
 }
 
 // Stats returns a point-in-time snapshot of usage and pause state.
+// It applies the same auto-resume logic as IsPaused so callers (e.g.
+// /status) never see stale pause information after the timer has expired.
 func (t *Tracker) Stats() Stats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.maybeResetDaily()
+	t.maybeAutoResume()
 	return Stats{
 		SessionTokens:  t.sessionTokens,
 		SessionCostUSD: t.sessionCostUSD,

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -1,0 +1,183 @@
+package budget
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRecord_AccumulatesUsage(t *testing.T) {
+	tr := New(Config{})
+	tr.Record(1000, 0.50)
+	tr.Record(2000, 1.00)
+
+	s := tr.Stats()
+	if s.SessionTokens != 3000 {
+		t.Errorf("SessionTokens: got %d, want 3000", s.SessionTokens)
+	}
+	if s.SessionCostUSD != 1.50 {
+		t.Errorf("SessionCostUSD: got %f, want 1.50", s.SessionCostUSD)
+	}
+	if s.DailyTokens != 3000 {
+		t.Errorf("DailyTokens: got %d, want 3000", s.DailyTokens)
+	}
+	if s.DailyCostUSD != 1.50 {
+		t.Errorf("DailyCostUSD: got %f, want 1.50", s.DailyCostUSD)
+	}
+}
+
+func TestExceeded_NoCaps(t *testing.T) {
+	tr := New(Config{})
+	tr.Record(999_999_999, 999_999.99)
+	if tr.Exceeded() {
+		t.Error("Exceeded should be false when no caps are configured")
+	}
+}
+
+func TestExceeded_TokenCap(t *testing.T) {
+	tr := New(Config{MaxDailyTokens: 5000})
+	tr.Record(4999, 0)
+	if tr.Exceeded() {
+		t.Error("should not exceed at 4999/5000")
+	}
+	tr.Record(1, 0)
+	if !tr.Exceeded() {
+		t.Error("should exceed at 5000/5000")
+	}
+}
+
+func TestExceeded_CostCap(t *testing.T) {
+	tr := New(Config{MaxDailyUSD: 10.00})
+	tr.Record(0, 9.99)
+	if tr.Exceeded() {
+		t.Error("should not exceed at $9.99/$10.00")
+	}
+	tr.Record(0, 0.01)
+	if !tr.Exceeded() {
+		t.Error("should exceed at $10.00/$10.00")
+	}
+}
+
+func TestExceededReason(t *testing.T) {
+	tr := New(Config{MaxDailyTokens: 1000, MaxDailyUSD: 5.00})
+	if r := tr.ExceededReason(); r != "" {
+		t.Errorf("expected empty reason, got %q", r)
+	}
+	tr.Record(1000, 0)
+	if r := tr.ExceededReason(); r == "" {
+		t.Error("expected non-empty reason for token cap")
+	}
+}
+
+func TestPauseAndResume(t *testing.T) {
+	tr := New(Config{})
+
+	paused, _, _ := tr.IsPaused()
+	if paused {
+		t.Error("should not be paused initially")
+	}
+
+	until := time.Now().Add(1 * time.Hour)
+	tr.Pause("rate limit", until)
+
+	paused, gotUntil, reason := tr.IsPaused()
+	if !paused {
+		t.Error("should be paused after Pause()")
+	}
+	if reason != "rate limit" {
+		t.Errorf("reason: got %q, want %q", reason, "rate limit")
+	}
+	if !gotUntil.Equal(until) {
+		t.Errorf("until: got %v, want %v", gotUntil, until)
+	}
+
+	tr.Resume()
+	paused, _, _ = tr.IsPaused()
+	if paused {
+		t.Error("should not be paused after Resume()")
+	}
+}
+
+func TestIsPaused_AutoResume(t *testing.T) {
+	tr := New(Config{})
+	// Pause until a time that's already past.
+	tr.Pause("test", time.Now().Add(-1*time.Second))
+
+	paused, _, _ := tr.IsPaused()
+	if paused {
+		t.Error("should auto-resume when pausedUntil is in the past")
+	}
+}
+
+func TestDailyReset(t *testing.T) {
+	tr := New(Config{MaxDailyTokens: 1000})
+
+	// Record usage and confirm it's tracked.
+	tr.Record(999, 0)
+	if tr.Exceeded() {
+		t.Error("should not exceed at 999/1000")
+	}
+
+	// Simulate time advancing to the next day.
+	tomorrow := time.Now().UTC().Add(25 * time.Hour)
+	tr.now = func() time.Time { return tomorrow }
+
+	// Daily counters should reset.
+	if tr.Exceeded() {
+		t.Error("should not exceed after daily reset")
+	}
+	s := tr.Stats()
+	if s.DailyTokens != 0 {
+		t.Errorf("DailyTokens after reset: got %d, want 0", s.DailyTokens)
+	}
+	// Session counters persist.
+	if s.SessionTokens != 999 {
+		t.Errorf("SessionTokens should persist across day boundary: got %d", s.SessionTokens)
+	}
+}
+
+func TestFormatTokens(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1K"},
+		{1500, "1.5K"},
+		{1_000_000, "1M"},
+		{2_500_000, "2.5M"},
+		{10_000_000, "10M"},
+	}
+	for _, tt := range tests {
+		got := FormatTokens(tt.input)
+		if got != tt.want {
+			t.Errorf("FormatTokens(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestNextUTCMidnight(t *testing.T) {
+	m := NextUTCMidnight()
+	now := time.Now().UTC()
+	if !m.After(now) {
+		t.Errorf("NextUTCMidnight() = %v, should be after now (%v)", m, now)
+	}
+	if m.Hour() != 0 || m.Minute() != 0 || m.Second() != 0 {
+		t.Errorf("NextUTCMidnight() should be midnight, got %v", m)
+	}
+}
+
+func TestStats_HasCaps(t *testing.T) {
+	noCaps := Stats{}
+	if noCaps.HasCaps() {
+		t.Error("HasCaps should be false with no caps")
+	}
+	tokenCap := Stats{MaxDailyTokens: 1000}
+	if !tokenCap.HasCaps() {
+		t.Error("HasCaps should be true with token cap")
+	}
+	costCap := Stats{MaxDailyUSD: 10.0}
+	if !costCap.HasCaps() {
+		t.Error("HasCaps should be true with cost cap")
+	}
+}

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -108,6 +108,20 @@ func TestIsPaused_AutoResume(t *testing.T) {
 	}
 }
 
+func TestStats_AutoResume(t *testing.T) {
+	tr := New(Config{})
+	// Pause until a time that's already past.
+	tr.Pause("expired pause", time.Now().Add(-1*time.Second))
+
+	s := tr.Stats()
+	if s.Paused {
+		t.Error("Stats should apply auto-resume when pausedUntil is in the past")
+	}
+	if s.PauseReason != "" {
+		t.Errorf("Stats PauseReason should be empty after auto-resume, got %q", s.PauseReason)
+	}
+}
+
 func TestDailyReset(t *testing.T) {
 	tr := New(Config{MaxDailyTokens: 1000})
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,10 @@ const (
 
 	// Auto-release-label (ENG-231) — disabled by default; opt in via .env.
 	DefaultReleaseBump = "patch"
+
+	// Budget / cost-aware management (ENG-217).
+	DefaultRateLimitStrategy = "pause"
+	DefaultRateLimitCooldown = 30 * time.Minute
 )
 
 // Config is Noctra's resolved runtime configuration.
@@ -152,6 +156,12 @@ type Config struct {
 	// RELEASE: line in its output.
 	AutoReleaseLabel   bool
 	DefaultReleaseBump string // "patch" (default), "minor", or "major"
+
+	// Budget / cost-aware management (ENG-217).
+	MaxDailyTokens    int64         // daily token cap, 0 = unlimited
+	MaxDailyUSD       float64       // daily dollar cap, 0 = unlimited
+	RateLimitStrategy string        // "pause" (default) or "shutdown"
+	RateLimitCooldown time.Duration // pause duration after rate limit (default 30m)
 
 	// Derived paths
 	ScriptDir    string
@@ -233,6 +243,13 @@ func Load(scriptDir string) (*Config, error) {
 	cfg.AutoReleaseLabel = getbool(fileEnv, "AUTO_RELEASE_LABEL", false)
 	cfg.DefaultReleaseBump = strings.ToLower(strings.TrimSpace(getenv(fileEnv, "DEFAULT_RELEASE_BUMP", DefaultReleaseBump)))
 
+	// Budget / cost-aware management (ENG-217)
+	cfg.MaxDailyTokens = int64(getint(fileEnv, "MAX_DAILY_TOKENS", 0))
+	cfg.MaxDailyUSD = getfloat(fileEnv, "MAX_DAILY_USD", 0)
+	cfg.RateLimitStrategy = strings.ToLower(strings.TrimSpace(getenv(fileEnv, "RATE_LIMIT_STRATEGY", DefaultRateLimitStrategy)))
+	cooldownSecs := getint(fileEnv, "RATE_LIMIT_COOLDOWN", int(DefaultRateLimitCooldown/time.Second))
+	cfg.RateLimitCooldown = time.Duration(cooldownSecs) * time.Second
+
 	return cfg, nil
 }
 
@@ -275,6 +292,12 @@ func (c *Config) Validate() error {
 		default:
 			errs = append(errs, fmt.Sprintf("DEFAULT_RELEASE_BUMP must be \"patch\", \"minor\", or \"major\", got %q", c.DefaultReleaseBump))
 		}
+	}
+
+	switch c.RateLimitStrategy {
+	case "pause", "shutdown":
+	default:
+		errs = append(errs, fmt.Sprintf("RATE_LIMIT_STRATEGY must be \"pause\" or \"shutdown\", got %q", c.RateLimitStrategy))
 	}
 
 	if c.RepoPath != "" && !isGitRepo(c.RepoPath) {
@@ -391,6 +414,18 @@ func getbool(fileEnv map[string]string, key string, def bool) bool {
 		return false
 	}
 	return def
+}
+
+func getfloat(fileEnv map[string]string, key string, def float64) float64 {
+	v := getenv(fileEnv, key, "")
+	if v == "" {
+		return def
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return def
+	}
+	return f
 }
 
 func getint(fileEnv map[string]string, key string, def int) int {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,7 @@ var noctraEnvKeys = []string{
 	"REPOS_BASE", "WORKTREE_BASE", "LOG_DIR",
 	"AUTO_ITERATE_PRS", "MAX_PR_ITERATIONS", "PR_POLL_INTERVAL",
 	"TRUSTED_REVIEWERS", "STATE_FILE",
+	"MAX_DAILY_TOKENS", "MAX_DAILY_USD", "RATE_LIMIT_STRATEGY", "RATE_LIMIT_COOLDOWN",
 }
 
 func isolateEnv(t *testing.T) {
@@ -646,5 +647,120 @@ func TestMigrateLegacyPaths(t *testing.T) {
 	MigrateLegacyPaths()
 	if b, err := os.ReadFile(filepath.Join(home, ".noctra", ".env")); err != nil || string(b) != "X=1" {
 		t.Errorf("second migration disturbed state: %v / %q", err, b)
+	}
+}
+
+func TestLoad_BudgetDefaults(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.MaxDailyTokens != 0 {
+		t.Errorf("MaxDailyTokens: got %d, want 0 (unlimited)", cfg.MaxDailyTokens)
+	}
+	if cfg.MaxDailyUSD != 0 {
+		t.Errorf("MaxDailyUSD: got %f, want 0 (unlimited)", cfg.MaxDailyUSD)
+	}
+	if cfg.RateLimitStrategy != DefaultRateLimitStrategy {
+		t.Errorf("RateLimitStrategy: got %q, want %q", cfg.RateLimitStrategy, DefaultRateLimitStrategy)
+	}
+	if cfg.RateLimitCooldown != DefaultRateLimitCooldown {
+		t.Errorf("RateLimitCooldown: got %v, want %v", cfg.RateLimitCooldown, DefaultRateLimitCooldown)
+	}
+}
+
+func TestLoad_BudgetFromEnv(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `
+LINEAR_API_KEY="lin_xyz"
+MAX_DAILY_TOKENS="5000000"
+MAX_DAILY_USD="50.00"
+RATE_LIMIT_STRATEGY="shutdown"
+RATE_LIMIT_COOLDOWN="900"
+`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.MaxDailyTokens != 5000000 {
+		t.Errorf("MaxDailyTokens: got %d, want 5000000", cfg.MaxDailyTokens)
+	}
+	if cfg.MaxDailyUSD != 50.0 {
+		t.Errorf("MaxDailyUSD: got %f, want 50.0", cfg.MaxDailyUSD)
+	}
+	if cfg.RateLimitStrategy != "shutdown" {
+		t.Errorf("RateLimitStrategy: got %q, want %q", cfg.RateLimitStrategy, "shutdown")
+	}
+	if cfg.RateLimitCooldown != 900*time.Second {
+		t.Errorf("RateLimitCooldown: got %v, want %v", cfg.RateLimitCooldown, 900*time.Second)
+	}
+}
+
+func TestValidate_RateLimitStrategyPause(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"
+RATE_LIMIT_STRATEGY="pause"`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate should pass with pause strategy: %v", err)
+	}
+}
+
+func TestValidate_RateLimitStrategyShutdown(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"
+RATE_LIMIT_STRATEGY="shutdown"`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate should pass with shutdown strategy: %v", err)
+	}
+}
+
+func TestValidate_InvalidRateLimitStrategyRejected(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"
+RATE_LIMIT_STRATEGY="explode"`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "RATE_LIMIT_STRATEGY") {
+		t.Fatalf("expected RATE_LIMIT_STRATEGY error, got %v", err)
+	}
+}
+
+func TestLoad_RateLimitStrategyCaseInsensitive(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"
+RATE_LIMIT_STRATEGY="Shutdown"`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RateLimitStrategy != "shutdown" {
+		t.Errorf("RateLimitStrategy should be lowercased, got %q", cfg.RateLimitStrategy)
 	}
 }

--- a/internal/pipeline/commands.go
+++ b/internal/pipeline/commands.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ahmadAlMezaal/noctra/internal/budget"
 	"github.com/ahmadAlMezaal/noctra/internal/notify"
 	"github.com/ahmadAlMezaal/noctra/internal/telegram"
 )
@@ -59,6 +60,34 @@ func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
 	fmt.Fprintf(&b, "❌ %d failed\n", fail)
 	fmt.Fprintf(&b, "📦 %d/%d dispatches used\n", dispatches, maxD)
 	fmt.Fprintf(&b, "⏱ Uptime: %s\n", uptime)
+
+	// Budget / usage stats (ENG-217).
+	bs := p.budget.Stats()
+	if bs.SessionTokens > 0 || bs.SessionCostUSD > 0 || bs.HasCaps() {
+		b.WriteString("\n*Budget:*\n")
+		if bs.SessionTokens > 0 || bs.SessionCostUSD > 0 {
+			usageLine := fmt.Sprintf("💰 Session: %s tokens", budget.FormatTokens(bs.SessionTokens))
+			if bs.SessionCostUSD > 0 {
+				usageLine += fmt.Sprintf(" ($%.2f)", bs.SessionCostUSD)
+			}
+			fmt.Fprintf(&b, "%s\n", usageLine)
+		}
+		if bs.MaxDailyTokens > 0 {
+			fmt.Fprintf(&b, "📊 Tokens: %s/%s today\n",
+				budget.FormatTokens(bs.DailyTokens), budget.FormatTokens(bs.MaxDailyTokens))
+		}
+		if bs.MaxDailyUSD > 0 {
+			fmt.Fprintf(&b, "💵 Cost: $%.2f/$%.2f today\n", bs.DailyCostUSD, bs.MaxDailyUSD)
+		}
+	}
+	if bs.Paused {
+		pauseMsg := fmt.Sprintf("⏸ Paused: %s", notify.EscapeMarkdown(bs.PauseReason))
+		if !bs.PausedUntil.IsZero() {
+			pauseMsg += fmt.Sprintf(" — resuming at %s", bs.PausedUntil.UTC().Format("15:04 UTC"))
+		}
+		fmt.Fprintf(&b, "\n%s\n", pauseMsg)
+	}
+
 	return b.String()
 }
 

--- a/internal/pipeline/commands_test.go
+++ b/internal/pipeline/commands_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ahmadAlMezaal/noctra/internal/budget"
 	"github.com/ahmadAlMezaal/noctra/internal/config"
 	"github.com/ahmadAlMezaal/noctra/internal/linear"
 )
@@ -41,6 +42,7 @@ func TestHandleStatus_Idle(t *testing.T) {
 			MaxConcurrent: 3,
 			MaxDispatches: 10,
 		},
+		budget:       budget.New(budget.Config{}),
 		active:       map[string]struct{}{},
 		sessionStart: time.Now().Add(-5 * time.Minute),
 	}
@@ -59,6 +61,7 @@ func TestHandleStatus_Active(t *testing.T) {
 			MaxConcurrent: 3,
 			MaxDispatches: 10,
 		},
+		budget: budget.New(budget.Config{}),
 		active: map[string]struct{}{
 			"ENG-42": {},
 			"ENG-44": {},
@@ -561,11 +564,59 @@ func TestHandleStatus_UptimeFormat(t *testing.T) {
 			MaxConcurrent: 5,
 			MaxDispatches: 20,
 		},
+		budget:       budget.New(budget.Config{}),
 		active:       map[string]struct{}{},
 		sessionStart: time.Now().Add(-2*time.Hour - 30*time.Minute),
 	}
 	reply := p.handleStatus(context.Background(), "")
 	if !strings.Contains(reply, "Uptime") {
 		t.Errorf("expected uptime in reply, got %q", reply)
+	}
+}
+
+func TestHandleStatus_BudgetCaps(t *testing.T) {
+	b := budget.New(budget.Config{MaxDailyTokens: 1_000_000, MaxDailyUSD: 25.0})
+	b.Record(500_000, 12.50)
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			MaxConcurrent: 3,
+			MaxDispatches: 10,
+		},
+		budget:       b,
+		active:       map[string]struct{}{},
+		sessionStart: time.Now().Add(-10 * time.Minute),
+	}
+	reply := p.handleStatus(context.Background(), "")
+	if !strings.Contains(reply, "Budget") {
+		t.Errorf("expected 'Budget' section in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "500K") || !strings.Contains(reply, "1M") {
+		t.Errorf("expected token usage in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "12.50") || !strings.Contains(reply, "25.00") {
+		t.Errorf("expected cost usage in reply, got %q", reply)
+	}
+}
+
+func TestHandleStatus_PausedState(t *testing.T) {
+	b := budget.New(budget.Config{})
+	b.Pause("rate limit", time.Now().Add(30*time.Minute))
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			MaxConcurrent: 3,
+			MaxDispatches: 10,
+		},
+		budget:       b,
+		active:       map[string]struct{}{},
+		sessionStart: time.Now(),
+	}
+	reply := p.handleStatus(context.Background(), "")
+	if !strings.Contains(reply, "Paused") {
+		t.Errorf("expected 'Paused' in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "rate limit") {
+		t.Errorf("expected pause reason in reply, got %q", reply)
 	}
 }

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -338,6 +338,14 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	// Record usage from the iteration (ENG-217).
 	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+	// Check budget caps immediately after recording — if exceeded, the pause
+	// takes effect on the next poll tick (in-flight work drains naturally).
+	if reason := p.budget.ExceededReason(); reason != "" {
+		p.flagBudgetExceeded(reason)
+		p.telegram.Send(ctx, fmt.Sprintf(
+			"⏸ *Daily budget exceeded*\n%s\nDispatching paused until next UTC midnight.",
+			notify.EscapeMarkdown(reason)))
+	}
 
 	// Rate limit is only classified on a failed run (see rateLimited), so a
 	// successful iteration whose transcript merely mentions "rate limit" (file

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -334,6 +334,11 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	}
 
 	output := agent.ReadAfter(logFile, offset)
+
+	// Record usage from the iteration (ENG-217).
+	usage := agent.ParseUsage(output)
+	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+
 	// Rate limit is only classified on a failed run (see rateLimited), so a
 	// successful iteration whose transcript merely mentions "rate limit" (file
 	// content / diff) doesn't trigger a false shutdown.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -237,6 +237,17 @@ func (p *Pipeline) Run(ctx context.Context) error {
 				continue
 			}
 
+			// Check budget caps on every tick so concurrent in-flight runs
+			// that pushed usage over the cap are caught promptly (rather
+			// than waiting for the next completed run to call flagBudgetExceeded).
+			if reason := p.budget.ExceededReason(); reason != "" {
+				p.flagBudgetExceeded(reason)
+				p.telegram.Send(ctx, fmt.Sprintf(
+					"⏸ *Daily budget exceeded*\n%s\nDispatching paused until next UTC midnight.",
+					notify.EscapeMarkdown(reason)))
+				continue
+			}
+
 			p.pollOnce(ctx, &wg)
 		}
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -78,12 +78,12 @@ func New(cfg *config.Config) *Pipeline {
 	}
 
 	p := &Pipeline{
-		cfg:            cfg,
-		linear:         newLinearClient(cfg),
-		resolver:       repo.FromConfig(cfg),
-		telegram:       notify.New(cfg.TelegramEnabled, cfg.TelegramBotToken, cfg.TelegramChatID),
-		review:         review.NewWithMode(cfg.GeminiMode, cfg.GeminiAPIKey, cfg.GeminiModel),
-		agent:          backend,
+		cfg:      cfg,
+		linear:   newLinearClient(cfg),
+		resolver: repo.FromConfig(cfg),
+		telegram: notify.New(cfg.TelegramEnabled, cfg.TelegramBotToken, cfg.TelegramChatID),
+		review:   review.NewWithMode(cfg.GeminiMode, cfg.GeminiAPIKey, cfg.GeminiModel),
+		agent:    backend,
 		budget: budget.New(budget.Config{
 			MaxDailyTokens: cfg.MaxDailyTokens,
 			MaxDailyUSD:    cfg.MaxDailyUSD,

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ahmadAlMezaal/noctra/internal/agent"
+	"github.com/ahmadAlMezaal/noctra/internal/budget"
 	"github.com/ahmadAlMezaal/noctra/internal/config"
 	"github.com/ahmadAlMezaal/noctra/internal/github"
 	"github.com/ahmadAlMezaal/noctra/internal/linear"
@@ -48,6 +49,9 @@ type Pipeline struct {
 	gh      *github.Client
 	watcher *watch.Watcher
 
+	// Budget tracker — always non-nil (no-op when no caps configured).
+	budget *budget.Tracker
+
 	sessionStart time.Time
 
 	mu                sync.Mutex
@@ -59,7 +63,7 @@ type Pipeline struct {
 	totalDispatches   int
 	successCount      int
 	failCount         int
-	rateLimitDetected bool
+	rateLimitDetected bool // only used when RateLimitStrategy=shutdown
 }
 
 // New constructs a Pipeline. It does not perform any I/O — call Run to start.
@@ -80,6 +84,10 @@ func New(cfg *config.Config) *Pipeline {
 		telegram:       notify.New(cfg.TelegramEnabled, cfg.TelegramBotToken, cfg.TelegramChatID),
 		review:         review.NewWithMode(cfg.GeminiMode, cfg.GeminiAPIKey, cfg.GeminiModel),
 		agent:          backend,
+		budget: budget.New(budget.Config{
+			MaxDailyTokens: cfg.MaxDailyTokens,
+			MaxDailyUSD:    cfg.MaxDailyUSD,
+		}),
 		active:         map[string]struct{}{},
 		cancels:        map[string]context.CancelFunc{},
 		killed:         map[string]struct{}{},
@@ -221,6 +229,14 @@ func (p *Pipeline) Run(ctx context.Context) error {
 				p.summary(ctx)
 				return nil
 			}
+
+			// Budget pause: skip dispatching but keep the loop alive.
+			if paused, until, reason := p.budget.IsPaused(); paused {
+				slog.Debug("⏸ dispatching paused",
+					"reason", reason, "until", until.Format(time.RFC3339))
+				continue
+			}
+
 			p.pollOnce(ctx, &wg)
 		}
 	}
@@ -380,10 +396,31 @@ func (p *Pipeline) skipPermanently(id string) {
 	}
 }
 
+// flagRateLimit handles a detected rate limit according to the configured
+// strategy. "shutdown" (legacy) sets a flag that causes the main loop to
+// exit on the next tick. "pause" (default, ENG-217) pauses dispatching for
+// the configured cooldown period without exiting.
 func (p *Pipeline) flagRateLimit() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.rateLimitDetected = true
+	if p.cfg.RateLimitStrategy == "shutdown" {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.rateLimitDetected = true
+		return
+	}
+	// Pause strategy: pause dispatching for the cooldown period.
+	resumeAt := time.Now().Add(p.cfg.RateLimitCooldown)
+	p.budget.Pause("rate limit", resumeAt)
+	slog.Info("⏸ rate limit detected — pausing dispatches",
+		"cooldown", p.cfg.RateLimitCooldown, "resume_at", resumeAt.Format(time.RFC3339))
+}
+
+// flagBudgetExceeded pauses dispatching until the next UTC midnight when a
+// daily budget cap is hit.
+func (p *Pipeline) flagBudgetExceeded(reason string) {
+	resumeAt := budget.NextUTCMidnight()
+	p.budget.Pause(reason, resumeAt)
+	slog.Info("⏸ daily budget exceeded — pausing dispatches",
+		"reason", reason, "resume_at", resumeAt.Format(time.RFC3339))
 }
 
 // rateLimited reports whether a run should be treated as having hit a usage /
@@ -464,6 +501,28 @@ func (p *Pipeline) banner() {
 	fmt.Printf("   Agent timeout:  %s\n", p.cfg.AgentTimeout)
 	fmt.Printf("   Max retries:    %d per ticket\n", p.cfg.MaxRetries)
 	fmt.Printf("   Max dispatches: %d per session\n", p.cfg.MaxDispatches)
+
+	// Budget caps (ENG-217).
+	budgetMode := "Unlimited"
+	bs := p.budget.Stats()
+	if bs.HasCaps() {
+		parts := make([]string, 0, 2)
+		if bs.MaxDailyTokens > 0 {
+			parts = append(parts, budget.FormatTokens(bs.MaxDailyTokens)+" tokens/day")
+		}
+		if bs.MaxDailyUSD > 0 {
+			parts = append(parts, fmt.Sprintf("$%.2f/day", bs.MaxDailyUSD))
+		}
+		budgetMode = strings.Join(parts, ", ")
+	}
+	fmt.Printf("   Budget:         %s\n", budgetMode)
+
+	rlMode := "pause (auto-resume after " + p.cfg.RateLimitCooldown.String() + ")"
+	if p.cfg.RateLimitStrategy == "shutdown" {
+		rlMode = "shutdown (legacy)"
+	}
+	fmt.Printf("   Rate limit:     %s\n", rlMode)
+
 	fmt.Printf("   Notifications:  %s\n", notifyMode)
 	fmt.Println()
 	fmt.Println("Waiting for tickets... (Ctrl+C to stop)")
@@ -475,10 +534,23 @@ func (p *Pipeline) summary(ctx context.Context) {
 	succ, fail := p.successCount, p.failCount
 	p.mu.Unlock()
 	dur := time.Since(p.sessionStart).Round(time.Minute)
-	slog.Info("👋 session complete", "success", succ, "fail", fail, "duration", dur)
+	bs := p.budget.Stats()
+
+	slog.Info("👋 session complete",
+		"success", succ, "fail", fail, "duration", dur,
+		"tokens", bs.SessionTokens, "cost_usd", bs.SessionCostUSD)
+
+	usageLine := ""
+	if bs.SessionTokens > 0 || bs.SessionCostUSD > 0 {
+		usageLine = fmt.Sprintf("\n💰 Usage: %s tokens", budget.FormatTokens(bs.SessionTokens))
+		if bs.SessionCostUSD > 0 {
+			usageLine += fmt.Sprintf(" ($%.2f)", bs.SessionCostUSD)
+		}
+	}
+
 	p.telegram.Send(ctx, fmt.Sprintf(
-		"🌅 *Noctra session complete*\n✅ %d PRs created\n❌ %d failed\n⏱ Duration: %s",
-		succ, fail, dur))
+		"🌅 *Noctra session complete*\n✅ %d PRs created\n❌ %d failed\n⏱ Duration: %s%s",
+		succ, fail, dur, usageLine))
 }
 
 // checkForUpdate runs once at startup in its own goroutine. It's strictly best-

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -369,6 +369,12 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 				// Record usage from the fix pass.
 				fixUsage := agent.ParseUsage(fixOutput)
 				p.budget.Record(fixUsage.TotalTokens, fixUsage.CostUSD)
+				if reason := p.budget.ExceededReason(); reason != "" {
+					p.flagBudgetExceeded(reason)
+					p.telegram.Send(ctx, fmt.Sprintf(
+						"⏸ *Daily budget exceeded*\n%s\nDispatching paused until next UTC midnight.",
+						notify.EscapeMarkdown(reason)))
+				}
 
 				switch classifyAgentRun(backend, fixErr, fixOutput) {
 				case agentRunTimedOut:

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -182,6 +182,22 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	output := agent.ReadAfter(logFile, offset)
 
+	// ── Record usage (ENG-217) ───────────────────────────────────────────────
+	usage := agent.ParseUsage(output)
+	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+	if usage.TotalTokens > 0 || usage.CostUSD > 0 {
+		logger.Info("usage recorded",
+			"tokens", usage.TotalTokens, "cost_usd", usage.CostUSD)
+	}
+	// Check budget caps after recording. If exceeded, the pause takes effect
+	// on the next poll tick (in-flight work drains naturally).
+	if reason := p.budget.ExceededReason(); reason != "" {
+		p.flagBudgetExceeded(reason)
+		p.telegram.Send(ctx, fmt.Sprintf(
+			"⏸ *Daily budget exceeded*\n%s\nDispatching paused until next UTC midnight.",
+			notify.EscapeMarkdown(reason)))
+	}
+
 	// ── Rate limit ───────────────────────────────────────────────────────────
 	// Only ever classified on a FAILED run (see rateLimited): scanning the
 	// transcript of a *successful* run caused false positives where an agent
@@ -189,18 +205,23 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// work discarded (ENG-178 — Codex built the Noctra landing page, whose
 	// copy advertises "rate-limit detection"; three good runs were thrown away).
 	if rateLimited(backend, runErr, output) {
-		logger.Warn("usage/rate limit detected — triggering shutdown")
+		logger.Warn("usage/rate limit detected")
 		p.bumpFailed(id)
 		p.flagRateLimit()
+
+		action := "pausing"
+		if p.cfg.RateLimitStrategy == "shutdown" {
+			action = "shutting down"
+		}
 		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
-			"🛑 **Noctra: Rate limit detected**\n\nThe agent hit a usage or rate limit while working on this ticket.\n\nTicket moved back to **%s**. Noctra is shutting down to avoid further limit hits.",
-			p.cfg.TriggerState))
+			"🛑 **Noctra: Rate limit detected**\n\nThe agent hit a usage or rate limit while working on this ticket.\n\nTicket moved back to **%s**. Noctra is %s to avoid further limit hits.",
+			p.cfg.TriggerState, action))
 		p.mu.Lock()
 		s, f, t := p.successCount, p.failCount, p.totalDispatches
 		p.mu.Unlock()
 		p.telegram.Send(ctx, fmt.Sprintf(
-			"🛑 *Usage limit detected*\nNoctra stopped after %d dispatches.\n✅ %d PRs created | ❌ %d failed",
-			t, s, f))
+			"🛑 *Usage limit detected*\nNoctra %s after %d dispatches.\n✅ %d PRs created | ❌ %d failed",
+			action, t, s, f))
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}
@@ -344,6 +365,11 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 				}
 
 				fixOutput := agent.ReadAfter(logFile, fixOffset)
+
+				// Record usage from the fix pass.
+				fixUsage := agent.ParseUsage(fixOutput)
+				p.budget.Record(fixUsage.TotalTokens, fixUsage.CostUSD)
+
 				switch classifyAgentRun(backend, fixErr, fixOutput) {
 				case agentRunTimedOut:
 					logger.Warn("fix-pass timed out", "timeout", p.cfg.AgentTimeout)


### PR DESCRIPTION
## ENG-217: Budget/cost-aware management with graceful pause/resume

**Linear:** https://linear.app/amazz/issue/ENG-217/budgetcost-aware-management-with-graceful-pauseresume

## What was implemented

## ENG-217: Budget/cost-aware management with graceful pause/resume

### What was implemented

**New package: `internal/budget/`** — Concurrency-safe budget tracker that:
- Tracks token and cost usage per session and per day
- Enforces configurable daily caps (`MAX_DAILY_TOKENS`, `MAX_DAILY_USD`)
- Provides pause/resume mechanism with auto-resume at a specified time
- Automatically resets daily counters at UTC midnight

**New file: `internal/agent/usage.go`** — Best-effort usage parser that extracts token counts and cost from agent CLI output using regex patterns for known formats (Codex "tokens used: N", general "input/output/total tokens", cost "$X.XX"). Returns zeros for backends that don't report usage.

**Config additions (`internal/config/config.go`):**
- `MAX_DAILY_TOKENS` — daily token cap (0 = unlimited, default)
- `MAX_DAILY_USD` — daily dollar cap (0 = unlimited, default)
- `RATE_LIMIT_STRATEGY` — "pause" (default, new behavior) or "shutdown" (legacy behavior)
- `RATE_LIMIT_COOLDOWN` — seconds to pause after rate limit (default: 1800 = 30 minutes)

**Pipeline changes:**
- **Graceful pause instead of hard stop:** When `RATE_LIMIT_STRATEGY=pause` (default), a rate limit pauses dispatching for the cooldown period instead of exiting. The main loop stays alive and auto-resumes when the cooldown expires.
- **Budget cap enforcement:** When a daily cap is hit, dispatching pauses until the next UTC midnight. In-flight work drains naturally.
- **Usage tracking:** After every agent run (initial dispatch, fix-pass, PR iteration), usage is parsed from the output and recorded in the budget tracker.
- **Startup banner** now shows budget caps and rate-limit strategy.
- **Telegram `/status`** now shows session token/cost usage, daily usage vs. caps, and pause state.
- **Session summary** includes usage stats.

**Backward compatibility:** The old hard-shutdown behavior is preserved via `RATE_LIMIT_STRATEGY=shutdown`. The default switches to "pause" but all existing `.env` files without the new setting get the new pause behavior automatically.

### Key decisions
- The budget tracker is always non-nil (no nil checks needed in pipeline code). With no caps configured, `Exceeded()` returns false and `Record()` is a lightweight accumulator for display purposes.
- Usage parsing is best-effort — backends that don't print token counts contribute zeros. The budget cap mechanism works regardless since it operates on whatever data is available.
- Rate-limit pause and budget-cap pause share the same `budget.Tracker.Pause` mechanism but use different resume times: cooldown period for rate limits, next UTC midnight for budget caps.
- Daily counters reset lazily (checked on access) rather than via a background goroutine, following the codebase's preference for simplicity.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*