### PR TITLE
ENG-232: Expand Telegram controls: /start, /move (state), global /pause + /resume

### DIFF
--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -609,6 +610,44 @@ func TestResolveStateIDs_SkipsTriggerWhenEmpty(t *testing.T) {
 	}
 	if ids.InReview != "s_review" {
 		t.Errorf("InReview: got %q, want %q", ids.InReview, "s_review")
+	}
+}
+
+func TestResolveStateID_ReturnsCompleteAvailableListOnSuccess(t *testing.T) {
+	client := fakeServer(t, struct {
+		authHeader string
+		query      string
+		variables  map[string]any
+	}{
+		authHeader: "test-key",
+		query:      "teams",
+	}, map[string]any{
+		"data": map[string]any{
+			"teams": map[string]any{
+				"nodes": []map[string]any{{
+					"key": "ENG",
+					"states": map[string]any{
+						"nodes": []map[string]any{
+							{"id": "s_backlog", "name": "Backlog"},
+							{"id": "s_next", "name": "Next"},
+							{"id": "s_review", "name": "In Review"},
+						},
+					},
+				}},
+			},
+		},
+	})
+
+	id, available, err := client.ResolveStateID(context.Background(), "ENG", "Backlog")
+	if err != nil {
+		t.Fatalf("ResolveStateID: %v", err)
+	}
+	if id != "s_backlog" {
+		t.Errorf("id: got %q, want %q", id, "s_backlog")
+	}
+	want := []string{"Backlog", "Next", "In Review"}
+	if !reflect.DeepEqual(available, want) {
+		t.Errorf("available: got %v, want %v", available, want)
 	}
 }
 

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -94,6 +94,8 @@ func (c *Client) ResolveStateID(ctx context.Context, teamKey, stateName string) 
 	available := make([]string, 0, len(states))
 	for _, s := range states {
 		available = append(available, s.Name)
+	}
+	for _, s := range states {
 		if s.Name == stateName {
 			return s.ID, available, nil
 		}

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -13,11 +13,47 @@ type StateIDs struct {
 	InReview string
 }
 
+// WorkflowStateID is a Linear workflow state with the fields Noctra needs for
+// resolving user-supplied state names.
+type WorkflowStateID struct {
+	ID   string
+	Name string
+}
+
 // ResolveStateIDs looks up the IDs for the trigger and in-review state names
 // within the team identified by teamKey (e.g. "ENG"). When triggerName is
 // empty (label-based trigger mode), the trigger-state lookup is skipped —
 // only the in-review state is required.
 func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inReviewName string) (StateIDs, error) {
+	states, err := c.TeamWorkflowStates(ctx, teamKey)
+	if err != nil {
+		return StateIDs{}, err
+	}
+
+	var ids StateIDs
+	available := make([]string, 0, len(states))
+	for _, s := range states {
+		available = append(available, s.Name)
+		switch s.Name {
+		case triggerName:
+			ids.Trigger = s.ID
+		case inReviewName:
+			ids.InReview = s.ID
+		}
+	}
+	if triggerName != "" && ids.Trigger == "" {
+		return StateIDs{}, fmt.Errorf("state %q not found in team %q (available: %v)",
+			triggerName, teamKey, available)
+	}
+	if ids.InReview == "" {
+		return StateIDs{}, fmt.Errorf("state %q not found in team %q (available: %v)",
+			inReviewName, teamKey, available)
+	}
+	return ids, nil
+}
+
+// TeamWorkflowStates returns every workflow state for the given Linear team.
+func (c *Client) TeamWorkflowStates(ctx context.Context, teamKey string) ([]WorkflowStateID, error) {
 	query := `{ teams { nodes { key states { nodes { id name } } } } }`
 
 	var resp struct {
@@ -25,50 +61,44 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 			Nodes []struct {
 				Key    string `json:"key"`
 				States struct {
-					Nodes []struct {
-						ID   string `json:"id"`
-						Name string `json:"name"`
-					} `json:"nodes"`
+					Nodes []WorkflowStateID `json:"nodes"`
 				} `json:"states"`
 			} `json:"nodes"`
 		} `json:"teams"`
 	}
 
 	if err := c.Do(ctx, query, nil, &resp); err != nil {
-		return StateIDs{}, err
+		return nil, err
 	}
 
 	for _, team := range resp.Teams.Nodes {
-		if team.Key != teamKey {
-			continue
+		if team.Key == teamKey {
+			return team.States.Nodes, nil
 		}
-		var ids StateIDs
-		var available []string
-		for _, s := range team.States.Nodes {
-			available = append(available, s.Name)
-			switch s.Name {
-			case triggerName:
-				ids.Trigger = s.ID
-			case inReviewName:
-				ids.InReview = s.ID
-			}
-		}
-		if triggerName != "" && ids.Trigger == "" {
-			return StateIDs{}, fmt.Errorf("state %q not found in team %q (available: %v)",
-				triggerName, teamKey, available)
-		}
-		if ids.InReview == "" {
-			return StateIDs{}, fmt.Errorf("state %q not found in team %q (available: %v)",
-				inReviewName, teamKey, available)
-		}
-		return ids, nil
 	}
 
 	var teams []string
 	for _, t := range resp.Teams.Nodes {
 		teams = append(teams, t.Key)
 	}
-	return StateIDs{}, fmt.Errorf("team %q not found (available: %v)", teamKey, teams)
+	return nil, fmt.Errorf("team %q not found (available: %v)", teamKey, teams)
+}
+
+// ResolveStateID looks up a single workflow state ID by exact name and returns
+// the available state names for a helpful caller-facing error.
+func (c *Client) ResolveStateID(ctx context.Context, teamKey, stateName string) (string, []string, error) {
+	states, err := c.TeamWorkflowStates(ctx, teamKey)
+	if err != nil {
+		return "", nil, err
+	}
+	available := make([]string, 0, len(states))
+	for _, s := range states {
+		available = append(available, s.Name)
+		if s.Name == stateName {
+			return s.ID, available, nil
+		}
+	}
+	return "", available, fmt.Errorf("state %q not found in team %q", stateName, teamKey)
 }
 
 // FetchTriggerIssues returns every issue currently in the named state, across
