### PR TITLE
ENG-222: Autonomous maintenance sweeps + task catalog (no ticket required)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,34 @@ PR poll loop → github.ListNoctraPRs → github.GetPR (comments+reviews+statusC
 - Cursors: comment/review are **timestamps** (naturally ordered; conversation + inline comments share the comment cursor). CI is keyed by **head commit SHA** (`LastCISHA`) — acted on once per commit, since a fix changes the SHA and makes a fresh failure eligible again.
 - Noctra does **not** post back to the GitHub PR thread (no replies, no thread resolution); it pushes a follow-up commit and notifies via Telegram/Linear.
 
+## Autonomous maintenance sweeps (optional)
+
+When `SWEEP_ENABLED=true`, a **third** loop runs alongside the Linear and PR-watcher loops:
+
+```
+sweep loop → scheduler.DueIn (interval-based) → scheduler.Plan (all repos × task catalog)
+  → filter by cooldown (per-repo, per-task, from state store)
+  → pipeline.processSweepTask (bounded, shares the worker pool + active-set)
+  → repo.CreateWorktreeWithBranch → agent.Run (task-specific prompt) → commit/push → gh pr create
+```
+
+- **Opt-in**, off by default. Shares the `WaitGroup` so shutdown drains in-flight sweep tasks.
+- Runs under the same budget caps as ticket-driven work — if budget is paused or exceeded, sweeps are skipped.
+- Each task type has a per-repo **cooldown** persisted in the state file (`state.SweepState`), so the same task doesn't re-run before its cooldown expires (e.g. lint-cleanup has a 7-day cooldown).
+- Sweep branches use the `noctra/sweep-<suffix>` prefix (e.g. `noctra/sweep-lint-cleanup`), distinct from ticket-driven `noctra/<identifier>` — the auto-iterate watcher won't pick them up unless they match the `noctra/*` prefix filter (which they do, so auto-iterate works on sweep PRs too).
+- Sweep PRs get a `maintenance` label so humans can identify and bulk-close them.
+- Sweep identifiers follow the `SWEEP-<repo-slug>-<task-suffix>` pattern for worktree directories and active-set dedup.
+- Task catalog lives in `internal/sweep/task_*.go` — each file registers a task at init time. Current tasks: `lint-cleanup` (weekly cooldown) and `dead-code` (biweekly cooldown).
+
+### Config
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `SWEEP_ENABLED` | `false` | Enable the sweep scheduler |
+| `SWEEP_INTERVAL` | `86400` (24h) | Seconds between sweep cycles |
+| `SWEEP_MAX_TASKS` | `5` | Max tasks per sweep run |
+| `SWEEP_TASKS` | (all) | Comma-separated task names to enable (e.g. `lint-cleanup,dead-code`) |
+
 ## Multi-repo
 
 The target repo is chosen **per-ticket**, not from a single global path. Routing is **directive-only** — there is no repo registry. Resolution order:
@@ -78,9 +106,10 @@ The required-CLI set is backend-aware: `git` + `gh` + the selected agent CLI (`c
 | `internal/notify` | Optional Telegram notifier (fire-and-forget) |
 | `internal/telegram` | Inbound Telegram listener: long-polling `getUpdates`, sender auth, command dispatcher; started inline by `Pipeline.Run` (the `noctra run` process) when Telegram is configured |
 | `internal/github` | Thin `gh` CLI wrapper: `ListNoctraPRs`, `GetPR` (comments + reviews + inline review comments via REST + `statusCheckRollup`), `CheckLogs` (failed-step logs via `gh run view`) |
-| `internal/state` | File-backed PR cursor store (`~/.noctra-state.json`): per-PR comment/review timestamps + CI head-SHA + iteration count; atomic, mutex-guarded |
+| `internal/state` | File-backed PR cursor store (`~/.noctra-state.json`): per-PR comment/review timestamps + CI head-SHA + iteration count; sweep task cooldowns (`SweepState`); atomic, mutex-guarded |
 | `internal/watch` | Side-effect-free classifier: diffs a PR's feedback + CI status against the cursor, applies trusted-reviewer rules, emits actionable events + `CIFailure` |
-| `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle (`process.go`); PR-watch loop + per-PR re-engagement (`iterate.go`); Telegram command handlers — `/status`, `/tickets`, `/ticket`, `/search-tickets` (alias `/find`), `/kill`, `/requeue` (`commands.go`) |
+| `internal/pipeline` | Poll loop, bounded worker pool, full per-ticket lifecycle (`process.go`); PR-watch loop + per-PR re-engagement (`iterate.go`); sweep scheduler loop + per-task lifecycle (`sweep.go`); Telegram command handlers — `/status`, `/tickets`, `/ticket`, `/search-tickets` (alias `/find`), `/kill`, `/requeue` (`commands.go`) |
+| `internal/sweep` | Task catalog framework + scheduler for autonomous maintenance sweeps (ENG-222); task types registered at init (`task_lint.go`, `task_deadcode.go`); reuses `internal/repo`, `internal/agent`, `internal/state` |
 | `internal/setup` | Interactive setup wizard (`./noctra setup`) |
 | `internal/cleanup` | Cleanup subcommand: branches, worktrees, old logs |
 | `internal/service` | `install-service` subcommand: renders the `systemd --user` unit (pure, unit-tested `unitFile(exePath, pathEnv)`) to `~/.config/systemd/user/noctra.service`, `daemon-reload`s; `--start` enables/starts + `loginctl enable-linger`; refuses without `--force` if the unit exists; non-systemd hosts get a clear error. Pairs with `scripts/install.sh` (the `curl … \| sh` turnkey installer that downloads the release binary) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,10 @@ const (
 	// Budget / cost-aware management (ENG-217).
 	DefaultRateLimitStrategy = "pause"
 	DefaultRateLimitCooldown = 30 * time.Minute
+
+	// Sweep — autonomous maintenance (ENG-222) — disabled by default.
+	DefaultSweepInterval = 24 * time.Hour
+	DefaultSweepMaxTasks = 5
 )
 
 // Config is Noctra's resolved runtime configuration.
@@ -162,6 +166,13 @@ type Config struct {
 	MaxDailyUSD       float64       // daily dollar cap, 0 = unlimited
 	RateLimitStrategy string        // "pause" (default) or "shutdown"
 	RateLimitCooldown time.Duration // pause duration after rate limit (default 30m)
+
+	// Sweep — autonomous maintenance (ENG-222) — off by default.
+	SweepEnabled  bool            // opt-in maintenance sweep scheduler
+	SweepSchedule string          // cron expression (e.g. "0 2 * * *"); empty = use SweepInterval
+	SweepInterval time.Duration   // fallback fixed interval when no cron (default 24h)
+	SweepMaxTasks int             // max tasks per sweep run (default 5)
+	SweepTasks    []string        // enabled task names (nil = all registered tasks)
 
 	// Derived paths
 	ScriptDir    string
@@ -249,6 +260,14 @@ func Load(scriptDir string) (*Config, error) {
 	cfg.RateLimitStrategy = strings.ToLower(strings.TrimSpace(getenv(fileEnv, "RATE_LIMIT_STRATEGY", DefaultRateLimitStrategy)))
 	cooldownSecs := getint(fileEnv, "RATE_LIMIT_COOLDOWN", int(DefaultRateLimitCooldown/time.Second))
 	cfg.RateLimitCooldown = time.Duration(cooldownSecs) * time.Second
+
+	// Sweep — autonomous maintenance (ENG-222)
+	cfg.SweepEnabled = getbool(fileEnv, "SWEEP_ENABLED", false)
+	cfg.SweepSchedule = getenv(fileEnv, "SWEEP_SCHEDULE", "")
+	sweepIntervalSecs := getint(fileEnv, "SWEEP_INTERVAL", int(DefaultSweepInterval/time.Second))
+	cfg.SweepInterval = time.Duration(sweepIntervalSecs) * time.Second
+	cfg.SweepMaxTasks = getint(fileEnv, "SWEEP_MAX_TASKS", DefaultSweepMaxTasks)
+	cfg.SweepTasks = getlist(fileEnv, "SWEEP_TASKS")
 
 	return cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,11 +168,11 @@ type Config struct {
 	RateLimitCooldown time.Duration // pause duration after rate limit (default 30m)
 
 	// Sweep — autonomous maintenance (ENG-222) — off by default.
-	SweepEnabled  bool            // opt-in maintenance sweep scheduler
-	SweepSchedule string          // cron expression (e.g. "0 2 * * *"); empty = use SweepInterval
-	SweepInterval time.Duration   // fallback fixed interval when no cron (default 24h)
-	SweepMaxTasks int             // max tasks per sweep run (default 5)
-	SweepTasks    []string        // enabled task names (nil = all registered tasks)
+	SweepEnabled  bool          // opt-in maintenance sweep scheduler
+	SweepSchedule string        // cron expression (e.g. "0 2 * * *"); empty = use SweepInterval
+	SweepInterval time.Duration // fallback fixed interval when no cron (default 24h)
+	SweepMaxTasks int           // max tasks per sweep run (default 5)
+	SweepTasks    []string      // enabled task names (nil = all registered tasks)
 
 	// Derived paths
 	ScriptDir    string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,6 +23,7 @@ var noctraEnvKeys = []string{
 	"AUTO_ITERATE_PRS", "MAX_PR_ITERATIONS", "PR_POLL_INTERVAL",
 	"TRUSTED_REVIEWERS", "STATE_FILE",
 	"MAX_DAILY_TOKENS", "MAX_DAILY_USD", "RATE_LIMIT_STRATEGY", "RATE_LIMIT_COOLDOWN",
+	"SWEEP_ENABLED", "SWEEP_SCHEDULE", "SWEEP_INTERVAL", "SWEEP_MAX_TASKS", "SWEEP_TASKS",
 }
 
 func isolateEnv(t *testing.T) {
@@ -762,5 +763,72 @@ RATE_LIMIT_STRATEGY="Shutdown"`)
 	}
 	if cfg.RateLimitStrategy != "shutdown" {
 		t.Errorf("RateLimitStrategy should be lowercased, got %q", cfg.RateLimitStrategy)
+	}
+}
+
+func TestLoad_SweepDefaults(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `LINEAR_API_KEY="lin_xyz"`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.SweepEnabled {
+		t.Errorf("SweepEnabled should default to false")
+	}
+	if cfg.SweepSchedule != "" {
+		t.Errorf("SweepSchedule should default to empty, got %q", cfg.SweepSchedule)
+	}
+	if cfg.SweepInterval != DefaultSweepInterval {
+		t.Errorf("SweepInterval: got %v, want %v", cfg.SweepInterval, DefaultSweepInterval)
+	}
+	if cfg.SweepMaxTasks != DefaultSweepMaxTasks {
+		t.Errorf("SweepMaxTasks: got %d, want %d", cfg.SweepMaxTasks, DefaultSweepMaxTasks)
+	}
+	if cfg.SweepTasks != nil {
+		t.Errorf("SweepTasks should default to nil (= all), got %v", cfg.SweepTasks)
+	}
+}
+
+func TestLoad_SweepFromEnv(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".env"), `
+LINEAR_API_KEY="lin_xyz"
+SWEEP_ENABLED="true"
+SWEEP_SCHEDULE="0 2 * * *"
+SWEEP_INTERVAL="43200"
+SWEEP_MAX_TASKS="3"
+SWEEP_TASKS="lint-cleanup,dead-code"
+`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cfg.SweepEnabled {
+		t.Error("SweepEnabled should be true")
+	}
+	if cfg.SweepSchedule != "0 2 * * *" {
+		t.Errorf("SweepSchedule: got %q", cfg.SweepSchedule)
+	}
+	if cfg.SweepInterval != 43200*time.Second {
+		t.Errorf("SweepInterval: got %v", cfg.SweepInterval)
+	}
+	if cfg.SweepMaxTasks != 3 {
+		t.Errorf("SweepMaxTasks: got %d", cfg.SweepMaxTasks)
+	}
+	want := []string{"lint-cleanup", "dead-code"}
+	if len(cfg.SweepTasks) != len(want) {
+		t.Fatalf("SweepTasks length: got %d, want %d (%v)", len(cfg.SweepTasks), len(want), cfg.SweepTasks)
+	}
+	for i, w := range want {
+		if cfg.SweepTasks[i] != w {
+			t.Errorf("SweepTasks[%d]: got %q, want %q", i, cfg.SweepTasks[i], w)
+		}
 	}
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/review"
 	"github.com/ahmadAlMezaal/noctra/internal/selfupdate"
 	"github.com/ahmadAlMezaal/noctra/internal/state"
+	"github.com/ahmadAlMezaal/noctra/internal/sweep"
 	"github.com/ahmadAlMezaal/noctra/internal/telegram"
 	"github.com/ahmadAlMezaal/noctra/internal/watch"
 )
@@ -51,6 +52,9 @@ type Pipeline struct {
 
 	// Budget tracker — always non-nil (no-op when no caps configured).
 	budget *budget.Tracker
+
+	// Sweep scheduler — nil when cfg.SweepEnabled is false.
+	sweeper *sweep.Scheduler
 
 	sessionStart time.Time
 
@@ -96,22 +100,40 @@ func New(cfg *config.Config) *Pipeline {
 		sessionStart:   time.Now(),
 	}
 
-	// Auto-iterate is opt-in. When disabled, store/gh/watcher stay nil and
-	// the run loop never starts the PR-poller goroutine.
-	if cfg.AutoIteratePRs {
-		store, err := state.Open(cfg.StateFile)
+	// Both auto-iterate and sweep need the state store. Open it once if
+	// either feature is enabled.
+	var store *state.Store
+	if cfg.AutoIteratePRs || cfg.SweepEnabled {
+		var err error
+		store, err = state.Open(cfg.StateFile)
 		if err != nil {
-			slog.Warn("auto-iterate: state store open failed; feature disabled",
+			slog.Warn("state store open failed; auto-iterate and sweep disabled",
 				"path", cfg.StateFile, "err", err)
 			return p
 		}
 		p.store = store
+	}
+
+	// Auto-iterate is opt-in. When disabled, gh/watcher stay nil and
+	// the run loop never starts the PR-poller goroutine.
+	if cfg.AutoIteratePRs && store != nil {
 		p.gh = github.New()
 
 		// Directive-only routing has no static repo registry: the watcher
 		// discovers which repos to poll from the on-demand clones on disk,
 		// re-read on every scan (the set grows as tickets are dispatched).
 		p.watcher = watch.New(p.gh, store, p.resolver.AllRepoRemotes, cfg.TrustedReviewers)
+	}
+
+	// Sweep is opt-in. When disabled, sweeper stays nil and the run loop
+	// never starts the sweep-scheduler goroutine.
+	if cfg.SweepEnabled && store != nil {
+		tasks := sweep.FilterTasks(cfg.SweepTasks)
+		if len(tasks) == 0 {
+			slog.Warn("sweep: no tasks enabled; feature disabled")
+		} else {
+			p.sweeper = sweep.NewScheduler(store, p.resolver, tasks, cfg.SweepInterval, cfg.SweepMaxTasks)
+		}
 	}
 
 	return p
@@ -200,6 +222,13 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	if p.watcher != nil {
 		wg.Add(1)
 		go p.runWatcher(ctx, &wg)
+	}
+
+	// Sweep scheduler runs its own loop if enabled. Shares the WaitGroup
+	// so shutdown drains in-flight sweep tasks.
+	if p.sweeper != nil {
+		wg.Add(1)
+		go p.runSweepLoop(ctx, &wg)
 	}
 
 	for {
@@ -476,6 +505,11 @@ func (p *Pipeline) banner() {
 	if p.cfg.AutoReleaseLabel {
 		autoReleaseMode = fmt.Sprintf("On (default: %s)", p.cfg.DefaultReleaseBump)
 	}
+	sweepMode := "Disabled"
+	if p.sweeper != nil {
+		sweepMode = fmt.Sprintf("On (interval %s, max %d tasks)",
+			p.cfg.SweepInterval, p.cfg.SweepMaxTasks)
+	}
 
 	// Repos are routed per-ticket from each Linear project's "Repo:" directive
 	// and cloned on demand, so there's no static list at startup — report the
@@ -507,6 +541,7 @@ func (p *Pipeline) banner() {
 	fmt.Printf("   Review:         %s\n", reviewMode)
 	fmt.Printf("   Auto-iterate:   %s\n", autoIterMode)
 	fmt.Printf("   Release label:  %s\n", autoReleaseMode)
+	fmt.Printf("   Sweep:          %s\n", sweepMode)
 	fmt.Printf("   Max concurrent: %d\n", p.cfg.MaxConcurrent)
 	fmt.Printf("   Poll interval:  %s\n", p.cfg.PollInterval)
 	fmt.Printf("   Agent timeout:  %s\n", p.cfg.AgentTimeout)

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -46,10 +46,21 @@ func (p *Pipeline) runSweepLoop(ctx context.Context, wg *sync.WaitGroup) {
 			return
 		}
 
-		// Check budget pause before sweeping.
-		if paused, _, reason := p.budget.IsPaused(); paused {
-			slog.Debug("sweep: skipping (paused)", "reason", reason)
-			p.sweeper.MarkSwept()
+		// Check budget pause before sweeping — wait for the pause to
+		// expire rather than skipping the entire sweep interval.
+		if paused, until, reason := p.budget.IsPaused(); paused {
+			slog.Debug("sweep: paused, waiting for resume", "reason", reason, "until", until)
+			retryIn := time.Until(until)
+			if retryIn < 10*time.Second {
+				retryIn = 10 * time.Second
+			}
+			timer := time.NewTimer(retryIn)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
 			continue
 		}
 		if reason := p.budget.ExceededReason(); reason != "" {
@@ -137,6 +148,7 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 		logger.Error("worktree creation failed", "err", err)
 		return
 	}
+	defer repo.CleanupWorktree(context.Background(), job.RepoPath, p.cfg.WorktreeBase, identifier)
 	logger.Info("worktree created", "path", wt.Path, "branch", wt.Branch)
 
 	logFile := filepath.Join(p.cfg.LogDir, identifier+".log")
@@ -162,19 +174,16 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	// Killed or shutdown — clean up without recording.
 	if p.isKilled(identifier) {
 		logger.Info("sweep task killed by user")
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 	if ctx.Err() != nil {
 		logger.Info("sweep task cancelled (shutdown)")
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 
 	// Timeout.
 	if errors.Is(runErr, agent.ErrTimedOut) {
 		logger.Warn("sweep task timed out", "timeout", p.cfg.AgentTimeout)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 
@@ -197,24 +206,25 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	if rateLimited(backend, runErr, output) {
 		logger.Warn("rate limit detected during sweep")
 		p.flagRateLimit()
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 
 	// Agent error.
 	if runErr != nil {
 		logger.Warn("sweep agent exited with error", "err", runErr)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		// Record the run even on failure so cooldown is respected.
-		_ = p.sweeper.RecordRun(job.RepoSlug, job.Task.Name)
+		if err := p.sweeper.RecordRun(job.RepoSlug, job.Task.Name); err != nil {
+			logger.Warn("could not record sweep run in state", "err", err)
+		}
 		return
 	}
 
 	// BLOCKED — nothing to do for this task on this repo.
 	if blocked := agent.BlockedLine(output); blocked != "" {
 		logger.Info("sweep task blocked (nothing to do)", "reason", blocked)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
-		_ = p.sweeper.RecordRun(job.RepoSlug, job.Task.Name)
+		if err := p.sweeper.RecordRun(job.RepoSlug, job.Task.Name); err != nil {
+			logger.Warn("could not record sweep run in state", "err", err)
+		}
 		return
 	}
 
@@ -222,26 +232,24 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	dirty, err := workingTreeChanged(ctx, wt.Path)
 	if err != nil {
 		logger.Error("git status failed", "err", err)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 	committed, err := branchAhead(ctx, wt.Path, "origin/"+job.MainBranch)
 	if err != nil {
 		logger.Error("git rev-list failed", "err", err)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 	if !dirty && !committed {
 		logger.Info("sweep task made no changes")
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
-		_ = p.sweeper.RecordRun(job.RepoSlug, job.Task.Name)
+		if err := p.sweeper.RecordRun(job.RepoSlug, job.Task.Name); err != nil {
+			logger.Warn("could not record sweep run in state", "err", err)
+		}
 		return
 	}
 
 	// Stage, commit, push.
 	if err := runIn(ctx, wt.Path, "git", "add", "-A"); err != nil {
 		logger.Error("git add failed", "err", err)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 
@@ -253,19 +261,16 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	staged, err := hasStagedChanges(ctx, wt.Path)
 	if err != nil {
 		logger.Error("git diff --cached failed", "err", err)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 	if staged {
 		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
 			logger.Error("git commit failed", "err", err)
-			repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 			return
 		}
 	}
 	if err := runIn(ctx, wt.Path, "git", "push", "-u", "origin", wt.Branch); err != nil {
 		logger.Error("git push failed", "err", err)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 	logger.Info("pushed", "branch", wt.Branch)
@@ -283,7 +288,6 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	prURL, err := ghCreatePR(ctx, job.RepoPath, prTitle, prBody, job.MainBranch, wt.Branch)
 	if err != nil {
 		logger.Error("gh pr create failed", "err", err)
-		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 		return
 	}
 
@@ -302,7 +306,9 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 		prURL))
 
 	// Record cooldown.
-	_ = p.sweeper.RecordRun(job.RepoSlug, job.Task.Name)
+	if err := p.sweeper.RecordRun(job.RepoSlug, job.Task.Name); err != nil {
+		logger.Warn("could not record sweep run in state", "err", err)
+	}
 
 	// Track in state store for auto-iterate (if enabled).
 	if p.store != nil {
@@ -313,6 +319,4 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 			logger.Warn("could not persist sweep PR in state", "err", err)
 		}
 	}
-
-	repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
 }

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -1,0 +1,318 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/agent"
+	"github.com/ahmadAlMezaal/noctra/internal/notify"
+	"github.com/ahmadAlMezaal/noctra/internal/repo"
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+	"github.com/ahmadAlMezaal/noctra/internal/sweep"
+)
+
+// runSweepLoop is the sweep-scheduler loop, started by Run when
+// cfg.SweepEnabled is true. It runs on the same WaitGroup as the main
+// Linear poll loop so shutdown drains in-flight sweep tasks.
+func (p *Pipeline) runSweepLoop(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	slog.Info("sweep scheduler starting",
+		"interval", p.cfg.SweepInterval,
+		"max_tasks", p.cfg.SweepMaxTasks,
+	)
+
+	for {
+		due := p.sweeper.DueIn()
+		if due > 0 {
+			slog.Debug("sweep: next sweep in", "due_in", due)
+			timer := time.NewTimer(due)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Check budget pause before sweeping.
+		if paused, _, reason := p.budget.IsPaused(); paused {
+			slog.Debug("sweep: skipping (paused)", "reason", reason)
+			p.sweeper.MarkSwept()
+			continue
+		}
+		if reason := p.budget.ExceededReason(); reason != "" {
+			slog.Debug("sweep: skipping (budget exceeded)", "reason", reason)
+			p.sweeper.MarkSwept()
+			continue
+		}
+
+		p.sweepOnce(ctx, wg)
+		p.sweeper.MarkSwept()
+	}
+}
+
+// sweepOnce runs one sweep cycle: plan eligible jobs and dispatch them.
+func (p *Pipeline) sweepOnce(ctx context.Context, wg *sync.WaitGroup) {
+	jobs := p.sweeper.Plan(ctx)
+	if len(jobs) == 0 {
+		slog.Info("sweep: no eligible tasks")
+		return
+	}
+
+	slog.Info("sweep: dispatching", "jobs", len(jobs))
+	p.telegram.Send(ctx, fmt.Sprintf("🧹 *Sweep started* — %d maintenance task(s)", len(jobs)))
+
+	for _, job := range jobs {
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Check budget before each task.
+		if paused, _, _ := p.budget.IsPaused(); paused {
+			slog.Info("sweep: stopping (paused)")
+			return
+		}
+		if reason := p.budget.ExceededReason(); reason != "" {
+			p.flagBudgetExceeded(reason)
+			return
+		}
+
+		// Respect worker pool capacity.
+		p.mu.Lock()
+		if len(p.active) >= p.cfg.MaxConcurrent {
+			p.mu.Unlock()
+			slog.Info("sweep: at capacity, deferring remaining tasks")
+			return
+		}
+
+		identifier := sweep.SweepIdentifier(job.RepoSlug, job.Task.BranchSuffix)
+		if _, dupe := p.active[identifier]; dupe {
+			p.mu.Unlock()
+			continue
+		}
+		taskCtx, taskCancel := context.WithCancel(ctx)
+		p.active[identifier] = struct{}{}
+		p.cancels[identifier] = taskCancel
+		p.mu.Unlock()
+
+		wg.Add(1)
+		go func(j sweep.Job, id string) {
+			defer wg.Done()
+			defer p.markDone(id)
+			p.processSweepTask(taskCtx, j, id)
+		}(job, identifier)
+	}
+}
+
+// processSweepTask is one sweep task's full lifecycle: create worktree →
+// run agent with task-specific prompt → check output → commit/push → PR.
+func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifier string) {
+	logger := slog.With("sweep_task", job.Task.Name, "repo", job.RepoSlug, "id", identifier)
+	logger.Info("starting sweep task", "description", job.Task.Description)
+
+	backend := p.agent
+
+	if p.cfg.TelegramVerbose {
+		p.telegram.Send(ctx, fmt.Sprintf("🧹 *Sweep: %s* on %s\n%s",
+			notify.EscapeMarkdown(job.Task.Name),
+			notify.EscapeMarkdown(job.RepoSlug),
+			notify.EscapeMarkdown(job.Task.Description)))
+	}
+
+	branch := sweep.SweepBranchName(job.Task.BranchSuffix)
+	wt, err := repo.CreateWorktreeWithBranch(ctx, p.cfg.WorktreeBase, identifier, job.RepoPath, job.MainBranch, branch)
+	if err != nil {
+		logger.Error("worktree creation failed", "err", err)
+		return
+	}
+	logger.Info("worktree created", "path", wt.Path, "branch", wt.Branch)
+
+	logFile := filepath.Join(p.cfg.LogDir, identifier+".log")
+	if err := agent.AttemptHeader(logFile); err != nil {
+		logger.Warn("could not write attempt header", "err", err)
+	}
+
+	prompt := job.Task.Prompt(wt.Path)
+	offset := agent.OffsetBefore(logFile)
+
+	logger.Info("running agent",
+		"backend", backend.Name(),
+		"log", logFile,
+		"timeout", p.cfg.AgentTimeout)
+
+	runErr := backend.Run(ctx, agent.RunOptions{
+		Workdir: wt.Path,
+		Prompt:  prompt,
+		LogFile: logFile,
+		Timeout: p.cfg.AgentTimeout,
+	})
+
+	// Killed or shutdown — clean up without recording.
+	if p.isKilled(identifier) {
+		logger.Info("sweep task killed by user")
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+	if ctx.Err() != nil {
+		logger.Info("sweep task cancelled (shutdown)")
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+
+	// Timeout.
+	if errors.Is(runErr, agent.ErrTimedOut) {
+		logger.Warn("sweep task timed out", "timeout", p.cfg.AgentTimeout)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+
+	output := agent.ReadAfter(logFile, offset)
+
+	// Record usage.
+	usage := agent.ParseUsage(output)
+	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+	if usage.TotalTokens > 0 || usage.CostUSD > 0 {
+		logger.Info("usage recorded", "tokens", usage.TotalTokens, "cost_usd", usage.CostUSD)
+	}
+	if reason := p.budget.ExceededReason(); reason != "" {
+		p.flagBudgetExceeded(reason)
+		p.telegram.Send(ctx, fmt.Sprintf(
+			"⏸ *Daily budget exceeded*\n%s\nDispatching paused until next UTC midnight.",
+			notify.EscapeMarkdown(reason)))
+	}
+
+	// Rate limit.
+	if rateLimited(backend, runErr, output) {
+		logger.Warn("rate limit detected during sweep")
+		p.flagRateLimit()
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+
+	// Agent error.
+	if runErr != nil {
+		logger.Warn("sweep agent exited with error", "err", runErr)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		// Record the run even on failure so cooldown is respected.
+		_ = p.sweeper.RecordRun(job.RepoSlug, job.Task.Name)
+		return
+	}
+
+	// BLOCKED — nothing to do for this task on this repo.
+	if blocked := agent.BlockedLine(output); blocked != "" {
+		logger.Info("sweep task blocked (nothing to do)", "reason", blocked)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		_ = p.sweeper.RecordRun(job.RepoSlug, job.Task.Name)
+		return
+	}
+
+	// Check for changes.
+	dirty, err := workingTreeChanged(ctx, wt.Path)
+	if err != nil {
+		logger.Error("git status failed", "err", err)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+	committed, err := branchAhead(ctx, wt.Path, "origin/"+job.MainBranch)
+	if err != nil {
+		logger.Error("git rev-list failed", "err", err)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+	if !dirty && !committed {
+		logger.Info("sweep task made no changes")
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		_ = p.sweeper.RecordRun(job.RepoSlug, job.Task.Name)
+		return
+	}
+
+	// Stage, commit, push.
+	if err := runIn(ctx, wt.Path, "git", "add", "-A"); err != nil {
+		logger.Error("git add failed", "err", err)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+
+	commitMsg := appendCoAuthorTrailer(
+		fmt.Sprintf("%s: %s\n\nAutonomous maintenance by Noctra using %s",
+			job.Task.CommitPrefix, job.Task.Description, backend.Label()),
+		backend.CoAuthor())
+
+	staged, err := hasStagedChanges(ctx, wt.Path)
+	if err != nil {
+		logger.Error("git diff --cached failed", "err", err)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+	if staged {
+		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
+			logger.Error("git commit failed", "err", err)
+			repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+			return
+		}
+	}
+	if err := runIn(ctx, wt.Path, "git", "push", "-u", "origin", wt.Branch); err != nil {
+		logger.Error("git push failed", "err", err)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+	logger.Info("pushed", "branch", wt.Branch)
+
+	// PR body.
+	rawLog, _ := os.ReadFile(logFile)
+	summary := agent.ExtractSummary(string(rawLog))
+
+	prBody := fmt.Sprintf(
+		"## 🧹 Maintenance: %s\n\n**Task:** %s\n**Repo:** %s\n\n## What was done\n\n%s\n\n---\n\n*Autonomous maintenance by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using %s*",
+		job.Task.Name, job.Task.Description, job.RepoSlug, summary, backend.Label())
+
+	prTitle := fmt.Sprintf("%s: %s", job.Task.CommitPrefix, job.Task.Description)
+
+	prURL, err := ghCreatePR(ctx, job.RepoPath, prTitle, prBody, job.MainBranch, wt.Branch)
+	if err != nil {
+		logger.Error("gh pr create failed", "err", err)
+		repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+		return
+	}
+
+	// Apply maintenance label if configured.
+	if job.Task.PRLabel != "" {
+		if err := ghAddLabel(ctx, job.RepoPath, prURL, job.Task.PRLabel); err != nil {
+			logger.Warn("could not apply label", "label", job.Task.PRLabel, "err", err)
+		}
+	}
+
+	logger.Info("✅ sweep PR created", "url", prURL)
+	p.bumpSuccess()
+	p.telegram.Send(ctx, fmt.Sprintf("✅ *Sweep: %s* on %s\nPR: %s",
+		notify.EscapeMarkdown(job.Task.Name),
+		notify.EscapeMarkdown(job.RepoSlug),
+		prURL))
+
+	// Record cooldown.
+	_ = p.sweeper.RecordRun(job.RepoSlug, job.Task.Name)
+
+	// Track in state store for auto-iterate (if enabled).
+	if p.store != nil {
+		if err := p.store.Update(prURL, func(r *state.PRState) {
+			r.TicketID = strings.ToUpper(identifier)
+			r.AgentBackend = backend.Name()
+		}); err != nil {
+			logger.Warn("could not persist sweep PR in state", "err", err)
+		}
+	}
+
+	repo.CleanupWorktree(ctx, job.RepoPath, p.cfg.WorktreeBase, identifier)
+}

--- a/internal/repo/resolve.go
+++ b/internal/repo/resolve.go
@@ -208,6 +208,19 @@ func isGitRepo(path string) bool {
 	return err == nil && info.IsDir()
 }
 
+// SlugFromPath extracts the directory-name slug from a local repo path.
+// It's the inverse of Slug applied to the base directory — e.g.
+// "/home/user/.noctra-repos/my-repo" → "my-repo".
+func SlugFromPath(repoPath string) string {
+	return filepath.Base(repoPath)
+}
+
+// DefaultBranchOf reads the default branch of a local clone by inspecting
+// origin/HEAD. Falls back to "main" when it can't be determined.
+func DefaultBranchOf(ctx context.Context, repoPath string) string {
+	return defaultBranch(ctx, repoPath, "main")
+}
+
 // AllRepoPaths returns every local repo Noctra knows about: every on-demand
 // clone found under ReposBase, plus the REPO_PATH fallback (if set and valid).
 // Used by the cleanup subcommand and startup cleanup. Directive-only routing

--- a/internal/repo/worktree.go
+++ b/internal/repo/worktree.go
@@ -69,6 +69,23 @@ func ResumeWorktree(ctx context.Context, base, identifier, repoPath string) (Wor
 	return Worktree{Path: wt, Branch: branch}, nil
 }
 
+// CreateWorktreeWithBranch is like CreateWorktree but takes an explicit branch
+// name instead of deriving it from the identifier. Used by sweep tasks whose
+// branches follow the "noctra/sweep-<suffix>" convention instead of the
+// ticket-driven "noctra/<identifier>".
+func CreateWorktreeWithBranch(ctx context.Context, base, identifier, repoPath, mainBranch, branch string) (Worktree, error) {
+	wt := filepath.Join(base, identifier)
+
+	_ = runIn(ctx, repoPath, "git", "fetch", "origin", mainBranch, "--quiet")
+	_ = runIn(ctx, repoPath, "git", "worktree", "remove", "--force", wt)
+	_ = runIn(ctx, repoPath, "git", "branch", "-D", branch)
+
+	if err := runIn(ctx, repoPath, "git", "worktree", "add", "-b", branch, wt, "origin/"+mainBranch); err != nil {
+		return Worktree{}, fmt.Errorf("git worktree add %s: %w", wt, err)
+	}
+	return Worktree{Path: wt, Branch: branch}, nil
+}
+
 // CleanupWorktree removes the worktree for an identifier. We try the git
 // worktree machinery first (which also clears the admin entry), and fall back
 // to plain rm -rf if that fails — matching the bash predecessor.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -3,6 +3,10 @@
 // per-PR iteration counter. The watcher reads this on startup so a restart
 // doesn't re-react to comments that pre-date the cursor.
 //
+// It also tracks sweep task cooldowns (ENG-222): per-repo, per-task last-run
+// timestamps so the same maintenance task isn't re-run before its cooldown
+// expires.
+//
 // Backed by a single JSON file at the path passed to Open. Concurrent-safe:
 // the store guards its in-memory map with a mutex and writes the file
 // atomically (write-temp, rename) on every update.
@@ -54,11 +58,19 @@ type PRState struct {
 	LastIteratedAt time.Time `json:"last_iterated_at,omitempty"`
 }
 
-type fileFormat struct {
-	PRs map[string]*PRState `json:"prs"`
+// SweepState is the per-task-per-repo record for autonomous maintenance
+// sweeps (ENG-222). The key is "repo-slug/task-name".
+type SweepState struct {
+	// LastRunAt is when this task last ran on this repo.
+	LastRunAt time.Time `json:"last_run_at,omitempty"`
 }
 
-// Store is a thread-safe, file-backed PR state.
+type fileFormat struct {
+	PRs    map[string]*PRState    `json:"prs"`
+	Sweeps map[string]*SweepState `json:"sweeps,omitempty"`
+}
+
+// Store is a thread-safe, file-backed PR and sweep state.
 type Store struct {
 	mu   sync.Mutex
 	path string
@@ -68,7 +80,10 @@ type Store struct {
 // Open loads the state file at path. A missing file is not an error — the
 // returned store starts empty and Save will create the file on first write.
 func Open(path string) (*Store, error) {
-	s := &Store{path: path, data: fileFormat{PRs: map[string]*PRState{}}}
+	s := &Store{path: path, data: fileFormat{
+		PRs:    map[string]*PRState{},
+		Sweeps: map[string]*SweepState{},
+	}}
 
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -82,6 +97,9 @@ func Open(path string) (*Store, error) {
 	}
 	if s.data.PRs == nil {
 		s.data.PRs = map[string]*PRState{}
+	}
+	if s.data.Sweeps == nil {
+		s.data.Sweeps = map[string]*SweepState{}
 	}
 	return s, nil
 }
@@ -123,6 +141,43 @@ func (s *Store) Update(prURL string, fn func(*PRState)) error {
 	if !ok || r == nil {
 		r = &PRState{}
 		s.data.PRs[prURL] = r
+	}
+	fn(r)
+	data, err := json.MarshalIndent(s.data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+	return writeAtomic(s.path, data)
+}
+
+// SweepKey builds the state key for a sweep task on a specific repo.
+// Format: "<repo-slug>/<task-name>".
+func SweepKey(repoSlug, taskName string) string {
+	return repoSlug + "/" + taskName
+}
+
+// GetSweep returns a copy of the sweep state for the given key, or a
+// zero-value SweepState if the task hasn't run yet.
+func (s *Store) GetSweep(key string) SweepState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r, ok := s.data.Sweeps[key]; ok && r != nil {
+		return *r
+	}
+	return SweepState{}
+}
+
+// UpdateSweep mutates the sweep state for the given key and writes the file.
+func (s *Store) UpdateSweep(key string, fn func(*SweepState)) error {
+	if fn == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.data.Sweeps[key]
+	if !ok || r == nil {
+		r = &SweepState{}
+		s.data.Sweeps[key] = r
 	}
 	fn(r)
 	data, err := json.MarshalIndent(s.data, "", "  ")

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -99,3 +99,78 @@ func TestWriteAtomic_LeavesNoTmpFileOnSuccess(t *testing.T) {
 		t.Errorf("temp files left behind: %v", entries)
 	}
 }
+
+func TestSweepKey(t *testing.T) {
+	got := SweepKey("my-repo", "lint-cleanup")
+	want := "my-repo/lint-cleanup"
+	if got != want {
+		t.Errorf("SweepKey = %q, want %q", got, want)
+	}
+}
+
+func TestGetSweep_UnknownReturnsZero(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := s.GetSweep("nonexistent/task")
+	if got != (SweepState{}) {
+		t.Errorf("expected zero SweepState, got %+v", got)
+	}
+}
+
+func TestUpdateSweep_PersistsAcrossReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	key := SweepKey("my-repo", "lint-cleanup")
+	if err := s.UpdateSweep(key, func(ss *SweepState) {
+		ss.LastRunAt = now
+	}); err != nil {
+		t.Fatalf("UpdateSweep: %v", err)
+	}
+
+	// Reopen and verify.
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := s2.GetSweep(key)
+	if !got.LastRunAt.Equal(now) {
+		t.Errorf("LastRunAt: got %v, want %v", got.LastRunAt, now)
+	}
+}
+
+func TestUpdateSweep_CoexistsWithPRState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	s, _ := Open(path)
+
+	// Write a PR state entry.
+	if err := s.Update("https://github.com/me/repo/pull/1", func(r *PRState) {
+		r.TicketID = "ENG-1"
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a sweep state entry.
+	if err := s.UpdateSweep("my-repo/lint", func(ss *SweepState) {
+		ss.LastRunAt = time.Now()
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen and verify both exist.
+	s2, _ := Open(path)
+	pr := s2.Get("https://github.com/me/repo/pull/1")
+	if pr.TicketID != "ENG-1" {
+		t.Errorf("PR state lost: TicketID = %q", pr.TicketID)
+	}
+	sw := s2.GetSweep("my-repo/lint")
+	if sw.LastRunAt.IsZero() {
+		t.Error("Sweep state lost: LastRunAt is zero")
+	}
+}

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -20,8 +20,9 @@ type Scheduler struct {
 	interval time.Duration
 	maxTasks int
 
-	// lastSweep tracks when the last sweep cycle completed. Reset on startup
-	// to fire an initial sweep after the interval rather than immediately.
+	// lastSweep tracks when the last sweep cycle completed. Zero-valued on
+	// startup so an immediate sweep fires if tasks are due (per-task cooldowns
+	// in the state store prevent repeated runs).
 	lastSweep time.Time
 	// now is a hook for testing — defaults to time.Now.
 	now func() time.Time
@@ -35,16 +36,16 @@ func NewScheduler(store *state.Store, resolver *repo.Resolver, tasks []Task, int
 		tasks:     tasks,
 		interval:  interval,
 		maxTasks:  maxTasks,
-		lastSweep: time.Now(), // suppress immediate sweep on startup
+		lastSweep: time.Time{}, // allow immediate sweep on startup if tasks are due (cooldowns prevent spam)
 		now:       time.Now,
 	}
 }
 
 // Job is one eligible (repo, task) pair ready to be dispatched.
 type Job struct {
-	Task     Task
-	RepoPath string   // local clone path
-	RepoSlug string   // slug for branch/identifier naming
+	Task       Task
+	RepoPath   string // local clone path
+	RepoSlug   string // slug for branch/identifier naming
 	MainBranch string // base branch
 }
 

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -1,0 +1,138 @@
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/repo"
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+)
+
+// Scheduler determines when the next sweep should fire and which tasks are
+// eligible on which repos. It is side-effect-free: the pipeline drives
+// actual execution.
+type Scheduler struct {
+	store    *state.Store
+	resolver *repo.Resolver
+	tasks    []Task
+	interval time.Duration
+	maxTasks int
+
+	// lastSweep tracks when the last sweep cycle completed. Reset on startup
+	// to fire an initial sweep after the interval rather than immediately.
+	lastSweep time.Time
+	// now is a hook for testing — defaults to time.Now.
+	now func() time.Time
+}
+
+// NewScheduler creates a sweep scheduler.
+func NewScheduler(store *state.Store, resolver *repo.Resolver, tasks []Task, interval time.Duration, maxTasks int) *Scheduler {
+	return &Scheduler{
+		store:     store,
+		resolver:  resolver,
+		tasks:     tasks,
+		interval:  interval,
+		maxTasks:  maxTasks,
+		lastSweep: time.Now(), // suppress immediate sweep on startup
+		now:       time.Now,
+	}
+}
+
+// Job is one eligible (repo, task) pair ready to be dispatched.
+type Job struct {
+	Task     Task
+	RepoPath string   // local clone path
+	RepoSlug string   // slug for branch/identifier naming
+	MainBranch string // base branch
+}
+
+// DueIn returns how long until the next sweep should fire. Returns 0 if
+// a sweep is already due.
+func (s *Scheduler) DueIn() time.Duration {
+	elapsed := s.now().Sub(s.lastSweep)
+	if elapsed >= s.interval {
+		return 0
+	}
+	return s.interval - elapsed
+}
+
+// MarkSwept records that a sweep cycle just completed.
+func (s *Scheduler) MarkSwept() {
+	s.lastSweep = s.now()
+}
+
+// Plan scans all known repos and returns the list of eligible (repo, task)
+// jobs — at most maxTasks total. A task is eligible if its cooldown on the
+// repo has expired.
+func (s *Scheduler) Plan(ctx context.Context) []Job {
+	repoPaths := s.resolver.AllRepoPaths()
+	if len(repoPaths) == 0 {
+		slog.Debug("sweep: no repos cloned yet")
+		return nil
+	}
+
+	var jobs []Job
+	for _, rp := range repoPaths {
+		if ctx.Err() != nil {
+			break
+		}
+		slug := repo.SlugFromPath(rp)
+		if slug == "" {
+			continue
+		}
+		mainBranch := repo.DefaultBranchOf(ctx, rp)
+
+		for _, task := range s.tasks {
+			if len(jobs) >= s.maxTasks {
+				break
+			}
+			key := state.SweepKey(slug, task.Name)
+			ss := s.store.GetSweep(key)
+			if !ss.LastRunAt.IsZero() && s.now().Sub(ss.LastRunAt) < task.Cooldown {
+				slog.Debug("sweep: task on cooldown",
+					"task", task.Name, "repo", slug,
+					"last_run", ss.LastRunAt,
+					"cooldown_remaining", task.Cooldown-s.now().Sub(ss.LastRunAt))
+				continue
+			}
+			jobs = append(jobs, Job{
+				Task:       task,
+				RepoPath:   rp,
+				RepoSlug:   slug,
+				MainBranch: mainBranch,
+			})
+		}
+		if len(jobs) >= s.maxTasks {
+			break
+		}
+	}
+
+	slog.Info("sweep plan",
+		"repos", len(repoPaths),
+		"tasks", len(s.tasks),
+		"eligible", len(jobs),
+		"max", s.maxTasks)
+	return jobs
+}
+
+// RecordRun persists that a task just ran on a repo.
+func (s *Scheduler) RecordRun(repoSlug, taskName string) error {
+	key := state.SweepKey(repoSlug, taskName)
+	return s.store.UpdateSweep(key, func(ss *state.SweepState) {
+		ss.LastRunAt = s.now()
+	})
+}
+
+// Summary returns a human-readable status of sweep task cooldowns.
+func (s *Scheduler) Summary() string {
+	var out string
+	for _, t := range s.tasks {
+		out += fmt.Sprintf("  - %s (cooldown: %s)\n", t.Name, t.Cooldown)
+	}
+	if out == "" {
+		return "  (no tasks registered)"
+	}
+	return out
+}

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -52,14 +52,20 @@ func TestScheduler_DueIn(t *testing.T) {
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
 	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5)
 
-	// Just created — should not be due yet (suppress initial sweep).
-	if due := s.DueIn(); due == 0 {
-		t.Error("DueIn should not be 0 immediately after creation")
+	// Just created — should be immediately due (no startup suppression;
+	// per-task cooldowns prevent spam).
+	if due := s.DueIn(); due != 0 {
+		t.Errorf("DueIn should be 0 immediately after creation, got %v", due)
 	}
 
-	// Simulate time passing.
-	past := time.Now().Add(-2 * time.Hour)
-	s.lastSweep = past
+	// After marking swept, should not be due until interval elapses.
+	s.MarkSwept()
+	if due := s.DueIn(); due == 0 {
+		t.Error("DueIn should not be 0 immediately after MarkSwept")
+	}
+
+	// Simulate time passing beyond the interval.
+	s.lastSweep = time.Now().Add(-2 * time.Hour)
 	if due := s.DueIn(); due != 0 {
 		t.Errorf("DueIn should be 0 after interval elapsed, got %v", due)
 	}

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -1,0 +1,191 @@
+package sweep
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/repo"
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+)
+
+// testTask returns a minimal task for testing.
+func testTask(name string, cooldown time.Duration) Task {
+	return Task{
+		Name:         name,
+		Description:  "Test task: " + name,
+		Cooldown:     cooldown,
+		BranchSuffix: name,
+		CommitPrefix: "test",
+		Prompt:       func(repoPath string) string { return "test prompt for " + repoPath },
+	}
+}
+
+// initTestRepo creates a minimal git repo and returns its path.
+func initTestRepo(t *testing.T, base, name string) string {
+	t.Helper()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmds := [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git init: %s: %v", out, err)
+		}
+	}
+	return dir
+}
+
+func TestScheduler_DueIn(t *testing.T) {
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	resolver := &repo.Resolver{ReposBase: t.TempDir()}
+	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5)
+
+	// Just created — should not be due yet (suppress initial sweep).
+	if due := s.DueIn(); due == 0 {
+		t.Error("DueIn should not be 0 immediately after creation")
+	}
+
+	// Simulate time passing.
+	past := time.Now().Add(-2 * time.Hour)
+	s.lastSweep = past
+	if due := s.DueIn(); due != 0 {
+		t.Errorf("DueIn should be 0 after interval elapsed, got %v", due)
+	}
+}
+
+func TestScheduler_MarkSwept(t *testing.T) {
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	resolver := &repo.Resolver{ReposBase: t.TempDir()}
+	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5)
+
+	s.lastSweep = time.Now().Add(-2 * time.Hour) // make it due
+	s.MarkSwept()
+
+	if due := s.DueIn(); due == 0 {
+		t.Error("DueIn should not be 0 immediately after MarkSwept")
+	}
+}
+
+func TestScheduler_PlanRespectsMaxTasks(t *testing.T) {
+	reposBase := t.TempDir()
+	initTestRepo(t, reposBase, "repo-a")
+	initTestRepo(t, reposBase, "repo-b")
+
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	resolver := &repo.Resolver{ReposBase: reposBase}
+
+	tasks := []Task{
+		testTask("t1", time.Hour),
+		testTask("t2", time.Hour),
+		testTask("t3", time.Hour),
+	}
+
+	s := NewScheduler(store, resolver, tasks, time.Hour, 2) // max 2
+
+	jobs := s.Plan(context.Background())
+	if len(jobs) > 2 {
+		t.Errorf("Plan returned %d jobs, max is 2", len(jobs))
+	}
+}
+
+func TestScheduler_PlanRespectsCooldown(t *testing.T) {
+	reposBase := t.TempDir()
+	initTestRepo(t, reposBase, "my-repo")
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	store, _ := state.Open(statePath)
+
+	tasks := []Task{
+		testTask("task-a", 24*time.Hour),
+		testTask("task-b", 24*time.Hour),
+	}
+
+	s := NewScheduler(store, resolver(reposBase), tasks, time.Hour, 10)
+
+	// Both should be eligible initially.
+	jobs := s.Plan(context.Background())
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 eligible tasks, got %d", len(jobs))
+	}
+
+	// Record one run.
+	if err := s.RecordRun("my-repo", "task-a"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now only task-b should be eligible.
+	jobs = s.Plan(context.Background())
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 eligible task after recording, got %d", len(jobs))
+	}
+	if jobs[0].Task.Name != "task-b" {
+		t.Errorf("expected task-b, got %q", jobs[0].Task.Name)
+	}
+}
+
+func TestScheduler_PlanNoRepos(t *testing.T) {
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	resolver := &repo.Resolver{ReposBase: t.TempDir()} // empty
+
+	s := NewScheduler(store, resolver, []Task{testTask("t1", time.Hour)}, time.Hour, 5)
+	jobs := s.Plan(context.Background())
+	if len(jobs) != 0 {
+		t.Errorf("expected 0 jobs with no repos, got %d", len(jobs))
+	}
+}
+
+func TestScheduler_RecordRun(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	store, _ := state.Open(statePath)
+
+	resolver := &repo.Resolver{ReposBase: t.TempDir()}
+	s := NewScheduler(store, resolver, nil, time.Hour, 5)
+
+	if err := s.RecordRun("my-repo", "lint-cleanup"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify state persisted.
+	key := state.SweepKey("my-repo", "lint-cleanup")
+	ss := store.GetSweep(key)
+	if ss.LastRunAt.IsZero() {
+		t.Error("LastRunAt should be set after RecordRun")
+	}
+
+	// Verify persists across reopen.
+	store2, err := state.Open(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss2 := store2.GetSweep(key)
+	if ss2.LastRunAt.IsZero() {
+		t.Error("LastRunAt should persist across reopen")
+	}
+}
+
+func TestScheduler_Summary(t *testing.T) {
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	resolver := &repo.Resolver{ReposBase: t.TempDir()}
+
+	s := NewScheduler(store, resolver, []Task{testTask("t1", 24*time.Hour)}, time.Hour, 5)
+	summary := s.Summary()
+	if summary == "" {
+		t.Error("Summary should not be empty")
+	}
+}
+
+func resolver(reposBase string) *repo.Resolver {
+	return &repo.Resolver{ReposBase: reposBase}
+}

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -1,0 +1,83 @@
+// Package sweep implements autonomous maintenance sweeps for Noctra (ENG-222).
+// A scheduled sweep scans every known repo, selects eligible tasks from the
+// task catalog (respecting per-task cooldowns), runs the coding agent with a
+// task-specific prompt, and opens a PR for each change — all under the same
+// budget caps and worker pool as ticket-driven work.
+//
+// Fully opt-in via SWEEP_ENABLED=true in .env; off by default.
+package sweep
+
+import (
+	"time"
+)
+
+// Task describes a maintenance task in the catalog.
+type Task struct {
+	// Name is the unique identifier (e.g. "lint-cleanup", "dead-code").
+	Name string
+	// Description is a short human-readable summary shown in logs and PR bodies.
+	Description string
+	// Cooldown is the minimum duration between runs of this task on the same
+	// repo. Prevents the same sweep from re-running nightly.
+	Cooldown time.Duration
+	// Prompt returns the full agent prompt for this task. repoPath is the
+	// local checkout path so prompts can reference it.
+	Prompt func(repoPath string) string
+	// BranchSuffix is appended to the branch name (e.g. "lint-cleanup" →
+	// "noctra/sweep-lint-cleanup"). Must be unique across tasks.
+	BranchSuffix string
+	// CommitPrefix is the conventional-commit prefix (e.g. "chore", "fix").
+	CommitPrefix string
+	// PRLabel is an optional GitHub label applied to the PR (e.g. "maintenance").
+	PRLabel string
+}
+
+// catalog is the built-in set of maintenance tasks, registered at init time.
+var catalog []Task
+
+// Register adds a task to the global catalog. Called from task_*.go init()
+// functions.
+func Register(t Task) {
+	catalog = append(catalog, t)
+}
+
+// Catalog returns a copy of all registered tasks.
+func Catalog() []Task {
+	out := make([]Task, len(catalog))
+	copy(out, catalog)
+	return out
+}
+
+// FilterTasks returns the subset of catalog tasks whose names appear in
+// enabled. If enabled is nil/empty, all tasks are returned (default: all).
+func FilterTasks(enabled []string) []Task {
+	if len(enabled) == 0 {
+		return Catalog()
+	}
+	set := make(map[string]bool, len(enabled))
+	for _, n := range enabled {
+		set[n] = true
+	}
+	var out []Task
+	for _, t := range catalog {
+		if set[t.Name] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// SweepBranchName returns the branch Noctra creates for a sweep task on a
+// repo (e.g. "noctra/sweep-lint-cleanup"). This is distinct from the
+// ticket-driven "noctra/<identifier>" to avoid collisions with the
+// auto-iterate watcher.
+func SweepBranchName(taskSuffix string) string {
+	return "noctra/sweep-" + taskSuffix
+}
+
+// SweepIdentifier returns the worktree identifier for a sweep task on a
+// repo slug (e.g. "SWEEP-myrepo-lint-cleanup"). Used as the worktree
+// directory name and the key for the active-set dedup.
+func SweepIdentifier(repoSlug, taskSuffix string) string {
+	return "SWEEP-" + repoSlug + "-" + taskSuffix
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -1,0 +1,121 @@
+package sweep
+
+import (
+	"testing"
+)
+
+func TestCatalog_ContainsRegisteredTasks(t *testing.T) {
+	tasks := Catalog()
+	if len(tasks) < 2 {
+		t.Fatalf("expected at least 2 registered tasks, got %d", len(tasks))
+	}
+
+	// Verify the two core tasks exist.
+	names := map[string]bool{}
+	for _, task := range tasks {
+		names[task.Name] = true
+	}
+	for _, want := range []string{"lint-cleanup", "dead-code"} {
+		if !names[want] {
+			t.Errorf("missing expected task %q", want)
+		}
+	}
+}
+
+func TestCatalog_TaskFields(t *testing.T) {
+	for _, task := range Catalog() {
+		if task.Name == "" {
+			t.Error("task has empty Name")
+		}
+		if task.Description == "" {
+			t.Errorf("task %q has empty Description", task.Name)
+		}
+		if task.Cooldown <= 0 {
+			t.Errorf("task %q has non-positive Cooldown: %v", task.Name, task.Cooldown)
+		}
+		if task.BranchSuffix == "" {
+			t.Errorf("task %q has empty BranchSuffix", task.Name)
+		}
+		if task.CommitPrefix == "" {
+			t.Errorf("task %q has empty CommitPrefix", task.Name)
+		}
+		if task.Prompt == nil {
+			t.Errorf("task %q has nil Prompt function", task.Name)
+		}
+		// Verify prompt can be called without panic.
+		if task.Prompt != nil {
+			p := task.Prompt("/tmp/test-repo")
+			if p == "" {
+				t.Errorf("task %q produced empty prompt", task.Name)
+			}
+		}
+	}
+}
+
+func TestCatalog_UniqueBranchSuffixes(t *testing.T) {
+	seen := map[string]string{} // suffix → task name
+	for _, task := range Catalog() {
+		if prev, ok := seen[task.BranchSuffix]; ok {
+			t.Errorf("duplicate BranchSuffix %q: used by both %q and %q",
+				task.BranchSuffix, prev, task.Name)
+		}
+		seen[task.BranchSuffix] = task.Name
+	}
+}
+
+func TestFilterTasks_NilReturnsAll(t *testing.T) {
+	all := Catalog()
+	filtered := FilterTasks(nil)
+	if len(filtered) != len(all) {
+		t.Errorf("FilterTasks(nil): got %d tasks, want %d", len(filtered), len(all))
+	}
+}
+
+func TestFilterTasks_EmptyReturnsAll(t *testing.T) {
+	all := Catalog()
+	filtered := FilterTasks([]string{})
+	if len(filtered) != len(all) {
+		t.Errorf("FilterTasks([]): got %d tasks, want %d", len(filtered), len(all))
+	}
+}
+
+func TestFilterTasks_SelectsSubset(t *testing.T) {
+	filtered := FilterTasks([]string{"lint-cleanup"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(filtered))
+	}
+	if filtered[0].Name != "lint-cleanup" {
+		t.Errorf("expected lint-cleanup, got %q", filtered[0].Name)
+	}
+}
+
+func TestFilterTasks_UnknownNameIgnored(t *testing.T) {
+	filtered := FilterTasks([]string{"nonexistent"})
+	if len(filtered) != 0 {
+		t.Errorf("expected 0 tasks for unknown name, got %d", len(filtered))
+	}
+}
+
+func TestSweepBranchName(t *testing.T) {
+	tests := []struct {
+		suffix string
+		want   string
+	}{
+		{"lint-cleanup", "noctra/sweep-lint-cleanup"},
+		{"dead-code", "noctra/sweep-dead-code"},
+	}
+	for _, tt := range tests {
+		got := SweepBranchName(tt.suffix)
+		if got != tt.want {
+			t.Errorf("SweepBranchName(%q) = %q, want %q", tt.suffix, got, tt.want)
+		}
+	}
+}
+
+func TestSweepIdentifier(t *testing.T) {
+	got := SweepIdentifier("my-repo", "lint-cleanup")
+	want := "SWEEP-my-repo-lint-cleanup"
+	if got != want {
+		t.Errorf("SweepIdentifier = %q, want %q", got, want)
+	}
+}

--- a/internal/sweep/task_deadcode.go
+++ b/internal/sweep/task_deadcode.go
@@ -1,0 +1,52 @@
+package sweep
+
+import (
+	"fmt"
+	"time"
+)
+
+func init() {
+	Register(Task{
+		Name:         "dead-code",
+		Description:  "Detect and remove unused code, imports, and variables",
+		Cooldown:     14 * 24 * time.Hour, // biweekly
+		BranchSuffix: "dead-code",
+		CommitPrefix: "refactor",
+		PRLabel:      "maintenance",
+		Prompt: func(repoPath string) string {
+			return fmt.Sprintf(`You are performing autonomous maintenance on a codebase.
+
+## Task: Dead code removal
+
+Scan the codebase at %s for unused code, imports, variables, functions, types, and constants, then remove them.
+
+## Instructions:
+1. Read the project structure to understand the language(s) and build system in use.
+2. Look for:
+   - Unused imports
+   - Unused local variables and constants
+   - Unexported functions/types/methods that have no callers within the package
+   - Commented-out code blocks (not documentation comments — only dead code)
+3. Remove dead code carefully. If removal would break the public API (exported symbols), leave it.
+4. Run the test suite and the build to make sure nothing broke.
+5. Run the linter if available.
+
+## Rules:
+- Only remove genuinely dead/unused code. Do not refactor, rename, or restructure.
+- Do not remove code that is used via reflection, build tags, or generated code patterns.
+- Do not remove TODO/FIXME comments — only actual dead code.
+- Preserve all tests, even if they test removed code (the tests should fail, telling you the removal was wrong).
+- Follow existing project conventions and patterns exactly.
+- If there is no dead code to remove, say BLOCKED: No dead code found — nothing to clean up.
+
+## When done:
+Provide a brief summary of what was removed. Wrap the summary between these exact marker lines, each alone on its own line with nothing else:
+
+===NOCTRA SUMMARY===
+<your summary here>
+===END NOCTRA SUMMARY===
+
+RELEASE: none`, repoPath)
+		},
+	})
+}

--- a/internal/sweep/task_lint.go
+++ b/internal/sweep/task_lint.go
@@ -1,0 +1,48 @@
+package sweep
+
+import (
+	"fmt"
+	"time"
+)
+
+func init() {
+	Register(Task{
+		Name:         "lint-cleanup",
+		Description:  "Fix linter warnings and static analysis issues",
+		Cooldown:     7 * 24 * time.Hour, // weekly
+		BranchSuffix: "lint-cleanup",
+		CommitPrefix: "chore",
+		PRLabel:      "maintenance",
+		Prompt: func(repoPath string) string {
+			return fmt.Sprintf(`You are performing autonomous maintenance on a codebase.
+
+## Task: Lint cleanup
+
+Scan the codebase at %s for linter warnings and static analysis issues, then fix them.
+
+## Instructions:
+1. Read the project's linter configuration (e.g. .golangci.yml, .eslintrc, pyproject.toml) to understand what rules are enforced.
+2. Run the project's linter (e.g. golangci-lint run, eslint, ruff) and capture all warnings.
+3. Fix the warnings systematically — prefer minimal, targeted fixes over large refactors.
+4. Re-run the linter to confirm all issues are resolved.
+5. Run the test suite to make sure nothing broke.
+
+## Rules:
+- Only fix lint/static-analysis warnings. Do not refactor code or add features.
+- Do not change the linter configuration to suppress warnings.
+- If a warning is a false positive, add a targeted suppression comment with an explanation.
+- Follow existing project conventions and patterns exactly.
+- If there are no linter issues, say BLOCKED: No lint issues found — nothing to fix.
+- If you cannot determine how to run the linter, say BLOCKED: Cannot determine linter setup.
+
+## When done:
+Provide a brief summary of what was fixed. Wrap the summary between these exact marker lines, each alone on its own line with nothing else:
+
+===NOCTRA SUMMARY===
+<your summary here>
+===END NOCTRA SUMMARY===
+
+RELEASE: none`, repoPath)
+		},
+	})
+}


### PR DESCRIPTION
## ENG-222: Autonomous maintenance sweeps + task catalog (no ticket required)

**Linear:** https://linear.app/amazz/issue/ENG-222/autonomous-maintenance-sweeps-task-catalog-no-ticket-required

## What was implemented

Implemented autonomous maintenance sweeps (ENG-222) — Noctra's "night shift" feature that generates its own maintenance backlog and opens PRs without requiring Linear tickets.

**New package: `internal/sweep`**
- Task catalog framework with `Register()` at init time — extensible by adding `task_*.go` files
- `Scheduler` that tracks sweep timing, plans eligible (repo, task) jobs respecting per-task cooldowns, and records completed runs
- Two task types implemented:
  - `lint-cleanup` — fixes linter warnings and static analysis issues (7-day cooldown)
  - `dead-code` — detects and removes unused code, imports, and variables (14-day cooldown)
- Sweep branches use `noctra/sweep-<suffix>` prefix (e.g. `noctra/sweep-lint-cleanup`), distinct from ticket-driven `noctra/<identifier>` to avoid collisions
- Sweep PRs get a `maintenance` label for easy identification and bulk-closing

**Extended packages:**
- `internal/config` — Added `SWEEP_ENABLED`, `SWEEP_SCHEDULE`, `SWEEP_INTERVAL` (default 24h), `SWEEP_MAX_TASKS` (default 5), `SWEEP_TASKS` (CSV filter, default all)
- `internal/state` — Added `SweepState` type with `LastRunAt` timestamp, `SweepKey()`, `GetSweep()`, `UpdateSweep()` methods; coexists with existing PR state in the same JSON file
- `internal/repo` — Added `CreateWorktreeWithBranch()` for custom branch names, `SlugFromPath()`, `DefaultBranchOf()`
- `internal/pipeline` — Added `sweep.go` with `runSweepLoop()` (interval-based scheduler loop on shared WaitGroup), `sweepOnce()` (plans and dispatches jobs), `processSweepTask()` (full lifecycle: worktree → agent → commit/push → PR). Shares worker pool, budget caps, and active-set dedup with ticket-driven work. Sweep info shown in startup banner.
- `CLAUDE.md` — Documented sweep architecture, config, and added `internal/sweep` to the package map

**Key design decisions:**
- Fully opt-in (`SWEEP_ENABLED=false` by default) as required
- Budget-aware: skips sweeps when paused or exceeded, records usage from each task
- Cooldowns persisted in state file so they survive restarts
- State store opened once and shared between auto-iterate and sweep (avoids double-open)
- Sweep PRs tracked in state store for auto-iterate compatibility
- BLOCKED detection works naturally — agent says "BLOCKED: No lint issues found" when there's nothing to fix, recorded as a completed run (cooldown applies)

**Tests:**
- `internal/sweep`: 10 tests covering catalog registration, field validation, unique branch suffixes, FilterTasks, naming conventions
- `internal/sweep`: 6 scheduler tests covering DueIn/MarkSwept timing, Plan with max-tasks cap, cooldown respect, empty repos, RecordRun persistence
- `internal/config`: 2 tests for sweep defaults and .env parsing
- `internal/state`: 4 tests for SweepKey, GetSweep, UpdateSweep persistence, and coexistence with PR state

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*