### PR TITLE
ENG-234: Sweep PR identity is inconsistent with the auto-iterate watcher (cross-repo collision)

### DIFF
--- a/internal/pipeline/iterate_test.go
+++ b/internal/pipeline/iterate_test.go
@@ -100,7 +100,7 @@ func TestIdentifierFromBranch(t *testing.T) {
 }
 
 func TestIdentifierFromBranch_SweepRoundTrip(t *testing.T) {
-	repoSlug := "Repo-A"
+	repoSlug := "Owner/Repo-A"
 	taskSuffix := "lint-cleanup"
 
 	got := identifierFromBranch(sweep.SweepBranchName(repoSlug, taskSuffix))

--- a/internal/pipeline/iterate_test.go
+++ b/internal/pipeline/iterate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ahmadAlMezaal/noctra/internal/sweep"
 	"github.com/ahmadAlMezaal/noctra/internal/watch"
 )
 
@@ -85,6 +86,7 @@ func TestIdentifierFromBranch(t *testing.T) {
 	}{
 		{"noctra/eng-42", "ENG-42"},
 		{"noctra/eng-181", "ENG-181"},
+		{"noctra/sweep-repo-a-lint-cleanup", "SWEEP-REPO-A-LINT-CLEANUP"},
 		{"main", ""},
 		{"feature/something", ""},
 		{"noctra/", ""},
@@ -94,5 +96,16 @@ func TestIdentifierFromBranch(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("identifierFromBranch(%q) = %q, want %q", tt.branch, got, tt.want)
 		}
+	}
+}
+
+func TestIdentifierFromBranch_SweepRoundTrip(t *testing.T) {
+	repoSlug := "Repo-A"
+	taskSuffix := "lint-cleanup"
+
+	got := identifierFromBranch(sweep.SweepBranchName(repoSlug, taskSuffix))
+	want := sweep.SweepIdentifier(repoSlug, taskSuffix)
+	if got != want {
+		t.Errorf("sweep branch identifier = %q, want %q", got, want)
 	}
 }

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -142,7 +141,7 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 			notify.EscapeMarkdown(job.Task.Description)))
 	}
 
