### PR TITLE
ci: build multi-arch Docker image on native runners (drop QEMU)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,12 @@ name: docker
 
 # Build the image on every relevant PR (validation only), and build + push to
 # GHCR on main and on version tags.
+#
+# Multi-arch is built on NATIVE runners — amd64 on ubuntu-latest, arm64 on
+# ubuntu-24.04-arm (free for public repos) — instead of emulating arm64 under
+# QEMU. Each arch is pushed by digest, then the `merge` job stitches them into a
+# single multi-arch manifest. This drops QEMU entirely and runs the two arches
+# in parallel.
 on:
   push:
     branches: [main]
@@ -16,24 +22,112 @@ on:
       - ".github/workflows/docker.yml"
   workflow_dispatch:
 
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
+  # PRs only validate that the image builds — do that natively on amd64, no push.
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          build-args: |
+            VERSION=${{ github.sha }}
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
+
+  # main/tags: build each arch natively, push by digest (no tags yet).
   build:
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version || github.sha }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Sanitize platform name
+        id: plat
+        run: echo "name=${platform//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ steps.plat.outputs.name }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stitch the per-arch digests into a single multi-arch manifest under the tags.
+  merge:
+    if: github.event_name != 'pull_request'
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
 
-      # QEMU is only needed to emulate the non-native arch (arm64). PRs build
-      # amd64-only (see platforms below), so skip the emulation setup there.
-      - uses: docker/setup-qemu-action@v4
-        if: github.event_name != 'pull_request'
       - uses: docker/setup-buildx-action@v4
 
-      # Only authenticate (and thus push) when this isn't a fork PR.
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -43,23 +137,19 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          # PRs only validate that the image builds — do that natively on amd64.
-          # The full multi-arch image is built (and pushed) on main/tags.
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version || github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## What

Rework `docker.yml` to build the multi-arch image on **native** runners instead of emulating arm64 under QEMU:

- **amd64** builds on `ubuntu-latest`, **arm64** builds on GitHub's native `ubuntu-24.04-arm` runner — both in parallel via a matrix.
- Each arch pushes **by digest**; a new `merge` job stitches the digests into a single multi-arch manifest under the usual tags (`type=ref` / `type=semver` / `latest`).
- PRs keep validating **amd64-only, no push**, same as before.
- `setup-qemu-action` is removed entirely.

## Why

The arm64 build was the only real bottleneck in this workflow — QEMU emulation is typically 5–10× slower than native. Native ARM runners are **free for public repos**, so this is a pure speedup at no cost and with no third-party CI dependency.

(Context: this came out of evaluating Blacksmith. For a public repo, GitHub's free native ARM runners capture ~90% of the win — eliminating QEMU — without adding an external runner provider.)

## Behavior preserved

- Same image name, tags, labels, and `VERSION` build-arg.
- Push still only happens on `main` / version tags, never on PRs.
- GHCR login still gated to non-PR events.

## Validation

- `actionlint` clean.
- YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)