### PR TITLE
sweep: wire SWEEP_SCHEDULE cron support + sweep step in setup wizard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,6 +196,20 @@ PR_POLL_INTERVAL=120
 # Example: gemini-code-assist,coderabbit
 TRUSTED_REVIEWERS=
 
+# ── Autonomous maintenance sweeps (optional, off by default) ──
+# Runs maintenance tasks across cloned repos on a schedule and opens PRs.
+SWEEP_ENABLED=false
+# Comma-separated subset of tasks; empty = all registered tasks in
+# internal/sweep (e.g. lint-cleanup, dead-code).
+SWEEP_TASKS=
+# When to run: a cron expression (e.g. "0 0 * * *" = every day at midnight).
+# Empty = use the fixed SWEEP_INTERVAL below instead.
+SWEEP_SCHEDULE=
+# Fallback fixed cadence in seconds when SWEEP_SCHEDULE is empty (86400 = 24h).
+SWEEP_INTERVAL=86400
+# Max tasks dispatched per sweep cycle.
+SWEEP_MAX_TASKS=5
+
 # Where Noctra persists PR cursors, sweep cooldowns, OAuth, and history.
 # Defaults to $HOME/.noctra/state.db.
 # STATE_DB=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ PR poll loop → github.ListNoctraPRs → github.GetPR (comments+reviews+statusC
 When `SWEEP_ENABLED=true`, a **third** loop runs alongside the Linear and PR-watcher loops:
 
 ```
-sweep loop → scheduler.DueIn (interval-based) → scheduler.Plan (all repos × task catalog)
+sweep loop → scheduler.DueIn (cron SWEEP_SCHEDULE or fixed SWEEP_INTERVAL) → scheduler.Plan (all repos × task catalog)
   → filter by cooldown (per-repo, per-task, from state store)
   → pipeline.processSweepTask (bounded, shares the worker pool + active-set)
   → repo.CreateWorktreeWithBranch → agent.Run (task-specific prompt) → commit/push → gh pr create
@@ -65,7 +65,8 @@ sweep loop → scheduler.DueIn (interval-based) → scheduler.Plan (all repos ×
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `SWEEP_ENABLED` | `false` | Enable the sweep scheduler |
-| `SWEEP_INTERVAL` | `86400` (24h) | Seconds between sweep cycles |
+| `SWEEP_SCHEDULE` | (empty) | Cron expression for when to sweep (e.g. `0 0 * * *` = daily midnight); empty = use `SWEEP_INTERVAL`. Parsed by `sweep.ParseCron` (zero-dep, standard 5-field); invalid → warn + fall back to interval |
+| `SWEEP_INTERVAL` | `86400` (24h) | Seconds between sweep cycles (fallback when no cron). Interval mode fires immediately on startup; cron mode waits for the next matching time |
 | `SWEEP_MAX_TASKS` | `5` | Max tasks per sweep run |
 | `SWEEP_TASKS` | (all) | Comma-separated task names to enable (e.g. `lint-cleanup,dead-code`) |
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -138,7 +138,17 @@ func New(cfg *config.Config) *Pipeline {
 		if len(tasks) == 0 {
 			slog.Warn("sweep: no tasks enabled; feature disabled")
 		} else {
-			p.sweeper = sweep.NewScheduler(store, p.resolver, tasks, cfg.SweepInterval, cfg.SweepMaxTasks)
+			var schedule *sweep.CronSchedule
+			if cfg.SweepSchedule != "" {
+				parsed, err := sweep.ParseCron(cfg.SweepSchedule)
+				if err != nil {
+					slog.Warn("sweep: invalid SWEEP_SCHEDULE; using interval instead",
+						"schedule", cfg.SweepSchedule, "err", err)
+				} else {
+					schedule = parsed
+				}
+			}
+			p.sweeper = sweep.NewScheduler(store, p.resolver, tasks, cfg.SweepInterval, cfg.SweepMaxTasks, schedule)
 		}
 	}
 
@@ -571,8 +581,11 @@ func (p *Pipeline) banner() {
 	}
 	sweepMode := "Disabled"
 	if p.sweeper != nil {
-		sweepMode = fmt.Sprintf("On (interval %s, max %d tasks)",
-			p.cfg.SweepInterval, p.cfg.SweepMaxTasks)
+		cadence := fmt.Sprintf("interval %s", p.cfg.SweepInterval)
+		if p.cfg.SweepSchedule != "" {
+			cadence = fmt.Sprintf("cron %q", p.cfg.SweepSchedule)
+		}
+		sweepMode = fmt.Sprintf("On (%s, max %d tasks)", cadence, p.cfg.SweepMaxTasks)
 	}
 
 	// Repos are routed per-ticket from each Linear project's "Repo:" directive

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -141,10 +141,14 @@ func New(cfg *config.Config) *Pipeline {
 			var schedule *sweep.CronSchedule
 			if cfg.SweepSchedule != "" {
 				parsed, err := sweep.ParseCron(cfg.SweepSchedule)
-				if err != nil {
+				switch {
+				case err != nil:
 					slog.Warn("sweep: invalid SWEEP_SCHEDULE; using interval instead",
 						"schedule", cfg.SweepSchedule, "err", err)
-				} else {
+				case parsed.Next(time.Now()).IsZero():
+					slog.Warn("sweep: SWEEP_SCHEDULE never matches a real date; using interval instead",
+						"schedule", cfg.SweepSchedule)
+				default:
 					schedule = parsed
 				}
 			}

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/config"
 	"github.com/ahmadAlMezaal/noctra/internal/linear"
 	"github.com/ahmadAlMezaal/noctra/internal/notify"
+	"github.com/ahmadAlMezaal/noctra/internal/sweep"
 )
 
 // Run drives the wizard. It writes scriptDir/.env.
@@ -168,6 +169,8 @@ func Run(scriptDir string) error {
 	// ── Optional: Auto-iterate on PR feedback ─────────────────────────────────
 	autoIterate, maxIter, prPoll, trusted := w.collectAutoIterate(existingEnv)
 
+	sweepEnabled, sweepTasks, sweepSchedule, sweepMaxTasks := w.collectSweep(existingEnv)
+
 	// ── Optional: Gemini review gate ───────────────────────────────────────────
 	geminiKey := ""
 	geminiMode := existingEnv["GEMINI_MODE"]
@@ -267,6 +270,20 @@ func Run(scriptDir string) error {
 			fmt.Printf("  TRUSTED_REVIEWERS     = %s\n", trusted)
 		}
 	}
+	fmt.Printf("  SWEEP_ENABLED         = %s\n", sweepEnabled)
+	if sweepEnabled == "true" {
+		if sweepTasks == "" {
+			fmt.Printf("  SWEEP_TASKS           = (all)\n")
+		} else {
+			fmt.Printf("  SWEEP_TASKS           = %s\n", sweepTasks)
+		}
+		if sweepSchedule == "" {
+			fmt.Printf("  SWEEP_SCHEDULE        = (interval %ds)\n", int(config.DefaultSweepInterval/time.Second))
+		} else {
+			fmt.Printf("  SWEEP_SCHEDULE        = %s\n", sweepSchedule)
+		}
+		fmt.Printf("  SWEEP_MAX_TASKS       = %d\n", sweepMaxTasks)
+	}
 	fmt.Printf("  TELEGRAM_ENABLED      = %s\n", tgEnabled)
 	if tgEnabled == "true" {
 		fmt.Printf("  TELEGRAM_BOT_TOKEN    = %s\n", mask(tgToken))
@@ -311,6 +328,10 @@ func Run(scriptDir string) error {
 		maxIter:           strconv.Itoa(maxIter),
 		prPoll:            strconv.Itoa(prPoll),
 		trusted:           trusted,
+		sweepEnabled:      sweepEnabled,
+		sweepTasks:        sweepTasks,
+		sweepSchedule:     sweepSchedule,
+		sweepMaxTasks:     strconv.Itoa(sweepMaxTasks),
 	}
 
 	// Merge into existing .env when the file already exists — this preserves
@@ -656,6 +677,44 @@ func (w *wizard) collectAutoIterate(existing map[string]string) (autoIterate str
 	return autoIterate, maxIter, prPoll, trusted
 }
 
+func (w *wizard) collectSweep(existing map[string]string) (enabled, tasks, schedule string, maxTasks int) {
+	enabled = "false"
+	maxTasks = config.DefaultSweepMaxTasks
+
+	wasEnabled := strings.EqualFold(existing["SWEEP_ENABLED"], "true")
+	prompt := "Enable autonomous maintenance sweeps (lint, deps, docs, tests, ...)?"
+	if wasEnabled {
+		prompt = "Maintenance sweeps are currently on. Keep them?"
+	}
+	if !w.confirm(prompt) {
+		return enabled, "", "", maxTasks
+	}
+	enabled = "true"
+
+	fmt.Println("Available tasks:")
+	for _, t := range sweep.Catalog() {
+		fmt.Printf("  - %-14s %s\n", t.Name, t.Description)
+	}
+	fmt.Println("Enter a comma-separated subset, or leave blank to run all of them.")
+	tasks = w.askEx("Sweep tasks", askOpts{existing: existing["SWEEP_TASKS"]})
+
+	fmt.Println("Schedule: a cron expression (e.g. \"0 0 * * *\" = every day at midnight),")
+	fmt.Println("or leave blank to use a fixed interval instead.")
+	schedule = w.askEx("Sweep schedule (cron)", askOpts{existing: existing["SWEEP_SCHEDULE"]})
+	if schedule != "" {
+		if _, err := sweep.ParseCron(schedule); err != nil {
+			fmt.Printf("  ⚠️  %v — saved anyway; Noctra will fall back to the interval if it can't parse it.\n", err)
+		}
+	}
+
+	maxTasks = w.askInt("Max sweep tasks per cycle", existing["SWEEP_MAX_TASKS"], config.DefaultSweepMaxTasks, 1)
+
+	fmt.Println("ℹ️  To add your own task, create internal/sweep/task_<name>.go that calls")
+	fmt.Println("   Register(Task{...}) — copy task_lint.go as a starting point.")
+
+	return enabled, tasks, schedule, maxTasks
+}
+
 // ── Helpers (file I/O, validators, formatting) ──────────────────────────────
 
 func pingLinear(apiKey string) (string, error) {
@@ -729,6 +788,8 @@ type envValues struct {
 	geminiMode, geminiKey                        string
 	tgEnabled, tgToken, tgChat, tgVerbose        string
 	autoIterate, maxIter, prPoll, trusted        string
+	sweepEnabled, sweepTasks, sweepSchedule      string
+	sweepMaxTasks                                string
 }
 
 // toMap returns the wizard-managed keys as a flat map suitable for
@@ -759,6 +820,10 @@ func (v envValues) toMap() map[string]string {
 		"MAX_PR_ITERATIONS":     v.maxIter,
 		"PR_POLL_INTERVAL":      v.prPoll,
 		"TRUSTED_REVIEWERS":     v.trusted,
+		"SWEEP_ENABLED":         v.sweepEnabled,
+		"SWEEP_TASKS":           v.sweepTasks,
+		"SWEEP_SCHEDULE":        v.sweepSchedule,
+		"SWEEP_MAX_TASKS":       v.sweepMaxTasks,
 	}
 
 	// Trigger-mode-dependent keys.
@@ -867,6 +932,16 @@ PR_POLL_INTERVAL="%s"
 # Comma-separated GitHub logins / bot names whose feedback Noctra will
 # act on. Humans are always trusted; empty = humans only (bots ignored).
 TRUSTED_REVIEWERS="%s"
+
+# Autonomous maintenance sweeps (ENG-222). Opt-in. Runs maintenance tasks
+# (lint, deps, docs, tests, modernize, bug-scan) across cloned repos.
+# SWEEP_TASKS: comma-separated subset, empty = all. SWEEP_SCHEDULE: a cron
+# expression (e.g. "0 0 * * *" = daily midnight), empty = use SWEEP_INTERVAL.
+SWEEP_ENABLED="%s"
+SWEEP_TASKS="%s"
+SWEEP_SCHEDULE="%s"
+SWEEP_INTERVAL="86400"
+SWEEP_MAX_TASKS="%s"
 `,
 		time.Now().Format(time.RFC3339),
 		v.linearKey, v.team, oauthLines, triggerLines, v.review,
