### PR TITLE
ENG-239: SWEEP_REPOS — choose which repos maintenance sweeps target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,9 @@ SWEEP_ENABLED=false
 # Comma-separated subset of tasks; empty = all registered tasks in
 # internal/sweep (e.g. lint-cleanup, dead-code).
 SWEEP_TASKS=
+# Comma-separated repos to sweep (owner/name or git URLs, cloned on demand).
+# Empty = every repo Noctra has already cloned from tickets.
+SWEEP_REPOS=
 # When to run: a cron expression (e.g. "0 0 * * *" = every day at midnight).
 # Empty = use the fixed SWEEP_INTERVAL below instead.
 SWEEP_SCHEDULE=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ PR poll loop → github.ListNoctraPRs → github.GetPR (comments+reviews+statusC
 When `SWEEP_ENABLED=true`, a **third** loop runs alongside the Linear and PR-watcher loops:
 
 ```
-sweep loop → scheduler.DueIn (cron SWEEP_SCHEDULE or fixed SWEEP_INTERVAL) → scheduler.Plan (all repos × task catalog)
+sweep loop → scheduler.DueIn (cron SWEEP_SCHEDULE or fixed SWEEP_INTERVAL) → scheduler.Plan (SWEEP_REPOS or all cloned repos × task catalog)
   → filter by cooldown (per-repo, per-task, from state store)
   → pipeline.processSweepTask (bounded, shares the worker pool + active-set)
   → repo.CreateWorktreeWithBranch → agent.Run (task-specific prompt) → commit/push → gh pr create
@@ -69,6 +69,7 @@ sweep loop → scheduler.DueIn (cron SWEEP_SCHEDULE or fixed SWEEP_INTERVAL) →
 | `SWEEP_INTERVAL` | `86400` (24h) | Seconds between sweep cycles (fallback when no cron). Interval mode fires immediately on startup; cron mode waits for the next matching time |
 | `SWEEP_MAX_TASKS` | `5` | Max tasks per sweep run |
 | `SWEEP_TASKS` | (all) | Comma-separated task names to enable (e.g. `lint-cleanup,dead-code`) |
+| `SWEEP_REPOS` | (all cloned) | Comma-separated `owner/name` or git URLs to sweep, resolved via `repo.ResolveDirect` (clone-on-demand). When set, **replaces** the `AllRepoPaths()` discovery; unresolvable entries warn and are skipped. Empty = every cloned repo |
 
 ## Multi-repo
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,6 +174,7 @@ type Config struct {
 	SweepInterval time.Duration // fallback fixed interval when no cron (default 24h)
 	SweepMaxTasks int           // max tasks per sweep run (default 5)
 	SweepTasks    []string      // enabled task names (nil = all registered tasks)
+	SweepRepos    []string      // explicit repos to sweep (owner/name or URL); nil = all cloned
 
 	// Derived paths
 	ScriptDir    string
@@ -274,6 +275,7 @@ func Load(scriptDir string) (*Config, error) {
 	cfg.SweepInterval = time.Duration(sweepIntervalSecs) * time.Second
 	cfg.SweepMaxTasks = getint(fileEnv, "SWEEP_MAX_TASKS", DefaultSweepMaxTasks)
 	cfg.SweepTasks = getlist(fileEnv, "SWEEP_TASKS")
+	cfg.SweepRepos = getlist(fileEnv, "SWEEP_REPOS")
 
 	return cfg, nil
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -152,7 +152,7 @@ func New(cfg *config.Config) *Pipeline {
 					schedule = parsed
 				}
 			}
-			p.sweeper = sweep.NewScheduler(store, p.resolver, tasks, cfg.SweepInterval, cfg.SweepMaxTasks, schedule)
+			p.sweeper = sweep.NewScheduler(store, p.resolver, tasks, cfg.SweepInterval, cfg.SweepMaxTasks, schedule, cfg.SweepRepos)
 		}
 	}
 
@@ -589,7 +589,11 @@ func (p *Pipeline) banner() {
 		if p.cfg.SweepSchedule != "" {
 			cadence = fmt.Sprintf("cron %q", p.cfg.SweepSchedule)
 		}
-		sweepMode = fmt.Sprintf("On (%s, max %d tasks)", cadence, p.cfg.SweepMaxTasks)
+		scope := "all cloned repos"
+		if n := len(p.cfg.SweepRepos); n > 0 {
+			scope = fmt.Sprintf("%d listed repo(s)", n)
+		}
+		sweepMode = fmt.Sprintf("On (%s, max %d tasks, %s)", cadence, p.cfg.SweepMaxTasks, scope)
 	}
 
 	// Repos are routed per-ticket from each Linear project's "Repo:" directive

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -169,7 +169,7 @@ func Run(scriptDir string) error {
 	// ── Optional: Auto-iterate on PR feedback ─────────────────────────────────
 	autoIterate, maxIter, prPoll, trusted := w.collectAutoIterate(existingEnv)
 
-	sweepEnabled, sweepTasks, sweepSchedule, sweepMaxTasks := w.collectSweep(existingEnv)
+	sweepEnabled, sweepTasks, sweepSchedule, sweepRepos, sweepMaxTasks := w.collectSweep(existingEnv)
 
 	// ── Optional: Gemini review gate ───────────────────────────────────────────
 	geminiKey := ""
@@ -277,6 +277,11 @@ func Run(scriptDir string) error {
 		} else {
 			fmt.Printf("  SWEEP_TASKS           = %s\n", sweepTasks)
 		}
+		if sweepRepos == "" {
+			fmt.Printf("  SWEEP_REPOS           = (all cloned)\n")
+		} else {
+			fmt.Printf("  SWEEP_REPOS           = %s\n", sweepRepos)
+		}
 		if sweepSchedule == "" {
 			fmt.Printf("  SWEEP_SCHEDULE        = (interval %ds)\n", int(config.DefaultSweepInterval/time.Second))
 		} else {
@@ -331,6 +336,7 @@ func Run(scriptDir string) error {
 		sweepEnabled:      sweepEnabled,
 		sweepTasks:        sweepTasks,
 		sweepSchedule:     sweepSchedule,
+		sweepRepos:        sweepRepos,
 		sweepMaxTasks:     strconv.Itoa(sweepMaxTasks),
 	}
 
@@ -677,7 +683,7 @@ func (w *wizard) collectAutoIterate(existing map[string]string) (autoIterate str
 	return autoIterate, maxIter, prPoll, trusted
 }
 
-func (w *wizard) collectSweep(existing map[string]string) (enabled, tasks, schedule string, maxTasks int) {
+func (w *wizard) collectSweep(existing map[string]string) (enabled, tasks, schedule, repos string, maxTasks int) {
 	enabled = "false"
 	maxTasks = config.DefaultSweepMaxTasks
 
@@ -687,7 +693,7 @@ func (w *wizard) collectSweep(existing map[string]string) (enabled, tasks, sched
 		prompt = "Maintenance sweeps are currently on. Keep them?"
 	}
 	if !w.confirm(prompt) {
-		return enabled, "", "", maxTasks
+		return enabled, "", "", "", maxTasks
 	}
 	enabled = "true"
 
@@ -697,6 +703,10 @@ func (w *wizard) collectSweep(existing map[string]string) (enabled, tasks, sched
 	}
 	fmt.Println("Enter a comma-separated subset, or leave blank to run all of them.")
 	tasks = w.askEx("Sweep tasks", askOpts{existing: existing["SWEEP_TASKS"]})
+
+	fmt.Println("Repos to sweep: comma-separated owner/name or git URLs.")
+	fmt.Println("Leave blank to sweep every repo Noctra has already cloned from tickets.")
+	repos = w.askEx("Sweep repos", askOpts{existing: existing["SWEEP_REPOS"]})
 
 	fmt.Println("Schedule: a cron expression (e.g. \"0 0 * * *\" = every day at midnight),")
 	fmt.Println("or leave blank to use a fixed interval instead.")
@@ -712,7 +722,7 @@ func (w *wizard) collectSweep(existing map[string]string) (enabled, tasks, sched
 	fmt.Println("ℹ️  To add your own task, create internal/sweep/task_<name>.go that calls")
 	fmt.Println("   Register(Task{...}) — copy task_lint.go as a starting point.")
 
-	return enabled, tasks, schedule, maxTasks
+	return enabled, tasks, schedule, repos, maxTasks
 }
 
 // ── Helpers (file I/O, validators, formatting) ──────────────────────────────
@@ -789,7 +799,7 @@ type envValues struct {
 	tgEnabled, tgToken, tgChat, tgVerbose        string
 	autoIterate, maxIter, prPoll, trusted        string
 	sweepEnabled, sweepTasks, sweepSchedule      string
-	sweepMaxTasks                                string
+	sweepRepos, sweepMaxTasks                    string
 }
 
 // toMap returns the wizard-managed keys as a flat map suitable for
@@ -822,6 +832,7 @@ func (v envValues) toMap() map[string]string {
 		"TRUSTED_REVIEWERS":     v.trusted,
 		"SWEEP_ENABLED":         v.sweepEnabled,
 		"SWEEP_TASKS":           v.sweepTasks,
+		"SWEEP_REPOS":           v.sweepRepos,
 		"SWEEP_SCHEDULE":        v.sweepSchedule,
 		"SWEEP_MAX_TASKS":       v.sweepMaxTasks,
 	}
@@ -934,11 +945,14 @@ PR_POLL_INTERVAL="%s"
 TRUSTED_REVIEWERS="%s"
 
 # Autonomous maintenance sweeps (ENG-222). Opt-in. Runs maintenance tasks
-# (lint, deps, docs, tests, modernize, bug-scan) across cloned repos.
-# SWEEP_TASKS: comma-separated subset, empty = all. SWEEP_SCHEDULE: a cron
-# expression (e.g. "0 0 * * *" = daily midnight), empty = use SWEEP_INTERVAL.
+# (lint, deps, docs, tests, modernize, bug-scan) across repos.
+# SWEEP_TASKS: comma-separated subset, empty = all. SWEEP_REPOS: comma-separated
+# owner/name or git URLs to sweep, empty = every repo Noctra has cloned.
+# SWEEP_SCHEDULE: a cron expression (e.g. "0 0 * * *" = daily midnight), empty =
+# use SWEEP_INTERVAL.
 SWEEP_ENABLED="%s"
 SWEEP_TASKS="%s"
+SWEEP_REPOS="%s"
 SWEEP_SCHEDULE="%s"
 SWEEP_INTERVAL="86400"
 SWEEP_MAX_TASKS="%s"
@@ -952,7 +966,7 @@ SWEEP_MAX_TASKS="%s"
 		v.tgEnabled, v.tgToken, v.tgChat, v.tgVerbose,
 		v.geminiMode, v.geminiKey,
 		v.autoIterate, v.maxIter, v.prPoll, v.trusted,
-		v.sweepEnabled, v.sweepTasks, v.sweepSchedule, v.sweepMaxTasks,
+		v.sweepEnabled, v.sweepTasks, v.sweepRepos, v.sweepSchedule, v.sweepMaxTasks,
 	)
 	return os.WriteFile(path, []byte(body), 0o600)
 }

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -10,16 +10,24 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/state"
 )
 
+// RepoResolver is the subset of *repo.Resolver the scheduler needs: discover
+// already-cloned repos, or resolve an explicit one (cloning on demand).
+type RepoResolver interface {
+	AllRepoPaths() []string
+	ResolveDirect(ctx context.Context, ref, branch string) (repo.Resolved, error)
+}
+
 // Scheduler determines when the next sweep should fire and which tasks are
 // eligible on which repos. It is side-effect-free: the pipeline drives
 // actual execution.
 type Scheduler struct {
-	store    *state.Store
-	resolver *repo.Resolver
-	tasks    []Task
-	interval time.Duration
-	maxTasks int
-	schedule *CronSchedule
+	store      *state.Store
+	resolver   RepoResolver
+	tasks      []Task
+	interval   time.Duration
+	maxTasks   int
+	schedule   *CronSchedule
+	sweepRepos []string
 
 	lastSweep     time.Time
 	startedAt     time.Time
@@ -28,18 +36,19 @@ type Scheduler struct {
 	nextScheduled time.Time
 }
 
-func NewScheduler(store *state.Store, resolver *repo.Resolver, tasks []Task, interval time.Duration, maxTasks int, schedule *CronSchedule) *Scheduler {
+func NewScheduler(store *state.Store, resolver RepoResolver, tasks []Task, interval time.Duration, maxTasks int, schedule *CronSchedule, sweepRepos []string) *Scheduler {
 	now := time.Now
 	return &Scheduler{
-		store:     store,
-		resolver:  resolver,
-		tasks:     tasks,
-		interval:  interval,
-		maxTasks:  maxTasks,
-		schedule:  schedule,
-		lastSweep: time.Time{},
-		startedAt: now(),
-		now:       now,
+		store:      store,
+		resolver:   resolver,
+		tasks:      tasks,
+		interval:   interval,
+		maxTasks:   maxTasks,
+		schedule:   schedule,
+		sweepRepos: sweepRepos,
+		lastSweep:  time.Time{},
+		startedAt:  now(),
+		now:        now,
 	}
 }
 
@@ -90,13 +99,31 @@ func (s *Scheduler) MarkSwept() {
 	s.lastSweep = s.now()
 }
 
+// repoPaths returns the repos to sweep: the explicit SWEEP_REPOS list
+// (resolved/cloned on demand) when set, otherwise every cloned repo.
+func (s *Scheduler) repoPaths(ctx context.Context) []string {
+	if len(s.sweepRepos) == 0 {
+		return s.resolver.AllRepoPaths()
+	}
+	var paths []string
+	for _, ref := range s.sweepRepos {
+		res, err := s.resolver.ResolveDirect(ctx, ref, "")
+		if err != nil {
+			slog.Warn("sweep: skipping repo it could not resolve", "repo", ref, "err", err)
+			continue
+		}
+		paths = append(paths, res.Path)
+	}
+	return paths
+}
+
 // Plan scans all known repos and returns the list of eligible (repo, task)
 // jobs — at most maxTasks total. A task is eligible if its cooldown on the
 // repo has expired.
 func (s *Scheduler) Plan(ctx context.Context) []Job {
-	repoPaths := s.resolver.AllRepoPaths()
+	repoPaths := s.repoPaths(ctx)
 	if len(repoPaths) == 0 {
-		slog.Debug("sweep: no repos cloned yet")
+		slog.Debug("sweep: no repos to sweep")
 		return nil
 	}
 

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -106,12 +106,17 @@ func (s *Scheduler) repoPaths(ctx context.Context) []string {
 		return s.resolver.AllRepoPaths()
 	}
 	var paths []string
+	seen := make(map[string]bool)
 	for _, ref := range s.sweepRepos {
 		res, err := s.resolver.ResolveDirect(ctx, ref, "")
 		if err != nil {
 			slog.Warn("sweep: skipping repo it could not resolve", "repo", ref, "err", err)
 			continue
 		}
+		if seen[res.Path] {
+			continue
+		}
+		seen[res.Path] = true
 		paths = append(paths, res.Path)
 	}
 	return paths

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -48,6 +48,23 @@ func TestPlan_SweepReposOverridesDiscovery(t *testing.T) {
 	}
 }
 
+func TestPlan_SweepReposDeduplicates(t *testing.T) {
+	base := t.TempDir()
+	wanted := initTestRepo(t, base, "wanted-repo")
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+
+	res := fakeResolver{direct: map[string]string{
+		"acme/wanted":                    wanted,
+		"git@github.com:acme/wanted.git": wanted,
+	}}
+	s := NewScheduler(store, res, []Task{testTask("t1", time.Hour)}, time.Hour, 5, nil,
+		[]string{"acme/wanted", "git@github.com:acme/wanted.git"})
+
+	if jobs := s.Plan(context.Background()); len(jobs) != 1 {
+		t.Errorf("expected 1 job (equivalent refs dedup to one repo), got %d", len(jobs))
+	}
+}
+
 func TestPlan_SweepReposSkipsUnresolvable(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	res := fakeResolver{direct: map[string]string{}}

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -2,6 +2,7 @@ package sweep
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,51 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/repo"
 	"github.com/ahmadAlMezaal/noctra/internal/state"
 )
+
+type fakeResolver struct {
+	all    []string
+	direct map[string]string
+}
+
+func (f fakeResolver) AllRepoPaths() []string { return f.all }
+
+func (f fakeResolver) ResolveDirect(_ context.Context, ref, _ string) (repo.Resolved, error) {
+	if p, ok := f.direct[ref]; ok {
+		return repo.Resolved{Path: p, MainBranch: "main"}, nil
+	}
+	return repo.Resolved{}, fmt.Errorf("unknown repo %q", ref)
+}
+
+func TestPlan_SweepReposOverridesDiscovery(t *testing.T) {
+	base := t.TempDir()
+	wanted := initTestRepo(t, base, "wanted-repo")
+	other := initTestRepo(t, base, "other-repo")
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+
+	res := fakeResolver{
+		all:    []string{other},
+		direct: map[string]string{"acme/wanted": wanted},
+	}
+	s := NewScheduler(store, res, []Task{testTask("t1", time.Hour)}, time.Hour, 5, nil, []string{"acme/wanted"})
+
+	jobs := s.Plan(context.Background())
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].RepoPath != wanted {
+		t.Errorf("swept %q, want the explicit repo %q (discovery should be ignored)", jobs[0].RepoPath, wanted)
+	}
+}
+
+func TestPlan_SweepReposSkipsUnresolvable(t *testing.T) {
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	res := fakeResolver{direct: map[string]string{}}
+	s := NewScheduler(store, res, []Task{testTask("t1", time.Hour)}, time.Hour, 5, nil, []string{"acme/missing"})
+
+	if jobs := s.Plan(context.Background()); len(jobs) != 0 {
+		t.Errorf("expected 0 jobs when nothing resolves, got %d", len(jobs))
+	}
+}
 
 // testTask returns a minimal task for testing.
 func testTask(name string, cooldown time.Duration) Task {
@@ -50,7 +96,7 @@ func initTestRepo(t *testing.T, base, name string) string {
 func TestScheduler_DueIn(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
-	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5, nil)
+	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5, nil, nil)
 
 	// Just created — should be immediately due (no startup suppression;
 	// per-task cooldowns prevent spam).
@@ -74,7 +120,7 @@ func TestScheduler_DueIn(t *testing.T) {
 func TestScheduler_MarkSwept(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
-	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5, nil)
+	s := NewScheduler(store, resolver, nil, 1*time.Hour, 5, nil, nil)
 
 	s.lastSweep = time.Now().Add(-2 * time.Hour) // make it due
 	s.MarkSwept()
@@ -98,7 +144,7 @@ func TestScheduler_PlanRespectsMaxTasks(t *testing.T) {
 		testTask("t3", time.Hour),
 	}
 
-	s := NewScheduler(store, resolver, tasks, time.Hour, 2, nil) // max 2
+	s := NewScheduler(store, resolver, tasks, time.Hour, 2, nil, nil) // max 2
 
 	jobs := s.Plan(context.Background())
 	if len(jobs) > 2 {
@@ -118,7 +164,7 @@ func TestScheduler_PlanRespectsCooldown(t *testing.T) {
 		testTask("task-b", 24*time.Hour),
 	}
 
-	s := NewScheduler(store, resolver(reposBase), tasks, time.Hour, 10, nil)
+	s := NewScheduler(store, resolver(reposBase), tasks, time.Hour, 10, nil, nil)
 
 	// Both should be eligible initially.
 	jobs := s.Plan(context.Background())
@@ -145,7 +191,7 @@ func TestScheduler_PlanNoRepos(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	resolver := &repo.Resolver{ReposBase: t.TempDir()} // empty
 
-	s := NewScheduler(store, resolver, []Task{testTask("t1", time.Hour)}, time.Hour, 5, nil)
+	s := NewScheduler(store, resolver, []Task{testTask("t1", time.Hour)}, time.Hour, 5, nil, nil)
 	jobs := s.Plan(context.Background())
 	if len(jobs) != 0 {
 		t.Errorf("expected 0 jobs with no repos, got %d", len(jobs))
@@ -157,7 +203,7 @@ func TestScheduler_RecordRun(t *testing.T) {
 	store, _ := state.Open(statePath)
 
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
-	s := NewScheduler(store, resolver, nil, time.Hour, 5, nil)
+	s := NewScheduler(store, resolver, nil, time.Hour, 5, nil, nil)
 
 	if err := s.RecordRun("my-repo", "lint-cleanup"); err != nil {
 		t.Fatal(err)
@@ -185,7 +231,7 @@ func TestScheduler_Summary(t *testing.T) {
 	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
 	resolver := &repo.Resolver{ReposBase: t.TempDir()}
 
-	s := NewScheduler(store, resolver, []Task{testTask("t1", 24*time.Hour)}, time.Hour, 5, nil)
+	s := NewScheduler(store, resolver, []Task{testTask("t1", 24*time.Hour)}, time.Hour, 5, nil, nil)
 	summary := s.Summary()
 	if summary == "" {
 		t.Error("Summary should not be empty")
@@ -201,7 +247,7 @@ func TestDueIn_CronWaitsForNextMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseCron: %v", err)
 	}
-	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch)
+	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch, nil)
 	base := time.Date(2026, 6, 20, 14, 0, 0, 0, time.UTC)
 	s.now = func() time.Time { return base }
 	s.startedAt = base
@@ -218,7 +264,7 @@ func TestDueIn_UnmatchableCronFallsBackToInterval(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseCron: %v", err)
 	}
-	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch)
+	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch, nil)
 	base := time.Date(2026, 6, 20, 14, 0, 0, 0, time.UTC)
 	s.now = func() time.Time { return base }
 	s.lastSweep = base.Add(-30 * time.Minute)
@@ -232,7 +278,7 @@ func TestDueIn_UnmatchableCronFallsBackToInterval(t *testing.T) {
 
 func TestDueIn_CronCachesNextComputation(t *testing.T) {
 	sch, _ := ParseCron("0 0 * * *")
-	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch)
+	s := NewScheduler(nil, nil, nil, time.Hour, 5, sch, nil)
 	base := time.Date(2026, 6, 20, 14, 0, 0, 0, time.UTC)
 	s.now = func() time.Time { return base }
 	s.startedAt = base


### PR DESCRIPTION
Closes ENG-239.

## Why

Sweeps ran against **every cloned repo** (`AllRepoPaths`), and a repo only gets cloned when a *ticket* routes to it — so sweep targets were an accident of what you'd worked on (in practice: just the `noctra` repo). No way to say "sweep these repos."

## What

New **`SWEEP_REPOS`** — comma-separated `owner/name` or git URLs (same format as the Linear `Repo:` directive). When set, the scheduler resolves each via `repo.ResolveDirect` (clone-on-demand) and sweeps **exactly those**, replacing the all-cloned default. Empty = unchanged.

```bash
noctra config set SWEEP_REPOS "ahmadAlMezaal/noctra-site, owner/another-repo"
```

- **Scheduler**: extracted a small `RepoResolver` interface (`AllRepoPaths` + `ResolveDirect`) so the planner is unit-testable; `Plan` uses `SWEEP_REPOS` when set. Unresolvable entries **warn and are skipped**, never fatal.
- **Freshness is unaffected**: `CreateWorktreeWithBranch` already fetches `origin/<main>` and builds the worktree from it, so a listed repo is swept on latest main even if its local clone is stale.
- **Wizard**: the sweep section now prompts for repos.
- **Banner**: shows the scope, e.g. `Sweep: On (cron "0 0 * * *", max 3 tasks, 2 listed repo(s))`.
- **Docs**: `.env.example` + `CLAUDE.md` (the site picks it up via the release auto-sync).

## Tests

`SWEEP_REPOS` overrides discovery (sweeps the listed repo, ignores the discovered one) and skips unresolvable entries. `go test ./...` + `go vet ./...` + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)