### PR TITLE
ENG-237: fix site-sync — call from release workflows instead of on: release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Optional: set this secret once a homebrew-tap repo exists to publish a formula.
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+  # File a site-update ticket for the just-published release (the tag name is the
+  # release version). Same reusable workflow tag-on-merge uses.
+  sync-site:
+    needs: goreleaser
+    uses: ./.github/workflows/site-sync-on-release.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/site-sync-on-release.yml
+++ b/.github/workflows/site-sync-on-release.yml
@@ -1,8 +1,20 @@
 name: Sync getnoctra.dev on release
 
+# Reusable workflow: files a Linear ticket in the Noctra Site project so Noctra
+# updates getnoctra.dev for a release. Called from tag-on-merge.yml and
+# release.yml (NOT triggered by `on: release`, because releases published with
+# GITHUB_TOKEN do not trigger other workflows). Also runnable manually for tests.
+
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: The released version tag (e.g. v0.14.0)
+        required: true
+        type: string
+    secrets:
+      LINEAR_API_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -16,11 +28,11 @@ jobs:
   file-site-ticket:
     name: File a Linear ticket to update the site
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.release.draft == false && github.event.release.prerelease == false) }}
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      TAG: ${{ github.event.release.tag_name || inputs.tag }}
-      NOTES: ${{ github.event.release.body || 'Manual test run — no release notes provided.' }}
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      TAG: ${{ inputs.tag }}
       TEAM_ID: 9b095a64-9aa8-4fe0-a515-345ba6e5af63
       PROJECT_ID: 24719bc7-b280-4458-be98-8b1f39b69b70
       TRIGGER_STATE: Next
@@ -32,6 +44,11 @@ jobs:
           if [ -z "${LINEAR_API_KEY:-}" ]; then
             echo "::error::LINEAR_API_KEY secret is not set — add it under repo Settings → Secrets and variables → Actions."
             exit 1
+          fi
+
+          notes=$(gh release view "$TAG" --repo "$REPO" --json body --jq '.body' 2>/dev/null || true)
+          if [ -z "$notes" ]; then
+            notes="See https://github.com/$REPO/releases/tag/$TAG"
           fi
 
           api() {
@@ -52,7 +69,7 @@ jobs:
           fi
 
           title="getnoctra.dev: document $TAG"
-          body=$(printf 'Update the marketing/docs site at getnoctra.dev so it reflects Noctra %s.\n\n## Release notes\n\n%s\n\n## What to do\n- Read the release notes above and update anything user-facing to match.\n- Likely files: `src/components/Features.astro`, `src/components/HowItWorks.astro`, `src/components/Compare.astro`, `src/pages/docs.astro`.\n- Keep the existing design, structure, and tone — make minimal, accurate edits.\n- If nothing user-facing changed in this release, respond: BLOCKED: Nothing on the site needs updating for %s.\n\nRepo: ahmadAlMezaal/noctra-site\nAuto-filed by the release workflow in ahmadAlMezaal/noctra.\n' "$TAG" "$NOTES" "$TAG")
+          body=$(printf 'Update the marketing/docs site at getnoctra.dev so it reflects Noctra %s.\n\n## Release notes\n\n%s\n\n## What to do\n- Read the release notes above and update anything user-facing to match.\n- Likely files: `src/components/Features.astro`, `src/components/HowItWorks.astro`, `src/components/Compare.astro`, `src/pages/docs.astro`.\n- Keep the existing design, structure, and tone — make minimal, accurate edits.\n- If nothing user-facing changed in this release, respond: BLOCKED: Nothing on the site needs updating for %s.\n\nRepo: ahmadAlMezaal/noctra-site\nAuto-filed by the release workflow in %s.\n' "$TAG" "$notes" "$TAG" "$REPO")
 
           create=$(jq -n \
             --arg title "$title" --arg desc "$body" \

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -32,6 +32,9 @@ jobs:
   tag-on-merge:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      next_version: ${{ steps.version.outputs.next_version }}
+      no_release: ${{ steps.check-label.outputs.no_release }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -148,3 +151,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+  # File a site-update ticket once the release is published. Called here (not via
+  # an `on: release` trigger) because the release above is created with
+  # GITHUB_TOKEN, which does not trigger other workflows.
+  sync-site:
+    needs: tag-on-merge
+    if: needs.tag-on-merge.outputs.no_release != 'true'
+    uses: ./.github/workflows/site-sync-on-release.yml
+    with:
+      tag: ${{ needs.tag-on-merge.outputs.next_version }}
+    secrets: inherit


### PR DESCRIPTION
Follow-up to #191 (ENG-237).

## The bug

The `on: release: published` trigger **never fired** — the workflow showed `0 runs` even after a release was cut. Root cause is the exact thing `tag-on-merge.yml` already documents:

> *Tags pushed with GITHUB_TOKEN don't trigger other workflows (GitHub policy to prevent loops).*

`tag-on-merge` (and `release.yml`) publish the release using `GITHUB_TOKEN`, and GitHub **won't wake another workflow from a `GITHUB_TOKEN`-created event**. So the `release` event happened, but site-sync was never triggered.

## The fix

Make site-sync a **reusable workflow** (`workflow_call`) and call it as a `sync-site` job **inside** the workflows that create the release — same run, no cross-workflow trigger:

- **`site-sync-on-release.yml`**: `on: release` → `on: workflow_call` (+ `workflow_dispatch` kept for manual tests). Now fetches the release notes itself via `gh release view`.
- **`tag-on-merge.yml`**: exposes `next_version`/`no_release` as job outputs and adds `sync-site` (`uses: ./.github/workflows/site-sync-on-release.yml`, `secrets: inherit`), gated on a release actually being cut.
- **`release.yml`** (manual-tag path): adds the same `sync-site` job with `tag: ${{ github.ref_name }}`.

## Result

Every release — whether via label-driven `tag-on-merge` or a manual tag push — files the `getnoctra.dev: document <tag>` ticket in the same run. Still needs the `LINEAR_API_KEY` secret (job fails loudly without it).

## Testing

YAML + embedded shell validated locally. After merge, smoke-test via Actions → "Sync getnoctra.dev on release" → Run workflow (`workflow_dispatch`) with a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)