@@ -877,6 +952,7 @@ TRUSTED_REVIEWERS="%s"
 		v.tgEnabled, v.tgToken, v.tgChat, v.tgVerbose,
 		v.geminiMode, v.geminiKey,
 		v.autoIterate, v.maxIter, v.prPoll, v.trusted,
+		v.sweepEnabled, v.sweepTasks, v.sweepSchedule, v.sweepMaxTasks,
 	)
 	return os.WriteFile(path, []byte(body), 0o600)
 }

--- a/internal/sweep/cron.go
+++ b/internal/sweep/cron.go
@@ -1,0 +1,119 @@
+package sweep
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type CronSchedule struct {
+	minute, hour, dom, month, dow uint64
+	domRestricted, dowRestricted  bool
+}
+
+func ParseCron(expr string) (*CronSchedule, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("cron %q: expected 5 fields, got %d", expr, len(fields))
+	}
+	s := &CronSchedule{}
+	var err error
+	if s.minute, err = parseCronField(fields[0], 0, 59); err != nil {
+		return nil, err
+	}
+	if s.hour, err = parseCronField(fields[1], 0, 23); err != nil {
+		return nil, err
+	}
+	if s.dom, err = parseCronField(fields[2], 1, 31); err != nil {
+		return nil, err
+	}
+	if s.month, err = parseCronField(fields[3], 1, 12); err != nil {
+		return nil, err
+	}
+	if s.dow, err = parseCronField(fields[4], 0, 7); err != nil {
+		return nil, err
+	}
+	if s.dow&(1<<7) != 0 {
+		s.dow |= 1 << 0
+		s.dow &^= 1 << 7
+	}
+	s.domRestricted = fields[2] != "*"
+	s.dowRestricted = fields[4] != "*"
+	return s, nil
+}
+
+func parseCronField(field string, min, max int) (uint64, error) {
+	var mask uint64
+	for _, part := range strings.Split(field, ",") {
+		step := 1
+		rng := part
+		if i := strings.IndexByte(part, '/'); i >= 0 {
+			rng = part[:i]
+			n, err := strconv.Atoi(part[i+1:])
+			if err != nil || n < 1 {
+				return 0, fmt.Errorf("cron: invalid step in %q", part)
+			}
+			step = n
+		}
+		lo, hi := min, max
+		if rng != "*" {
+			if i := strings.IndexByte(rng, '-'); i >= 0 {
+				a, err1 := strconv.Atoi(rng[:i])
+				b, err2 := strconv.Atoi(rng[i+1:])
+				if err1 != nil || err2 != nil {
+					return 0, fmt.Errorf("cron: invalid range in %q", part)
+				}
+				lo, hi = a, b
+			} else {
+				v, err := strconv.Atoi(rng)
+				if err != nil {
+					return 0, fmt.Errorf("cron: invalid value %q", part)
+				}
+				lo, hi = v, v
+			}
+		}
+		if lo < min || hi > max || lo > hi {
+			return 0, fmt.Errorf("cron: value out of range [%d-%d] in %q", min, max, part)
+		}
+		for v := lo; v <= hi; v += step {
+			mask |= 1 << uint(v)
+		}
+	}
+	return mask, nil
+}
+
+func (s *CronSchedule) Next(after time.Time) time.Time {
+	t := after.Truncate(time.Minute).Add(time.Minute)
+	limit := t.AddDate(1, 0, 0)
+	for ; t.Before(limit); t = t.Add(time.Minute) {
+		if s.matches(t) {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func (s *CronSchedule) matches(t time.Time) bool {
+	if s.minute&(1<<uint(t.Minute())) == 0 {
+		return false
+	}
+	if s.hour&(1<<uint(t.Hour())) == 0 {
+		return false
+	}
+	if s.month&(1<<uint(int(t.Month()))) == 0 {
+		return false
+	}
+	domMatch := s.dom&(1<<uint(t.Day())) != 0
+	dowMatch := s.dow&(1<<uint(int(t.Weekday()))) != 0
+	switch {
+	case s.domRestricted && s.dowRestricted:
+		return domMatch || dowMatch
+	case s.domRestricted:
+		return domMatch
+	case s.dowRestricted:
+		return dowMatch
+	default:
+		return true
+	}
+}

--- a/internal/sweep/cron_test.go
+++ b/internal/sweep/cron_test.go
@@ -1,0 +1,91 @@
+package sweep
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCron_Invalid(t *testing.T) {
+	for _, expr := range []string{
+		"",
+		"0 0 * *",
+		"0 0 * * * *",
+		"60 0 * * *",
+		"0 24 * * *",
+		"0 0 0 * *",
+		"0 0 32 * *",
+		"0 0 * 13 *",
+		"abc 0 * * *",
+		"*/0 * * * *",
+		"5-2 * * * *",
+	} {
+		if _, err := ParseCron(expr); err == nil {
+			t.Errorf("ParseCron(%q): expected error, got nil", expr)
+		}
+	}
+}
+
+func TestCronNext_DailyMidnight(t *testing.T) {
+	s, err := ParseCron("0 0 * * *")
+	if err != nil {
+		t.Fatalf("ParseCron: %v", err)
+	}
+	from := time.Date(2026, 6, 20, 14, 30, 0, 0, time.UTC)
+	got := s.Next(from)
+	want := time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("Next = %v, want %v", got, want)
+	}
+}
+
+func TestCronNext_SpecificHour(t *testing.T) {
+	s, _ := ParseCron("30 9 * * *")
+	from := time.Date(2026, 6, 20, 9, 30, 0, 0, time.UTC)
+	got := s.Next(from)
+	want := time.Date(2026, 6, 21, 9, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("Next (strictly after) = %v, want %v", got, want)
+	}
+}
+
+func TestCronNext_EveryFifteenMinutes(t *testing.T) {
+	s, _ := ParseCron("*/15 * * * *")
+	from := time.Date(2026, 6, 20, 10, 7, 0, 0, time.UTC)
+	got := s.Next(from)
+	want := time.Date(2026, 6, 20, 10, 15, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("Next = %v, want %v", got, want)
+	}
+}
+
+func TestCronNext_Weekdays(t *testing.T) {
+	s, _ := ParseCron("0 9 * * 1-5")
+	// 2026-06-20 is a Saturday; next weekday 9am is Monday 2026-06-22.
+	from := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	got := s.Next(from)
+	want := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("Next = %v, want %v (weekday %s)", got, want, got.Weekday())
+	}
+}
+
+func TestCronNext_DomDowOr(t *testing.T) {
+	// When both dom and dow are restricted, either matching fires.
+	s, _ := ParseCron("0 0 13 * 5") // the 13th OR any Friday
+	from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	got := s.Next(from)
+	// First Friday in June 2026 is the 5th — earlier than the 13th.
+	want := time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("Next = %v, want %v", got, want)
+	}
+}
+
+func TestCronNext_SundayAsSeven(t *testing.T) {
+	s7, _ := ParseCron("0 0 * * 7")
+	s0, _ := ParseCron("0 0 * * 0")
+	from := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	if !s7.Next(from).Equal(s0.Next(from)) {
+		t.Errorf("dow=7 and dow=0 should both mean Sunday: %v vs %v", s7.Next(from), s0.Next(from))
+	}
+}

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -19,25 +19,25 @@ type Scheduler struct {
 	tasks    []Task
 	interval time.Duration
 	maxTasks int
+	schedule *CronSchedule
 
-	// lastSweep tracks when the last sweep cycle completed. Zero-valued on
-	// startup so an immediate sweep fires if tasks are due (per-task cooldowns
-	// in the state store prevent repeated runs).
 	lastSweep time.Time
-	// now is a hook for testing — defaults to time.Now.
-	now func() time.Time
+	startedAt time.Time
+	now       func() time.Time
 }
 