-	branch := sweep.SweepBranchName(job.Task.BranchSuffix)
+	branch := sweep.SweepBranchName(job.RepoSlug, job.Task.BranchSuffix)
 	wt, err := repo.CreateWorktreeWithBranch(ctx, p.cfg.WorktreeBase, identifier, job.RepoPath, job.MainBranch, branch)
 	if err != nil {
 		logger.Error("worktree creation failed", "err", err)
@@ -313,7 +312,7 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	// Track in state store for auto-iterate (if enabled).
 	if p.store != nil {
 		if err := p.store.Update(prURL, func(r *state.PRState) {
-			r.TicketID = strings.ToUpper(identifier)
+			r.TicketID = identifier
 			r.AgentBackend = backend.Name()
 		}); err != nil {
 			logger.Warn("could not persist sweep PR in state", "err", err)

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -81,5 +81,9 @@ func SweepBranchName(repoSlug, taskSuffix string) string {
 // repo slug (e.g. "SWEEP-MYREPO-LINT-CLEANUP"). Used as the worktree
 // directory name and the key for the active-set dedup.
 func SweepIdentifier(repoSlug, taskSuffix string) string {
-	return strings.ToUpper("SWEEP-" + repoSlug + "-" + taskSuffix)
+	return strings.ToUpper("SWEEP-" + sanitizeRepoSlug(repoSlug) + "-" + taskSuffix)
+}
+
+func sanitizeRepoSlug(repoSlug string) string {
+	return strings.ReplaceAll(repoSlug, "/", "-")
 }

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -8,6 +8,7 @@
 package sweep
 
 import (
+	"strings"
 	"time"
 )
 
@@ -23,8 +24,9 @@ type Task struct {
 	// Prompt returns the full agent prompt for this task. repoPath is the
 	// local checkout path so prompts can reference it.
 	Prompt func(repoPath string) string
-	// BranchSuffix is appended to the branch name (e.g. "lint-cleanup" →
-	// "noctra/sweep-lint-cleanup"). Must be unique across tasks.
+	// BranchSuffix is appended to the sweep branch identity (e.g.
+	// "lint-cleanup" → "noctra/sweep-<repo>-lint-cleanup"). Must be unique
+	// across tasks.
 	BranchSuffix string
 	// CommitPrefix is the conventional-commit prefix (e.g. "chore", "fix").
 	CommitPrefix string
@@ -68,16 +70,16 @@ func FilterTasks(enabled []string) []Task {
 }
 
 // SweepBranchName returns the branch Noctra creates for a sweep task on a
-// repo (e.g. "noctra/sweep-lint-cleanup"). This is distinct from the
-// ticket-driven "noctra/<identifier>" to avoid collisions with the
-// auto-iterate watcher.
-func SweepBranchName(taskSuffix string) string {
-	return "noctra/sweep-" + taskSuffix
+// repo (e.g. "noctra/sweep-myrepo-lint-cleanup"). This is distinct from the
+// ticket-driven "noctra/<identifier>" and includes the repo slug so the
+// auto-iterate watcher can reconstruct the same identifier.
+func SweepBranchName(repoSlug, taskSuffix string) string {
+	return "noctra/" + strings.ToLower(SweepIdentifier(repoSlug, taskSuffix))
 }
 
 // SweepIdentifier returns the worktree identifier for a sweep task on a
-// repo slug (e.g. "SWEEP-myrepo-lint-cleanup"). Used as the worktree
+// repo slug (e.g. "SWEEP-MYREPO-LINT-CLEANUP"). Used as the worktree
 // directory name and the key for the active-set dedup.
 func SweepIdentifier(repoSlug, taskSuffix string) string {
-	return "SWEEP-" + repoSlug + "-" + taskSuffix
+	return strings.ToUpper("SWEEP-" + repoSlug + "-" + taskSuffix)
 }

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -98,23 +98,24 @@ func TestFilterTasks_UnknownNameIgnored(t *testing.T) {
 
 func TestSweepBranchName(t *testing.T) {
 	tests := []struct {
-		suffix string
-		want   string
+		repoSlug string
+		suffix   string
+		want     string
 	}{
-		{"lint-cleanup", "noctra/sweep-lint-cleanup"},
-		{"dead-code", "noctra/sweep-dead-code"},
+		{"repo-a", "lint-cleanup", "noctra/sweep-repo-a-lint-cleanup"},
+		{"Repo-B", "dead-code", "noctra/sweep-repo-b-dead-code"},
 	}
 	for _, tt := range tests {
-		got := SweepBranchName(tt.suffix)
+		got := SweepBranchName(tt.repoSlug, tt.suffix)
 		if got != tt.want {
-			t.Errorf("SweepBranchName(%q) = %q, want %q", tt.suffix, got, tt.want)
+			t.Errorf("SweepBranchName(%q, %q) = %q, want %q", tt.repoSlug, tt.suffix, got, tt.want)
 		}
 	}
 }
 
 func TestSweepIdentifier(t *testing.T) {
 	got := SweepIdentifier("my-repo", "lint-cleanup")
-	want := "SWEEP-my-repo-lint-cleanup"
+	want := "SWEEP-MY-REPO-LINT-CLEANUP"
 	if got != want {
 		t.Errorf("SweepIdentifier = %q, want %q", got, want)
 	}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -104,6 +104,7 @@ func TestSweepBranchName(t *testing.T) {
 	}{
 		{"repo-a", "lint-cleanup", "noctra/sweep-repo-a-lint-cleanup"},
 		{"Repo-B", "dead-code", "noctra/sweep-repo-b-dead-code"},
+		{"owner/repo-c", "lint-cleanup", "noctra/sweep-owner-repo-c-lint-cleanup"},
 	}
 	for _, tt := range tests {
 		got := SweepBranchName(tt.repoSlug, tt.suffix)
@@ -114,9 +115,18 @@ func TestSweepBranchName(t *testing.T) {
 }
 
 func TestSweepIdentifier(t *testing.T) {
-	got := SweepIdentifier("my-repo", "lint-cleanup")
-	want := "SWEEP-MY-REPO-LINT-CLEANUP"
-	if got != want {
-		t.Errorf("SweepIdentifier = %q, want %q", got, want)
+	tests := []struct {
+		repoSlug string
+		suffix   string
+		want     string
+	}{
+		{"my-repo", "lint-cleanup", "SWEEP-MY-REPO-LINT-CLEANUP"},
+		{"owner/my-repo", "lint-cleanup", "SWEEP-OWNER-MY-REPO-LINT-CLEANUP"},
+	}
+	for _, tt := range tests {
+		got := SweepIdentifier(tt.repoSlug, tt.suffix)
+		if got != tt.want {
+			t.Errorf("SweepIdentifier(%q, %q) = %q, want %q", tt.repoSlug, tt.suffix, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## ENG-234: Sweep PR identity is inconsistent with the auto-iterate watcher (cross-repo collision)

**Linear:** https://linear.app/amazz/issue/ENG-234/sweep-pr-identity-is-inconsistent-with-the-auto-iterate-watcher-cross

## What was implemented

Implemented ENG-234 by making sweep identity canonical and repo-scoped: `SweepIdentifier` now returns uppercase `SWEEP-<REPO-SLUG>-<TASK-SUFFIX>`, and `SweepBranchName` now encodes the repo slug as `noctra/sweep-<slug>-<suffix>`. Sweep PR state now stores the canonical identifier directly, so dispatch, branch-derived watcher identity, logs, active-set keys, and resume behavior line up.

Added tests for the new branch format and a watcher round-trip assertion: `identifierFromBranch(SweepBranchName(...)) == SweepIdentifier(...)`.

Validation passed:
- `/usr/local/go/bin/go test ./...`
- `PATH=/usr/local/go/bin:$PATH /home/ahmadalmezaal/go/bin/golangci-lint run`

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using OpenAI Codex*