### PR TITLE
ENG-237: auto-file a Linear ticket on release to keep getnoctra.dev in sync

### DIFF
--- a/.github/workflows/site-sync-on-release.yml
+++ b/.github/workflows/site-sync-on-release.yml
@@ -1,0 +1,71 @@
+name: Sync getnoctra.dev on release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Version tag to document (manual test run)
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  file-site-ticket:
+    name: File a Linear ticket to update the site
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.release.draft == false && github.event.release.prerelease == false) }}
+    env:
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      NOTES: ${{ github.event.release.body || 'Manual test run — no release notes provided.' }}
+      TEAM_ID: 9b095a64-9aa8-4fe0-a515-345ba6e5af63
+      PROJECT_ID: 24719bc7-b280-4458-be98-8b1f39b69b70
+      TRIGGER_STATE: Next
+    steps:
+      - name: Create Linear ticket in the Noctra Site project
+        run: |
+          set -euo pipefail
+
+          if [ -z "${LINEAR_API_KEY:-}" ]; then
+            echo "::error::LINEAR_API_KEY secret is not set — add it under repo Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+          api() {
+            curl -sS -X POST https://api.linear.app/graphql \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "$1"
+          }
+
+          state_query=$(jq -n --arg teamId "$TEAM_ID" \
+            '{query:"query($teamId:String!){team(id:$teamId){states{nodes{id name}}}}",variables:{teamId:$teamId}}')
+          state_resp=$(api "$state_query")
+          state_id=$(printf '%s' "$state_resp" | jq -r --arg name "$TRIGGER_STATE" \
+            '.data.team.states.nodes[]? | select(.name==$name) | .id')
+          if [ -z "$state_id" ] || [ "$state_id" = "null" ]; then
+            echo "::error::could not resolve the '$TRIGGER_STATE' state id. Response: $state_resp"
+            exit 1
+          fi
+
+          title="getnoctra.dev: document $TAG"
+          body=$(printf 'Update the marketing/docs site at getnoctra.dev so it reflects Noctra %s.\n\n## Release notes\n\n%s\n\n## What to do\n- Read the release notes above and update anything user-facing to match.\n- Likely files: `src/components/Features.astro`, `src/components/HowItWorks.astro`, `src/components/Compare.astro`, `src/pages/docs.astro`.\n- Keep the existing design, structure, and tone — make minimal, accurate edits.\n- If nothing user-facing changed in this release, respond: BLOCKED: Nothing on the site needs updating for %s.\n\nRepo: ahmadAlMezaal/noctra-site\nAuto-filed by the release workflow in ahmadAlMezaal/noctra.\n' "$TAG" "$NOTES" "$TAG")
+
+          create=$(jq -n \
+            --arg title "$title" --arg desc "$body" \
+            --arg teamId "$TEAM_ID" --arg projectId "$PROJECT_ID" --arg stateId "$state_id" \
+            '{query:"mutation($input:IssueCreateInput!){issueCreate(input:$input){success issue{identifier url}}}",variables:{input:{title:$title,description:$desc,teamId:$teamId,projectId:$projectId,stateId:$stateId}}}')
+          resp=$(api "$create")
+
+          if [ "$(printf '%s' "$resp" | jq -r '.data.issueCreate.success')" != "true" ]; then
+            echo "::error::issueCreate failed: $resp"
+            exit 1
+          fi
+
+          ident=$(printf '%s' "$resp" | jq -r '.data.issueCreate.issue.identifier')
+          url=$(printf '%s' "$resp" | jq -r '.data.issueCreate.issue.url')
+          echo "Created $ident for $TAG — $url"
+          echo "### 🌙 Site update ticket filed: [$ident]($url)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes ENG-237.

## Why

Every Noctra release means hand-updating [getnoctra.dev](https://getnoctra.dev) (`ahmadAlMezaal/noctra-site`). This makes the site self-maintaining by reusing Noctra itself.

## What

`.github/workflows/site-sync-on-release.yml` — on a published release (skips drafts/prereleases):

1. Resolves the Engineering team's **`Next`** state id via the Linear GraphQL API (by name, so it survives id changes).
2. Creates an issue in the **Noctra Site** project, in the `Next` state, titled `getnoctra.dev: document <tag>`, body = the release notes + a checklist pointing the agent at the likely Astro files (`Features.astro`, `HowItWorks.astro`, `Compare.astro`, `docs.astro`) with a `BLOCKED:` escape if nothing user-facing changed.
3. Noctra (already routing the Noctra Site project to `noctra-site`) picks it up, clones the site, and opens a PR you review.

## Setup needed (one-time)

Add a **`LINEAR_API_KEY`** repo secret (Settings → Secrets and variables → Actions). The job **fails loudly** if it's missing.

## Notes / testing

- `workflow_dispatch` with a `tag` input lets you trigger a manual test run without cutting a release.
- `curl` + `jq` only — no new deps. The ticket body is built with `jq --arg`, so release notes containing quotes/backticks/newlines encode as valid JSON (verified locally).
- Starts on **all** non-prerelease releases; easy to gate to minor/major later if patch tickets prove noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)