-// NewScheduler creates a sweep scheduler.
-func NewScheduler(store *state.Store, resolver *repo.Resolver, tasks []Task, interval time.Duration, maxTasks int) *Scheduler {
+func NewScheduler(store *state.Store, resolver *repo.Resolver, tasks []Task, interval time.Duration, maxTasks int, schedule *CronSchedule) *Scheduler {
+	now := time.Now
 	return &Scheduler{
 		store:     store,
 		resolver:  resolver,
 		tasks:     tasks,
 		interval:  interval,
 		maxTasks:  maxTasks,
-		lastSweep: time.Time{}, // allow immediate sweep on startup if tasks are due (cooldowns prevent spam)
-		now:       time.Now,
+		schedule:  schedule,
+		lastSweep: time.Time{},
+		startedAt: now(),
+		now:       now,
 	}
 }
 
@@ -50,9 +50,22 @@ type Job struct {
 }
 
 // DueIn returns how long until the next sweep should fire. Returns 0 if
-// a sweep is already due.
+// a sweep is already due. With a cron schedule it waits for the next matching
+// time (no immediate sweep on startup); otherwise it uses the fixed interval
+// (which does fire immediately on startup, since lastSweep is zero).
 func (s *Scheduler) DueIn() time.Duration {
-	elapsed := s.now().Sub(s.lastSweep)
+	now := s.now()
+	if s.schedule != nil {
+		ref := s.lastSweep
+		if ref.IsZero() {
+			ref = s.startedAt
+		}
+		if d := s.schedule.Next(ref).Sub(now); d > 0 {
+			return d
+		}
+		return 0
+	}
+	elapsed := now.Sub(s.lastSweep)
 	if elapsed >= s.interval {
 		return 0
 	}

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -21,9 +21,11 @@ type Scheduler struct {
 	maxTasks int
 	schedule *CronSchedule
 
-	lastSweep time.Time
-	startedAt time.Time
-	now       func() time.Time
+	lastSweep     time.Time
+	startedAt     time.Time
+	now           func() time.Time
+	lastRef       time.Time
+	nextScheduled time.Time
 }
 
 func NewScheduler(store *state.Store, resolver *repo.Resolver, tasks []Task, interval time.Duration, maxTasks int, schedule *CronSchedule) *Scheduler {
@@ -60,11 +62,22 @@ func (s *Scheduler) DueIn() time.Duration {
 		if ref.IsZero() {
 			ref = s.startedAt
 		}
-		if d := s.schedule.Next(ref).Sub(now); d > 0 {
+		if !ref.Equal(s.lastRef) {
+			s.lastRef = ref
+			s.nextScheduled = s.schedule.Next(ref)
+		}
+		if s.nextScheduled.IsZero() {
+			return s.intervalDueIn(now)
+		}
+		if d := s.nextScheduled.Sub(now); d > 0 {
 			return d
 		}
 		return 0
 	}
+	return s.intervalDueIn(now)
+}
+
+func (s *Scheduler) intervalDueIn(now time.Time) time.Duration {
 	elapsed := now.Sub(s.lastSweep)
 	if elapsed >= s.interval {
 		return 0

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -195,3 +195,55 @@ func TestScheduler_Summary(t *testing.T) {
 func resolver(reposBase string) *repo.Resolver {
 	return &repo.Resolver{ReposBase: reposBase}
 }
+
+func TestDueIn_CronWaitsForNextMatch(t *testing.T) {
+	sch, err := ParseCron("0 0 * * *")
+	if err != nil {
+		t.Fatalf("ParseCron: %v", err)
+	}
+	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch)
+	base := time.Date(2026, 6, 20, 14, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return base }
+	s.startedAt = base
+
+	got := s.DueIn()
+	want := 10 * time.Hour
+	if got != want {
+		t.Errorf("DueIn = %v, want %v", got, want)
+	}
+}
+
+func TestDueIn_UnmatchableCronFallsBackToInterval(t *testing.T) {
+	sch, err := ParseCron("0 0 30 2 *")
+	if err != nil {
+		t.Fatalf("ParseCron: %v", err)
+	}
+	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch)
+	base := time.Date(2026, 6, 20, 14, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return base }
+	s.lastSweep = base.Add(-30 * time.Minute)
+
+	got := s.DueIn()
+	want := 30 * time.Minute
+	if got != want {
+		t.Errorf("unmatchable cron DueIn = %v, want %v (interval fallback, not 0-spin)", got, want)
+	}
+}
+
+func TestDueIn_CronCachesNextComputation(t *testing.T) {
+	sch, _ := ParseCron("0 0 * * *")
+	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch)
+	base := time.Date(2026, 6, 20, 14, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return base }
+	s.startedAt = base
+
+	_ = s.DueIn()
+	first := s.nextScheduled
+	if first.IsZero() {
+		t.Fatal("nextScheduled not cached after first DueIn")
+	}
+	_ = s.DueIn()
+	if !s.nextScheduled.Equal(first) {
+		t.Error("nextScheduled changed without the reference changing (not cached)")
+	}
+}

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -50,7 +50,7 @@ func initTestRepo(t *testing.T, base, name string) string {
 func TestScheduler_DueIn(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
-	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5)
+	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5, nil)
 
 	// Just created — should be immediately due (no startup suppression;
 	// per-task cooldowns prevent spam).
@@ -74,7 +74,7 @@ func TestScheduler_DueIn(t *testing.T) {
 func TestScheduler_MarkSwept(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
-	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5)
+	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5, nil)
 
 	s.lastSweep = time.Now().Add(-2 * time.Hour) // make it due
 	s.MarkSwept()
@@ -98,7 +98,7 @@ func TestScheduler_PlanRespectsMaxTasks(t *testing.T) {
 		testTask("t3", time.Hour),
 	}
 
-	s := NewScheduler(store, resolver, tasks, time.Hour, 2) // max 2
+	s := NewScheduler(store, resolver, tasks, time.Hour, 2, nil) // max 2
 
 	jobs := s.Plan(context.Background())
 	if len(jobs) > 2 {
@@ -118,7 +118,7 @@ func TestScheduler_PlanRespectsCooldown(t *testing.T) {
 		testTask("task-b", 24*time.Hour),
 	}
 
-	s := NewScheduler(store, resolver(reposBase), tasks, time.Hour, 10)
+	s := NewScheduler(store, resolver(reposBase), tasks, time.Hour, 10, nil)
 
 	// Both should be eligible initially.
 	jobs := s.Plan(context.Background())
@@ -145,7 +145,7 @@ func TestScheduler_PlanNoRepos(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	resolver := &repo.Resolver{ReposBase: t.TempDir()} // empty
 
-	s := NewScheduler(store, resolver, []Task{testTask("t1", time.Hour)}, time.Hour, 5)
+	s := NewScheduler(store, resolver, []Task{testTask("t1", time.Hour)}, time.Hour, 5, nil)
 	jobs := s.Plan(context.Background())
 	if len(jobs) != 0 {
 		t.Errorf("expected 0 jobs with no repos, got %d", len(jobs))
@@ -157,7 +157,7 @@ func TestScheduler_RecordRun(t *testing.T) {
 	store, _ := state.Open(statePath)
 
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
-	s := NewScheduler(store, resolver, nil, time.Hour, 5)
+	s := NewScheduler(store, resolver, nil, time.Hour, 5, nil)
 
 	if err := s.RecordRun("my-repo", "lint-cleanup"); err != nil {
 		t.Fatal(err)
@@ -185,7 +185,7 @@ func TestScheduler_Summary(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
 
-	s := NewScheduler(store, resolver, []Task{testTask("t1", 24*time.Hour)}, time.Hour, 5)
+	s := NewScheduler(store, resolver, []Task{testTask("t1", 24*time.Hour)}, time.Hour, 5, nil)
 	summary := s.Summary()
 	if summary == "" {
 		t.Error("Summary should not be empty")


### PR DESCRIPTION
## Why

`SWEEP_SCHEDULE` was documented as a cron expression and read into config — but **nothing consumed it**. The scheduler only ever used `SWEEP_INTERVAL`, so "run every day at midnight" was impossible. This finishes the feature.

## What

- **`internal/sweep/cron.go`** — a **zero-dependency** standard 5-field cron parser (go.mod stays dep-free). Supports `*`, values, ranges, lists, `*/n` steps, the dom/dow OR rule, and Sunday as `0` or `7`; `Next(t)` returns the next matching minute.
- **`scheduler.DueIn`** — with a cron schedule set, waits for the next matching time (and **does not** fire immediately on startup, unlike interval mode). Fixed-interval behaviour is unchanged. An invalid `SWEEP_SCHEDULE` **warns and falls back to the interval** (never fatal).
- **Banner** shows the cron expression when set.
- **Setup wizard** — new optional sweep section: enable sweeps, pick tasks from the **live catalog**, set a cron schedule + max tasks, with a validation hint, and a pointer for contributors on **how to add a task** (`internal/sweep/task_*.go`).
- **Docs** — `.env.example` sweep block, `CLAUDE.md` config table + loop diagram.

## Result

```bash
SWEEP_SCHEDULE="0 0 * * *"   # every day at midnight
```

## Tests

Cron parser: invalid-expression rejection, daily-midnight, specific-hour (strictly-after), `*/15`, weekday ranges, dom/dow OR, Sunday-as-7. Existing scheduler tests updated for the new signature. `go test ./...` + `go vet ./...` + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)