@@ -239,7 +269,7 @@ func (c *Client) Comment(ctx context.Context, issueID, body string) error {
 // to UUIDs for the `issue(id:)` argument.
 func (c *Client) GetIssueByIdentifier(ctx context.Context, identifier string) (Issue, error) {
 	query := `query($id: String!) {
-	  issue(id: $id) { id identifier title description url project { name } state { name type } assignee { name } labels { nodes { name } } }
+	  issue(id: $id) { id identifier title description url project { name } team { key } state { name type } assignee { name } labels { nodes { name } } }
 	}`
 
 	var resp struct {

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -61,6 +61,11 @@ type WorkflowState struct {
 	Type string `json:"type"`
 }
 
+// Team is the Linear team that owns an issue.
+type Team struct {
+	Key string `json:"key"`
+}
+
 // User is the subset of a Linear user Noctra surfaces (the assignee).
 type User struct {
 	Name string `json:"name"`
@@ -101,6 +106,7 @@ type Issue struct {
 	Description string            `json:"description"`
 	URL         string            `json:"url"`
 	Project     *Project          `json:"project,omitempty"`
+	Team        *Team             `json:"team,omitempty"`
 	State       *WorkflowState    `json:"state,omitempty"`
 	Assignee    *User             `json:"assignee,omitempty"`
 	Comments    CommentConnection `json:"comments,omitempty"`

--- a/internal/pipeline/commands.go
+++ b/internal/pipeline/commands.go
@@ -109,11 +109,19 @@ func (p *Pipeline) handleStart(ctx context.Context, args string) string {
 	if identifier == "" {
 		return "Usage: /start <ticket>\n\nExample: /start ENG-42"
 	}
+	if p.isActiveRun(identifier) {
+		return fmt.Sprintf("%s is already running; use /kill if you need to stop it first.",
+			notify.EscapeMarkdown(identifier))
+	}
 
 	issue, err := p.linear.GetIssueByIdentifier(ctx, identifier)
 	if err != nil {
 		return fmt.Sprintf("Could not find ticket %s: %s",
 			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+	if p.isActiveRun(issue.Identifier) {
+		return fmt.Sprintf("%s is already running; use /kill if you need to stop it first.",
+			notify.EscapeMarkdown(issue.Identifier))
 	}
 	if err := p.triggerIssue(ctx, issue); err != nil {
 		return fmt.Sprintf("Found %s but failed to start it: %s",
@@ -128,11 +136,19 @@ func (p *Pipeline) handleMove(ctx context.Context, args string) string {
 	if identifier == "" || stateName == "" {
 		return "Usage: /move <ticket> <state>\n\nExample: /move ENG-42 \"In Review\""
 	}
+	if p.isActiveRun(identifier) {
+		return fmt.Sprintf("%s is already running; use /kill if you need to stop it first.",
+			notify.EscapeMarkdown(identifier))
+	}
 
 	issue, err := p.linear.GetIssueByIdentifier(ctx, identifier)
 	if err != nil {
 		return fmt.Sprintf("Could not find ticket %s: %s",
 			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+	if p.isActiveRun(issue.Identifier) {
+		return fmt.Sprintf("%s is already running; use /kill if you need to stop it first.",
+			notify.EscapeMarkdown(issue.Identifier))
 	}
 	teamKey := p.cfg.LinearTeamKey
 	if issue.Team != nil && issue.Team.Key != "" {

--- a/internal/pipeline/commands.go
+++ b/internal/pipeline/commands.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ahmadAlMezaal/noctra/internal/budget"
+	"github.com/ahmadAlMezaal/noctra/internal/linear"
 	"github.com/ahmadAlMezaal/noctra/internal/notify"
 	"github.com/ahmadAlMezaal/noctra/internal/telegram"
 )
@@ -21,6 +22,10 @@ func (p *Pipeline) registerCommands(d *telegram.Dispatcher) {
 	d.Register("ticket", "Show a ticket's details (e.g. /ticket ENG-42)", p.handleTicket)
 	d.Register("search-tickets", "Search Linear tickets by text (e.g. /search-tickets auth login)", p.handleSearch)
 	d.Register("find", "Alias for /search-tickets", p.handleSearch)
+	d.Register("start", "Start a ticket on the next poll (e.g. /start ENG-42)", p.handleStart)
+	d.Register("move", "Move a ticket to a Linear state (e.g. /move ENG-42 \"In Review\")", p.handleMove)
+	d.Register("pause", "Pause new dispatches without killing active runs", p.handlePause)
+	d.Register("resume", "Resume new dispatches after /pause", p.handleResume)
 	d.Register("kill", "Kill a running ticket (e.g. /kill ENG-42)", p.handleKill)
 	d.Register("requeue", "Re-queue a ticket with context (e.g. /requeue ENG-42 use Auth0)", p.handleRequeue)
 }
@@ -38,6 +43,7 @@ func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
 	dispatches := p.totalDispatches
 	maxD := p.cfg.MaxDispatches
 	maxC := p.cfg.MaxConcurrent
+	operatorPaused := p.paused
 	p.mu.Unlock()
 
 	sort.Strings(active)
@@ -45,6 +51,11 @@ func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
 
 	var b strings.Builder
 	b.WriteString("*Noctra Status*\n\n")
+	if operatorPaused {
+		b.WriteString("⏸ *Dispatch:* paused by operator\n\n")
+	} else {
+		b.WriteString("▶️ *Dispatch:* running\n\n")
+	}
 
 	if len(active) == 0 {
 		fmt.Fprintf(&b, "*Active runs:* 0/%d (idle)\n", maxC)
@@ -89,6 +100,78 @@ func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
 	}
 
 	return b.String()
+}
+
+// handleStart moves a ticket into the configured trigger state/label so the
+// next poll dispatches it.
+func (p *Pipeline) handleStart(ctx context.Context, args string) string {
+	identifier := normalizeIdentifier(strings.TrimSpace(args), p.cfg.LinearTeamKey)
+	if identifier == "" {
+		return "Usage: /start <ticket>\n\nExample: /start ENG-42"
+	}
+
+	issue, err := p.linear.GetIssueByIdentifier(ctx, identifier)
+	if err != nil {
+		return fmt.Sprintf("Could not find ticket %s: %s",
+			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+	if err := p.triggerIssue(ctx, issue); err != nil {
+		return fmt.Sprintf("Found %s but failed to start it: %s",
+			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+	return fmt.Sprintf("✅ %s will start on the next poll", notify.EscapeMarkdown(identifier))
+}
+
+// handleMove moves a ticket to any workflow state in its owning Linear team.
+func (p *Pipeline) handleMove(ctx context.Context, args string) string {
+	identifier, stateName := parseMoveArgs(args, p.cfg.LinearTeamKey)
+	if identifier == "" || stateName == "" {
+		return "Usage: /move <ticket> <state>\n\nExample: /move ENG-42 \"In Review\""
+	}
+
+	issue, err := p.linear.GetIssueByIdentifier(ctx, identifier)
+	if err != nil {
+		return fmt.Sprintf("Could not find ticket %s: %s",
+			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+	teamKey := p.cfg.LinearTeamKey
+	if issue.Team != nil && issue.Team.Key != "" {
+		teamKey = issue.Team.Key
+	}
+
+	stateID, available, err := p.linear.ResolveStateID(ctx, teamKey, stateName)
+	if err != nil {
+		if len(available) > 0 {
+			return fmt.Sprintf("State %q not found for team %s.\n\nAvailable states: %s",
+				notify.EscapeMarkdown(stateName),
+				notify.EscapeMarkdown(teamKey),
+				notify.EscapeMarkdown(strings.Join(available, ", ")))
+		}
+		return fmt.Sprintf("Could not resolve state for %s: %s",
+			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+	if err := p.linear.SetState(ctx, issue.ID, stateID); err != nil {
+		return fmt.Sprintf("Found %s but failed to move it: %s",
+			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
+	}
+	return fmt.Sprintf("✅ %s moved to %s",
+		notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(stateName))
+}
+
+func (p *Pipeline) handlePause(_ context.Context, _ string) string {
+	alreadyPaused := p.PauseDispatch()
+	if alreadyPaused {
+		return "⏸ Dispatch is already paused. Active runs will continue."
+	}
+	return "⏸ Dispatch paused. Active runs will continue."
+}
+
+func (p *Pipeline) handleResume(_ context.Context, _ string) string {
+	wasPaused := p.ResumeDispatch()
+	if !wasPaused {
+		return "▶️ Dispatch is already running."
+	}
+	return "▶️ Dispatch resumed."
 }
 
 // handleTickets reports a project's Linear ticket counts grouped by workflow
@@ -259,17 +342,9 @@ func (p *Pipeline) handleRequeue(ctx context.Context, args string) string {
 		}
 	}
 
-	// Move to trigger state/label so the next poll picks it up.
-	if p.cfg.TriggerMode == "label" && p.labelID != "" {
-		if err := p.linear.AddLabel(ctx, issue.ID, p.labelID); err != nil {
-			return fmt.Sprintf("Commented on %s but failed to add trigger label: %s",
-				notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
-		}
-	} else if p.states.Trigger != "" {
-		if err := p.linear.SetState(ctx, issue.ID, p.states.Trigger); err != nil {
-			return fmt.Sprintf("Commented on %s but failed to move to trigger state: %s",
-				notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
-		}
+	if err := p.triggerIssue(ctx, issue); err != nil {
+		return fmt.Sprintf("Commented on %s but failed to requeue it: %s",
+			notify.EscapeMarkdown(identifier), notify.EscapeMarkdown(err.Error()))
 	}
 
 	reply := fmt.Sprintf("✅ %s requeued", notify.EscapeMarkdown(identifier))
@@ -281,6 +356,37 @@ func (p *Pipeline) handleRequeue(ctx context.Context, args string) string {
 		reply += fmt.Sprintf("\nContext added: %s", notify.EscapeMarkdown(display))
 	}
 	return reply
+}
+
+func (p *Pipeline) triggerIssue(ctx context.Context, issue linear.Issue) error {
+	if p.cfg.TriggerMode == "label" && p.labelID != "" {
+		return p.linear.AddLabel(ctx, issue.ID, p.labelID)
+	}
+	if p.states.Trigger != "" {
+		return p.linear.SetState(ctx, issue.ID, p.states.Trigger)
+	}
+	return fmt.Errorf("trigger is not resolved")
+}
+
+func parseMoveArgs(args, teamKey string) (string, string) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return "", ""
+	}
+	fields := strings.Fields(args)
+	if len(fields) == 0 {
+		return "", ""
+	}
+	identifier := normalizeIdentifier(fields[0], teamKey)
+	stateName := strings.TrimSpace(strings.TrimPrefix(args, fields[0]))
+	if len(stateName) >= 2 {
+		first := stateName[0]
+		last := stateName[len(stateName)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			stateName = strings.TrimSpace(stateName[1 : len(stateName)-1])
+		}
+	}
+	return identifier, stateName
 }
 
 // normalizeIdentifier converts user input to the standard "ENG-42" format.

--- a/internal/pipeline/commands_test.go
+++ b/internal/pipeline/commands_test.go
@@ -406,6 +406,293 @@ func TestHandleRequeue_NoContext(t *testing.T) {
 	}
 }
 
+func TestHandleStart_StateMode(t *testing.T) {
+	var stateChanged bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "issue(id:"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"id":         "uuid-42",
+						"identifier": "ENG-42",
+						"title":      "Fix login",
+						"team":       map[string]any{"key": "ENG"},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "issueUpdate"):
+			stateChanged = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issueUpdate": map[string]any{"success": true},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			LinearTeamKey: "ENG",
+			TriggerMode:   "state",
+		},
+		linear: client,
+		states: linear.StateIDs{Trigger: "state-trigger-id"},
+	}
+
+	reply := p.handleStart(context.Background(), "42")
+	if !strings.Contains(reply, "next poll") {
+		t.Errorf("expected next poll reply, got %q", reply)
+	}
+	if !stateChanged {
+		t.Error("expected trigger state to be set")
+	}
+}
+
+func TestHandleStart_LabelMode(t *testing.T) {
+	var addedLabel bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "issue(id:") && strings.Contains(req.Query, "labels"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"labels": map[string]any{
+							"nodes": []map[string]any{},
+						},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "issue(id:"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"id":         "uuid-42",
+						"identifier": "ENG-42",
+						"title":      "Fix login",
+						"team":       map[string]any{"key": "ENG"},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "issueUpdate"):
+			addedLabel = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issueUpdate": map[string]any{"success": true},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			LinearTeamKey: "ENG",
+			TriggerMode:   "label",
+			TriggerLabel:  "noctra",
+		},
+		linear:  client,
+		labelID: "label-id-123",
+	}
+
+	reply := p.handleStart(context.Background(), "ENG-42")
+	if !strings.Contains(reply, "next poll") {
+		t.Errorf("expected next poll reply, got %q", reply)
+	}
+	if !addedLabel {
+		t.Error("expected trigger label to be added")
+	}
+}
+
+func TestHandleMove(t *testing.T) {
+	var moved bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "issue(id:"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"id":         "uuid-42",
+						"identifier": "ENG-42",
+						"title":      "Fix login",
+						"team":       map[string]any{"key": "APP"},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "teams"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"teams": map[string]any{
+						"nodes": []map[string]any{{
+							"key": "APP",
+							"states": map[string]any{
+								"nodes": []map[string]any{
+									{"id": "s_backlog", "name": "Backlog"},
+									{"id": "s_review", "name": "In Review"},
+								},
+							},
+						}},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "issueUpdate"):
+			if req.Variables["stateId"] != "s_review" {
+				t.Errorf("stateId: got %v, want s_review", req.Variables["stateId"])
+			}
+			moved = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issueUpdate": map[string]any{"success": true},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg:    &config.Config{LinearTeamKey: "ENG"},
+		linear: client,
+	}
+
+	reply := p.handleMove(context.Background(), "ENG-42 \"In Review\"")
+	if !strings.Contains(reply, "moved to In Review") {
+		t.Errorf("expected moved reply, got %q", reply)
+	}
+	if !moved {
+		t.Error("expected issue state to be updated")
+	}
+}
+
+func TestHandleMove_UnknownStateListsAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "issue(id:"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"id":         "uuid-42",
+						"identifier": "ENG-42",
+						"title":      "Fix login",
+						"team":       map[string]any{"key": "ENG"},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "teams"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"teams": map[string]any{
+						"nodes": []map[string]any{{
+							"key": "ENG",
+							"states": map[string]any{
+								"nodes": []map[string]any{
+									{"id": "s_next", "name": "Next"},
+									{"id": "s_review", "name": "In Review"},
+								},
+							},
+						}},
+					},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg:    &config.Config{LinearTeamKey: "ENG"},
+		linear: client,
+	}
+
+	reply := p.handleMove(context.Background(), "ENG-42 Blocked")
+	if !strings.Contains(reply, "Available states") {
+		t.Errorf("expected available states in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "Next") || !strings.Contains(reply, "In Review") {
+		t.Errorf("expected state names in reply, got %q", reply)
+	}
+}
+
+func TestHandlePauseResumeAndStatus(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{
+			MaxConcurrent: 3,
+			MaxDispatches: 10,
+		},
+		budget:       budget.New(budget.Config{}),
+		active:       map[string]struct{}{"ENG-42": {}},
+		sessionStart: time.Now(),
+	}
+
+	if reply := p.handlePause(context.Background(), ""); !strings.Contains(reply, "paused") {
+		t.Errorf("expected paused reply, got %q", reply)
+	}
+	status := p.handleStatus(context.Background(), "")
+	if !strings.Contains(status, "paused by operator") {
+		t.Errorf("expected operator pause in status, got %q", status)
+	}
+	if !strings.Contains(status, "ENG-42") {
+		t.Errorf("active run should still be reported, got %q", status)
+	}
+	if reply := p.handleResume(context.Background(), ""); !strings.Contains(reply, "resumed") {
+		t.Errorf("expected resumed reply, got %q", reply)
+	}
+	status = p.handleStatus(context.Background(), "")
+	if !strings.Contains(status, "running") {
+		t.Errorf("expected running status, got %q", status)
+	}
+}
+
+func TestParseMoveArgs(t *testing.T) {
+	id, state := parseMoveArgs(`42 "In Review"`, "ENG")
+	if id != "ENG-42" || state != "In Review" {
+		t.Fatalf("parseMoveArgs quoted: got %q, %q", id, state)
+	}
+	id, state = parseMoveArgs("eng-42 Blocked", "ENG")
+	if id != "ENG-42" || state != "Blocked" {
+		t.Fatalf("parseMoveArgs bare: got %q, %q", id, state)
+	}
+}
+
 // ticketCountServer returns a Linear server that answers the ProjectIssueCounts
 // query with two states (Backlog x2, Next x1) and records the requested project.
 func ticketCountServer(t *testing.T, gotProject *string) *httptest.Server {

--- a/internal/pipeline/commands_test.go
+++ b/internal/pipeline/commands_test.go
@@ -525,6 +525,75 @@ func TestHandleStart_LabelMode(t *testing.T) {
 	}
 }
 
+func TestHandleStart_ActiveTicketBlocked(t *testing.T) {
+	p := &Pipeline{
+		cfg:    &config.Config{LinearTeamKey: "ENG"},
+		active: map[string]struct{}{"ENG-42": {}},
+	}
+
+	reply := p.handleStart(context.Background(), "42")
+	if !strings.Contains(reply, "already running") {
+		t.Errorf("expected active-ticket reply, got %q", reply)
+	}
+}
+
+func TestHandleStart_BlocksIfTicketBecomesActiveAfterLookup(t *testing.T) {
+	var stateChanged bool
+	p := &Pipeline{
+		cfg: &config.Config{
+			LinearTeamKey: "ENG",
+			TriggerMode:   "state",
+		},
+		active: map[string]struct{}{},
+		states: linear.StateIDs{Trigger: "state-trigger-id"},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "issue(id:"):
+			p.mu.Lock()
+			p.active["ENG-42"] = struct{}{}
+			p.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issue": map[string]any{
+						"id":         "uuid-42",
+						"identifier": "ENG-42",
+						"title":      "Fix login",
+						"team":       map[string]any{"key": "ENG"},
+					},
+				},
+			})
+		case strings.Contains(req.Query, "issueUpdate"):
+			stateChanged = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"issueUpdate": map[string]any{"success": true},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+	p.linear = client
+
+	reply := p.handleStart(context.Background(), "ENG-42")
+	if !strings.Contains(reply, "already running") {
+		t.Errorf("expected active-ticket reply, got %q", reply)
+	}
+	if stateChanged {
+		t.Error("expected active ticket not to be moved to trigger state")
+	}
+}
+
 func TestHandleMove(t *testing.T) {
 	var moved bool
 
@@ -592,6 +661,18 @@ func TestHandleMove(t *testing.T) {
 	}
 	if !moved {
 		t.Error("expected issue state to be updated")
+	}
+}
+
+func TestHandleMove_ActiveTicketBlocked(t *testing.T) {
+	p := &Pipeline{
+		cfg:    &config.Config{LinearTeamKey: "ENG"},
+		active: map[string]struct{}{"ENG-42": {}},
+	}
+
+	reply := p.handleMove(context.Background(), "ENG-42 \"In Review\"")
+	if !strings.Contains(reply, "already running") {
+		t.Errorf("expected active-ticket reply, got %q", reply)
 	}
 }
 

--- a/internal/pipeline/dispatch_test.go
+++ b/internal/pipeline/dispatch_test.go
@@ -1,9 +1,17 @@
 package pipeline
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/ahmadAlMezaal/noctra/internal/config"
+	"github.com/ahmadAlMezaal/noctra/internal/linear"
 	"github.com/ahmadAlMezaal/noctra/internal/repo"
 )
 
@@ -71,5 +79,46 @@ func TestBumpFailed_BoundsRetries(t *testing.T) {
 	}
 	if p.failCount != 5 {
 		t.Fatalf("failCount: got %d, want 5", p.failCount)
+	}
+}
+
+func TestPollOnce_OperatorPauseSkipsFetch(t *testing.T) {
+	var fetched bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"teams": map[string]any{"nodes": []map[string]any{}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := linear.New("test-key")
+	client.Endpoint = srv.URL
+
+	p := &Pipeline{
+		cfg: &config.Config{
+			MaxConcurrent: 1,
+			MaxDispatches: 10,
+			TriggerMode:   "state",
+			TriggerState:  "Next",
+		},
+		linear:         client,
+		active:         map[string]struct{}{},
+		cancels:        map[string]context.CancelFunc{},
+		failedAttempts: map[string]int{},
+		skipped:        map[string]struct{}{},
+		sessionStart:   time.Now(),
+		paused:         true,
+	}
+
+	var wg sync.WaitGroup
+	p.pollOnce(context.Background(), &wg)
+	wg.Wait()
+
+	if fetched {
+		t.Fatal("pollOnce fetched tickets while operator pause was active")
 	}
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -64,6 +64,7 @@ type Pipeline struct {
 	successCount      int
 	failCount         int
 	rateLimitDetected bool // only used when RateLimitStrategy=shutdown
+	paused            bool // operator pause via Telegram; active runs continue
 }
 
 // New constructs a Pipeline. It does not perform any I/O — call Run to start.
@@ -255,6 +256,11 @@ func (p *Pipeline) Run(ctx context.Context) error {
 
 func (p *Pipeline) pollOnce(ctx context.Context, wg *sync.WaitGroup) {
 	p.mu.Lock()
+	if p.paused {
+		p.mu.Unlock()
+		slog.Debug("⏸ dispatching paused by operator")
+		return
+	}
 	inFlight := len(p.active)
 	available := p.cfg.MaxConcurrent - inFlight
 	dispatched := p.totalDispatches
@@ -376,6 +382,32 @@ func (p *Pipeline) KillRun(identifier string) error {
 	p.killed[identifier] = struct{}{}
 	cancel()
 	return nil
+}
+
+// PauseDispatch stops future poll dispatches while letting active runs drain.
+// It returns true if dispatching was already paused.
+func (p *Pipeline) PauseDispatch() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	alreadyPaused := p.paused
+	p.paused = true
+	return alreadyPaused
+}
+
+// ResumeDispatch re-enables future poll dispatches. It returns true if
+// dispatching had been paused.
+func (p *Pipeline) ResumeDispatch() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	wasPaused := p.paused
+	p.paused = false
+	return wasPaused
+}
+
+func (p *Pipeline) dispatchPaused() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.paused
 }
 
 func (p *Pipeline) bumpFailed(id string) int {
@@ -512,6 +544,11 @@ func (p *Pipeline) banner() {
 	fmt.Printf("   Agent timeout:  %s\n", p.cfg.AgentTimeout)
 	fmt.Printf("   Max retries:    %d per ticket\n", p.cfg.MaxRetries)
 	fmt.Printf("   Max dispatches: %d per session\n", p.cfg.MaxDispatches)
+	if p.dispatchPaused() {
+		fmt.Printf("   Dispatch:       Paused by operator\n")
+	} else {
+		fmt.Printf("   Dispatch:       Running\n")
+	}
 
 	// Budget caps (ENG-217).
 	budgetMode := "Unlimited"

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -367,6 +367,13 @@ func (p *Pipeline) isKilled(id string) bool {
 	return ok
 }
 
+func (p *Pipeline) isActiveRun(identifier string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, ok := p.active[identifier]
+	return ok
+}
+
 // KillRun cancels the context for an in-flight ticket, terminating any
 // running Claude process. The goroutine handles worktree cleanup on return.
 func (p *Pipeline) KillRun(identifier string) error {

--- a/internal/telegram/listener_test.go
+++ b/internal/telegram/listener_test.go
@@ -34,6 +34,33 @@ func TestListener_AuthRejectsWrongChat(t *testing.T) {
 	}
 }
 
+func TestListener_AuthRejectsStateChangingCommands(t *testing.T) {
+	for _, cmd := range []string{"/start ENG-42", "/move ENG-42 Done", "/pause", "/resume"} {
+		t.Run(cmd, func(t *testing.T) {
+			l := New("tok", "12345")
+			var dispatched bool
+			for _, name := range []string{"start", "move", "pause", "resume"} {
+				l.dispatcher.Register(name, name, func(_ context.Context, _ string) string {
+					dispatched = true
+					return ""
+				})
+			}
+
+			l.handleUpdate(context.Background(), Update{
+				UpdateID: 1,
+				Message: &Message{
+					Text: cmd,
+					Chat: Chat{ID: 99999},
+					From: &User{Username: "attacker"},
+				},
+			})
+			if dispatched {
+				t.Fatalf("%s handler should not be called for unauthorised chat", cmd)
+			}
+		})
+	}
+}
+
 func TestListener_AuthAcceptsCorrectChat(t *testing.T) {
 	l := New("tok", "12345")
 	var dispatched bool


### PR DESCRIPTION
## ENG-232: Expand Telegram controls: /start, /move (state), global /pause + /resume

**Linear:** https://linear.app/amazz/issue/ENG-232/expand-telegram-controls-start-move-state-global-pause-resume

## What was implemented

Implemented Telegram `/start`, `/move`, `/pause`, and `/resume`. `/start` reuses the trigger state/label path, `/move` resolves workflow states against the ticket’s owning Linear team and reports available states on invalid input, and global operator pause now gates `pollOnce` without cancelling active runs. `/status` and the startup banner report dispatch state.

Added handler and gate tests, plus authorization regression coverage for the new Telegram commands. Verified with `/usr/local/go/bin/go test ./...` and `/usr/local/go/bin/go vet ./...`; `golangci-lint` was not installed locally.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using OpenAI Codex*