### PR TITLE
ENG-221: Plan-confirm step for vague tickets before implementing

### DIFF
--- a/internal/agent/plan_prompt.go
+++ b/internal/agent/plan_prompt.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BuildPlanPrompt returns a plan-only prompt for the agent. Instead of
+// implementing the ticket, the agent reads the codebase and produces a
+// detailed implementation plan. The plan is posted as a Linear comment for
+// human review before Noctra proceeds with the actual implementation.
+func BuildPlanPrompt(in BuildPromptInput) string {
+	desc := in.Description
+	if desc == "" {
+		desc = "No description provided."
+	}
+
+	discussion := ""
+	if len(in.Comments) > 0 {
+		discussion = "\n\n## Ticket discussion (human clarifications — treat as authoritative, newest wins):\n" +
+			strings.Join(in.Comments, "\n\n")
+	}
+
+	return fmt.Sprintf(`You are reviewing a Linear ticket and producing an implementation plan. Do NOT implement anything — only plan.
+
+## Ticket: %s — %s
+%s%s
+
+## Instructions:
+1. Read the codebase to understand the project structure, conventions, and relevant code.
+2. Identify the files that need to be created or modified.
+3. Outline the implementation steps in detail.
+4. Note any risks, open questions, or decisions that need human input.
+5. Do NOT write any code, create files, run tests, or make any changes to the repository.
+
+## Output format:
+Produce your plan between these exact marker lines, each alone on its own line with nothing else:
+
+===NOCTRA PLAN===
+<your detailed implementation plan here>
+===END NOCTRA PLAN===
+
+The plan should include:
+- **Summary**: A brief overview of the approach.
+- **Files to modify**: List each file and what changes are needed.
+- **New files**: Any new files to create and their purpose.
+- **Implementation steps**: Ordered steps to implement the feature.
+- **Testing strategy**: How to test the changes.
+- **Risks / open questions**: Anything that might need clarification.`, in.Identifier, in.Title, desc, discussion)
+}
+
+// Plan markers the plan-only prompt asks the agent to wrap its plan in.
+const (
+	PlanStartMarker = "===NOCTRA PLAN==="
+	PlanEndMarker   = "===END NOCTRA PLAN==="
+)
+
+// ExtractPlan returns the agent's plan from the output, delimited by the
+// PlanStartMarker and PlanEndMarker. Returns ("", false) when the markers
+// are absent or the content between them is empty.
+func ExtractPlan(output string) (string, bool) {
+	start := strings.LastIndex(output, PlanStartMarker)
+	if start < 0 {
+		return "", false
+	}
+	rest := output[start+len(PlanStartMarker):]
+	end := strings.Index(rest, PlanEndMarker)
+	if end < 0 {
+		return "", false
+	}
+	plan := strings.TrimSpace(rest[:end])
+	if plan == "" {
+		return "", false
+	}
+	return plan, true
+}
+
+// BuildPlanImplementPrompt returns the implementation prompt that includes
+// the previously approved plan as context. This is used when a human approves
+// the plan and Noctra resumes with the actual implementation.
+func BuildPlanImplementPrompt(in BuildPromptInput, plan string) string {
+	desc := in.Description
+	if desc == "" {
+		desc = "No description provided."
+	}
+
+	discussion := ""
+	if len(in.Comments) > 0 {
+		discussion = "\n\n## Ticket discussion (human clarifications — treat as authoritative, newest wins):\n" +
+			strings.Join(in.Comments, "\n\n")
+	}
+
+	releaseInstruction := ""
+	if in.AutoReleaseLabel {
+		releaseInstruction = `
+
+After your summary (outside the markers), emit exactly one line:
+RELEASE: patch | minor | major | none
+
+Guidelines: none = docs/chore/internal-only, patch = bug fix, minor = new feature, major = breaking change.`
+	}
+
+	return fmt.Sprintf(`You are implementing a Linear ticket. A plan was previously created and approved by a human reviewer. Follow the plan closely, but adapt if you discover issues during implementation.
+
+## Ticket: %s — %s
+%s%s
+
+## Approved implementation plan:
+%s
+
+## Instructions:
+1. Follow the approved plan above as closely as possible.
+2. Implement the ticket requirements according to the plan.
+3. Write or update tests as needed.
+4. Run the test suite and fix any failures.
+5. Run the linter and fix any issues.
+6. If you need to deviate from the plan, explain why in your summary.
+
+## Rules:
+- Stay focused on this ticket only — do not modify unrelated code.
+- Follow existing project conventions and patterns exactly.
+- If you get stuck or need human input, say BLOCKED: <reason> and stop.
+- Do NOT create PRs or push branches — Noctra handles that.
+
+## When done:
+Provide a brief summary of what was implemented and any important decisions made. Wrap the summary between these exact marker lines, each alone on its own line with nothing else:
+
+===NOCTRA SUMMARY===
+<your summary here>
+===END NOCTRA SUMMARY===
+%s`, in.Identifier, in.Title, desc, discussion, plan, releaseInstruction)
+}

--- a/internal/agent/plan_prompt_test.go
+++ b/internal/agent/plan_prompt_test.go
@@ -1,0 +1,173 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPlanPrompt_BasicFields(t *testing.T) {
+	out := BuildPlanPrompt(BuildPromptInput{
+		Identifier:  "ENG-221",
+		Title:       "Plan-confirm step",
+		Description: "Add a plan-confirm feature.",
+	})
+
+	if !strings.Contains(out, "ENG-221") {
+		t.Error("prompt missing identifier")
+	}
+	if !strings.Contains(out, "Plan-confirm step") {
+		t.Error("prompt missing title")
+	}
+	if !strings.Contains(out, "Add a plan-confirm feature.") {
+		t.Error("prompt missing description")
+	}
+	if !strings.Contains(out, "Do NOT implement anything") {
+		t.Error("prompt should instruct agent not to implement")
+	}
+	if !strings.Contains(out, PlanStartMarker) {
+		t.Error("prompt missing plan start marker")
+	}
+	if !strings.Contains(out, PlanEndMarker) {
+		t.Error("prompt missing plan end marker")
+	}
+}
+
+func TestBuildPlanPrompt_IncludesComments(t *testing.T) {
+	out := BuildPlanPrompt(BuildPromptInput{
+		Identifier:  "ENG-221",
+		Title:       "Plan-confirm step",
+		Description: "Details.",
+		Comments:    []string{"Ahmad: Use the existing clarification plumbing."},
+	})
+
+	if !strings.Contains(out, "Ticket discussion") {
+		t.Error("prompt missing discussion section")
+	}
+	if !strings.Contains(out, "Use the existing clarification plumbing.") {
+		t.Error("prompt missing clarification comment")
+	}
+}
+
+func TestBuildPlanPrompt_NoDiscussionWhenNoComments(t *testing.T) {
+	out := BuildPlanPrompt(BuildPromptInput{
+		Identifier:  "ENG-1",
+		Title:       "Do a thing",
+		Description: "Details.",
+	})
+	if strings.Contains(out, "Ticket discussion") {
+		t.Error("prompt should not have discussion section when no comments")
+	}
+}
+
+func TestExtractPlan_Valid(t *testing.T) {
+	output := `Some preamble text.
+
+===NOCTRA PLAN===
+## Summary
+Modify the config to add PLAN_CONFIRM.
+
+## Files to modify
+- internal/config/config.go
+===END NOCTRA PLAN===
+
+Done.`
+
+	plan, ok := ExtractPlan(output)
+	if !ok {
+		t.Fatal("expected to extract plan")
+	}
+	if !strings.Contains(plan, "Modify the config") {
+		t.Errorf("plan missing expected content: %s", plan)
+	}
+	if !strings.Contains(plan, "internal/config/config.go") {
+		t.Errorf("plan missing files section: %s", plan)
+	}
+}
+
+func TestExtractPlan_MissingMarkers(t *testing.T) {
+	_, ok := ExtractPlan("No markers here.")
+	if ok {
+		t.Error("expected no plan when markers are absent")
+	}
+}
+
+func TestExtractPlan_EmptyBetweenMarkers(t *testing.T) {
+	output := "===NOCTRA PLAN===\n   \n===END NOCTRA PLAN==="
+	_, ok := ExtractPlan(output)
+	if ok {
+		t.Error("expected no plan when content between markers is empty")
+	}
+}
+
+func TestExtractPlan_LastPairWins(t *testing.T) {
+	output := `===NOCTRA PLAN===
+First plan (echoed instruction)
+===END NOCTRA PLAN===
+
+===NOCTRA PLAN===
+Second plan (actual)
+===END NOCTRA PLAN===`
+
+	plan, ok := ExtractPlan(output)
+	if !ok {
+		t.Fatal("expected to extract plan")
+	}
+	if !strings.Contains(plan, "Second plan") {
+		t.Errorf("expected last plan to win, got: %s", plan)
+	}
+}
+
+func TestBuildPlanImplementPrompt_IncludesPlan(t *testing.T) {
+	plan := "1. Add config field\n2. Add agent prompt"
+	out := BuildPlanImplementPrompt(BuildPromptInput{
+		Identifier:  "ENG-221",
+		Title:       "Plan-confirm step",
+		Description: "Add a plan-confirm feature.",
+	}, plan)
+
+	if !strings.Contains(out, "Approved implementation plan") {
+		t.Error("prompt missing plan section header")
+	}
+	if !strings.Contains(out, plan) {
+		t.Error("prompt missing the plan content")
+	}
+	if !strings.Contains(out, SummaryStartMarker) {
+		t.Error("prompt missing summary start marker")
+	}
+	if !strings.Contains(out, SummaryEndMarker) {
+		t.Error("prompt missing summary end marker")
+	}
+	// Should NOT contain RELEASE instruction when AutoReleaseLabel is false.
+	if strings.Contains(out, "RELEASE:") {
+		t.Error("prompt should not contain RELEASE instruction when AutoReleaseLabel is false")
+	}
+}
+
+func TestBuildPlanImplementPrompt_ReleaseInstruction(t *testing.T) {
+	out := BuildPlanImplementPrompt(BuildPromptInput{
+		Identifier:       "ENG-50",
+		Title:            "Feature",
+		Description:      "Details.",
+		AutoReleaseLabel: true,
+	}, "The plan.")
+
+	if !strings.Contains(out, "RELEASE: patch | minor | major | none") {
+		t.Error("prompt should include RELEASE instruction when AutoReleaseLabel=true")
+	}
+}
+
+func TestBuildPlanImplementPrompt_IncludesComments(t *testing.T) {
+	out := BuildPlanImplementPrompt(BuildPromptInput{
+		Identifier:  "ENG-5",
+		Title:       "Ticket",
+		Description: "Details.",
+		Comments:    []string{"Ahmad: prefer the stdin approach."},
+	}, "The plan.")
+
+	if !strings.Contains(out, "Ticket discussion") {
+		t.Error("prompt missing discussion section")
+	}
+	if !strings.Contains(out, "prefer the stdin approach") {
+		t.Error("prompt missing clarification comment")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,9 @@ const (
 	// Sweep — autonomous maintenance (ENG-222) — disabled by default.
 	DefaultSweepInterval = 24 * time.Hour
 	DefaultSweepMaxTasks = 5
+
+	// Plan-confirm (ENG-221) — disabled by default; opt in via .env.
+	DefaultPlanConfirmLabel = "plan-first"
 )
 
 // Config is Noctra's resolved runtime configuration.
@@ -175,6 +178,13 @@ type Config struct {
 	SweepMaxTasks int           // max tasks per sweep run (default 5)
 	SweepTasks    []string      // enabled task names (nil = all registered tasks)
 	SweepRepos    []string      // explicit repos to sweep (owner/name or URL); nil = all cloned
+
+	// Plan-confirm (ENG-221) — off by default; opt in via .env or per-ticket
+	// with the "plan-first" label. When enabled, Noctra runs the agent in
+	// plan-only mode first, posts the plan as a Linear comment, and waits
+	// for human approval before implementing.
+	PlanConfirm      bool   // global opt-in for plan-confirm on all tickets
+	PlanConfirmLabel string // label name that activates plan-confirm per-ticket (default "plan-first")
 
 	// Derived paths
 	ScriptDir    string
@@ -276,6 +286,10 @@ func Load(scriptDir string) (*Config, error) {
 	cfg.SweepMaxTasks = getint(fileEnv, "SWEEP_MAX_TASKS", DefaultSweepMaxTasks)
 	cfg.SweepTasks = getlist(fileEnv, "SWEEP_TASKS")
 	cfg.SweepRepos = getlist(fileEnv, "SWEEP_REPOS")
+
+	// Plan-confirm (ENG-221)
+	cfg.PlanConfirm = getbool(fileEnv, "PLAN_CONFIRM", false)
+	cfg.PlanConfirmLabel = getenv(fileEnv, "PLAN_CONFIRM_LABEL", DefaultPlanConfirmLabel)
 
 	return cfg, nil
 }

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -498,6 +498,30 @@ func (c *Client) AddLabel(ctx context.Context, issueID, labelID string) error {
 	return nil
 }
 
+// FetchIssueComments returns the most recent comments on an issue (up to 50).
+// Used by the plan-confirm flow (ENG-221) to check for approval comments
+// posted after the plan was submitted.
+func (c *Client) FetchIssueComments(ctx context.Context, issueID string) ([]Comment, error) {
+	query := `query($id: String!) {
+	  issue(id: $id) { comments(last: 50) { nodes { body user { name } } } }
+	}`
+
+	var resp struct {
+		Issue *struct {
+			Comments struct {
+				Nodes []Comment `json:"nodes"`
+			} `json:"comments"`
+		} `json:"issue"`
+	}
+	if err := c.Do(ctx, query, map[string]any{"id": issueID}, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Issue == nil {
+		return nil, fmt.Errorf("issue %s not found", issueID)
+	}
+	return resp.Issue.Comments.Nodes, nil
+}
+
 // Ping verifies the API key works by fetching the authenticated viewer.
 // Returns the viewer's display name on success.
 func (c *Client) Ping(ctx context.Context) (string, error) {

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -129,7 +129,10 @@ var systemCommentMarkers = []string{
 	"This comment thread is synced",
 }
 
-func isSystemComment(body string) bool {
+// IsSystemComment reports whether a comment body was posted automatically by
+// Noctra (or the Linear↔GitHub sync) and should be excluded from human
+// clarifications.
+func IsSystemComment(body string) bool {
 	// Classify only by the first non-empty line. A human who quotes one of our
 	// notifications (a "> 🚧 **Noctra…" block) and then adds their own reply
 	// must still count as a clarification — so a leading ">" quote is never a
@@ -161,7 +164,7 @@ func (i Issue) ClarificationComments() []string {
 	var out []string
 	for _, c := range i.Comments.Nodes {
 		body := strings.TrimSpace(c.Body)
-		if body == "" || isSystemComment(body) {
+		if body == "" || IsSystemComment(body) {
 			continue
 		}
 		author := "Someone"
@@ -196,6 +199,34 @@ func (i Issue) AssigneeName() string {
 		return ""
 	}
 	return i.Assignee.Name
+}
+
+// PlanConfirmCommentPrefix identifies Noctra's plan-confirm comments so they
+// can be distinguished from other system comments by the approval scanner.
+const PlanConfirmCommentPrefix = "📋 **Noctra: Implementation plan**"
+
+// HasLabel reports whether the issue carries a label with the given name
+// (case-insensitive, trimmed).
+func (i Issue) HasLabel(name string) bool {
+	target := strings.ToLower(strings.TrimSpace(name))
+	for _, l := range i.Labels.Nodes {
+		if strings.ToLower(strings.TrimSpace(l.Name)) == target {
+			return true
+		}
+	}
+	return false
+}
+
+// IsApprovalComment reports whether a comment body constitutes human approval
+// of a pending plan. Recognized signals: "go", "lgtm", "approved", "approve",
+// "👍", or the standard GitHub/Slack emoji shortcodes for thumbs-up.
+func IsApprovalComment(body string) bool {
+	s := strings.ToLower(strings.TrimSpace(body))
+	switch s {
+	case "go", "lgtm", "approved", "approve", "👍", ":thumbsup:", ":+1:":
+		return true
+	}
+	return false
 }
 
 // BackendLabelPrefix is the label-name prefix that selects a per-ticket

--- a/internal/linear/types_test.go
+++ b/internal/linear/types_test.go
@@ -117,3 +117,66 @@ func TestBackendLabel_EmptyIssue(t *testing.T) {
 		t.Errorf("empty issue BackendLabel() = %q, want empty", got)
 	}
 }
+
+func TestHasLabel(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels []Label
+		target string
+		want   bool
+	}{
+		{"no labels", nil, "plan-first", false},
+		{"exact match", []Label{{Name: "plan-first"}}, "plan-first", true},
+		{"case-insensitive", []Label{{Name: "Plan-First"}}, "plan-first", true},
+		{"whitespace trimmed", []Label{{Name: " plan-first "}}, "plan-first", true},
+		{"no match", []Label{{Name: "bug"}, {Name: "noctra"}}, "plan-first", false},
+		{"empty target", []Label{{Name: "bug"}}, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			issue := Issue{Labels: LabelConnection{Nodes: c.labels}}
+			if got := issue.HasLabel(c.target); got != c.want {
+				t.Errorf("HasLabel(%q) = %v, want %v", c.target, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsApprovalComment(t *testing.T) {
+	cases := []struct {
+		body string
+		want bool
+	}{
+		{"go", true},
+		{"Go", true},
+		{"GO", true},
+		{"  go  ", true},
+		{"lgtm", true},
+		{"LGTM", true},
+		{"approved", true},
+		{"approve", true},
+		{"👍", true},
+		{":thumbsup:", true},
+		{":+1:", true},
+		// Non-approval comments.
+		{"", false},
+		{"looks good but needs changes", false},
+		{"go ahead and fix the bug too", false},
+		{"not approved", false},
+		{"please go fix it", false},
+	}
+	for _, c := range cases {
+		t.Run(c.body, func(t *testing.T) {
+			if got := IsApprovalComment(c.body); got != c.want {
+				t.Errorf("IsApprovalComment(%q) = %v, want %v", c.body, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsSystemComment_PlanConfirmComment(t *testing.T) {
+	planComment := PlanConfirmCommentPrefix + "\n\n## Summary\nDo this and that."
+	if !IsSystemComment(planComment) {
+		t.Error("plan-confirm comment should be classified as a system comment")
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -56,6 +56,11 @@ type Pipeline struct {
 	// Sweep scheduler — nil when cfg.SweepEnabled is false.
 	sweeper *sweep.Scheduler
 
+	// Plan-confirm label ID — resolved at startup when plan-confirm is enabled
+	// and the label name resolves successfully. Empty if resolution fails
+	// (per-ticket label detection degrades to global-only mode).
+	planConfirmLabelID string
+
 	sessionStart time.Time
 
 	mu                sync.Mutex
@@ -63,6 +68,7 @@ type Pipeline struct {
 	cancels           map[string]context.CancelFunc // per-ticket cancel (for /kill)
 	killed            map[string]struct{}           // tickets killed via /kill
 	failedAttempts    map[string]int                // per-ticket retry counter
+	approvedPlans     map[string]string             // plan-confirm: approved plans keyed by identifier (ENG-221)
 	skipped           map[string]struct{}           // non-transient failures — never re-dispatched
 	totalDispatches   int
 	successCount      int
@@ -83,9 +89,9 @@ func New(cfg *config.Config) *Pipeline {
 	}
 
 	// Open the state store up front if any feature needs it: auto-iterate,
-	// sweep, or actor=app OAuth refresh persistence.
+	// sweep, plan-confirm, or actor=app OAuth refresh persistence.
 	var store *state.Store
-	if cfg.AutoIteratePRs || cfg.SweepEnabled || cfg.ActorAppConfigured() {
+	if cfg.AutoIteratePRs || cfg.SweepEnabled || cfg.PlanConfirm || cfg.PlanConfirmLabel != "" || cfg.ActorAppConfigured() {
 		s, err := state.OpenMigrating(cfg.StateDB, cfg.StateFile)
 		if err != nil {
 			slog.Warn("state store open failed", "path", cfg.StateDB, "legacy_path", cfg.StateFile, "err", err)
@@ -197,6 +203,22 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	}
 
 	slog.Info("resolved Linear states", "trigger_mode", p.cfg.TriggerMode, "in_review", p.cfg.InReviewState)
+
+	// Resolve the plan-confirm label ID so per-ticket activation works even
+	// when the global PLAN_CONFIRM is off. Best-effort: a missing label just
+	// disables per-ticket activation (the global flag still works).
+	if p.cfg.PlanConfirmLabel != "" {
+		plCtx, plCancel := context.WithTimeout(ctx, 30*time.Second)
+		plID, err := p.linear.ResolveLabelID(plCtx, p.cfg.PlanConfirmLabel)
+		plCancel()
+		if err != nil {
+			slog.Warn("plan-confirm label not found — per-ticket label activation disabled",
+				"label", p.cfg.PlanConfirmLabel, "err", err)
+		} else {
+			p.planConfirmLabelID = plID
+			slog.Info("resolved plan-confirm label", "label", p.cfg.PlanConfirmLabel, "id", plID)
+		}
+	}
 
 	p.startupCleanup(ctx)
 	p.banner()
@@ -317,6 +339,11 @@ func (p *Pipeline) pollOnce(ctx context.Context, wg *sync.WaitGroup) {
 	if dispatched >= p.cfg.MaxDispatches {
 		return
 	}
+
+	// Check for approved plans before fetching new tickets so approved
+	// plans can be dispatched in the same cycle (ENG-221).
+	p.pollPlanApprovals(ctx, wg, &available)
+
 	if available <= 0 {
 		slog.Debug("at capacity", "active", inFlight, "max", p.cfg.MaxConcurrent)
 		return
@@ -373,6 +400,14 @@ func (p *Pipeline) pollOnce(ctx context.Context, wg *sync.WaitGroup) {
 		if _, skip := p.skipped[issue.Identifier]; skip {
 			p.mu.Unlock()
 			slog.Debug("skipping (non-transient failure)", "id", issue.Identifier)
+			continue
+		}
+		// Skip tickets that have a pending plan awaiting approval (ENG-221).
+		// They stay in the trigger state but should not be re-dispatched until
+		// the human approves or the plan is cleared.
+		if p.hasPendingPlan(issue.Identifier) {
+			p.mu.Unlock()
+			slog.Debug("skipping (plan awaiting approval)", "id", issue.Identifier)
 			continue
 		}
 		ticketCtx, ticketCancel := context.WithCancel(ctx)
@@ -629,7 +664,14 @@ func (p *Pipeline) banner() {
 	fmt.Printf("   Review:         %s\n", reviewMode)
 	fmt.Printf("   Auto-iterate:   %s\n", autoIterMode)
 	fmt.Printf("   Release label:  %s\n", autoReleaseMode)
+	planConfirmMode := "Disabled"
+	if p.cfg.PlanConfirm {
+		planConfirmMode = fmt.Sprintf("On (all tickets, label %q)", p.cfg.PlanConfirmLabel)
+	} else if p.planConfirmLabelID != "" {
+		planConfirmMode = fmt.Sprintf("Per-ticket (label %q)", p.cfg.PlanConfirmLabel)
+	}
 	fmt.Printf("   Sweep:          %s\n", sweepMode)
+	fmt.Printf("   Plan-confirm:   %s\n", planConfirmMode)
 	fmt.Printf("   Max concurrent: %d\n", p.cfg.MaxConcurrent)
 	fmt.Printf("   Poll interval:  %s\n", p.cfg.PollInterval)
 	fmt.Printf("   Agent timeout:  %s\n", p.cfg.AgentTimeout)

--- a/internal/pipeline/plan.go
+++ b/internal/pipeline/plan.go
@@ -1,0 +1,359 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/agent"
+	"github.com/ahmadAlMezaal/noctra/internal/linear"
+	"github.com/ahmadAlMezaal/noctra/internal/notify"
+	"github.com/ahmadAlMezaal/noctra/internal/repo"
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+)
+
+// needsPlanConfirm reports whether a ticket should go through the plan-confirm
+// flow. True when either the global PLAN_CONFIRM=true is set, or the issue
+// carries the plan-confirm label (e.g. "plan-first").
+func (p *Pipeline) needsPlanConfirm(issue linear.Issue) bool {
+	if p.cfg.PlanConfirm {
+		return true
+	}
+	if p.cfg.PlanConfirmLabel != "" && issue.HasLabel(p.cfg.PlanConfirmLabel) {
+		return true
+	}
+	return false
+}
+
+// hasPendingPlan reports whether a ticket has a plan awaiting approval.
+// Caller must NOT hold p.mu (the store has its own locking).
+func (p *Pipeline) hasPendingPlan(identifier string) bool {
+	if p.store == nil {
+		return false
+	}
+	ps := p.store.GetPlan(identifier)
+	return ps.Plan != ""
+}
+
+// pollPlanApprovals checks all pending plans for human approval comments and
+// dispatches approved tickets for implementation. Called at the start of each
+// poll cycle. available is decremented for each dispatched ticket.
+func (p *Pipeline) pollPlanApprovals(ctx context.Context, wg *sync.WaitGroup, available *int) {
+	if p.store == nil {
+		return
+	}
+	plans := p.store.AllPlans()
+	if len(plans) == 0 {
+		return
+	}
+
+	slog.Debug("checking plan approvals", "pending", len(plans))
+
+	for identifier, ps := range plans {
+		if *available <= 0 {
+			break
+		}
+		p.mu.Lock()
+		if p.totalDispatches >= p.cfg.MaxDispatches {
+			p.mu.Unlock()
+			return
+		}
+		if _, dupe := p.active[identifier]; dupe {
+			p.mu.Unlock()
+			continue
+		}
+		p.mu.Unlock()
+
+		approved, err := p.checkPlanApproval(ctx, ps)
+		if err != nil {
+			slog.Warn("plan approval check failed", "id", identifier, "err", err)
+			continue
+		}
+		if !approved {
+			continue
+		}
+
+		slog.Info("plan approved — resuming implementation", "id", identifier)
+
+		// Fetch the full issue so we have all fields for the implementation
+		// prompt (title, description, comments, labels, project).
+		fctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		issue, err := p.linear.GetIssueByIdentifier(fctx, identifier)
+		cancel()
+		if err != nil {
+			slog.Warn("could not fetch issue for approved plan", "id", identifier, "err", err)
+			continue
+		}
+
+		// Re-fetch comments for the clarification list — GetIssueByIdentifier
+		// doesn't include them.
+		cctx, ccancel := context.WithTimeout(ctx, 30*time.Second)
+		comments, cerr := p.linear.FetchIssueComments(cctx, issue.ID)
+		ccancel()
+		if cerr == nil {
+			issue.Comments = linear.CommentConnection{Nodes: comments}
+		}
+
+		// Remove the plan-confirm label if it's a per-ticket label.
+		if p.planConfirmLabelID != "" && issue.HasLabel(p.cfg.PlanConfirmLabel) {
+			if err := p.linear.RemoveLabel(ctx, issue.ID, p.planConfirmLabelID); err != nil {
+				slog.Warn("could not remove plan-confirm label", "id", identifier, "err", err)
+			}
+		}
+
+		// Delete the plan from state — it's been approved and we're about to
+		// dispatch the implementation.
+		plan := ps.Plan
+		if err := p.store.DeletePlan(identifier); err != nil {
+			slog.Warn("could not delete plan state", "id", identifier, "err", err)
+		}
+
+		p.mu.Lock()
+		if _, dupe := p.active[identifier]; dupe {
+			p.mu.Unlock()
+			continue
+		}
+		ticketCtx, ticketCancel := context.WithCancel(ctx)
+		p.active[identifier] = struct{}{}
+		p.cancels[identifier] = ticketCancel
+		p.totalDispatches++
+		p.mu.Unlock()
+
+		*available--
+
+		wg.Add(1)
+		go func(iss linear.Issue, approvedPlan string) {
+			defer wg.Done()
+			defer p.markDone(iss.Identifier)
+			p.processWithPlan(ticketCtx, iss, approvedPlan)
+		}(issue, plan)
+	}
+}
+
+// checkPlanApproval fetches comments on the issue and checks whether any
+// non-system comment posted after the plan constitutes approval.
+func (p *Pipeline) checkPlanApproval(ctx context.Context, ps state.PlanState) (bool, error) {
+	fctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	comments, err := p.linear.FetchIssueComments(fctx, ps.IssueID)
+	if err != nil {
+		return false, err
+	}
+
+	// Comments are returned in chronological order (last: 50). We look for
+	// an approval comment that appears AFTER the plan comment. We detect the
+	// plan comment by its prefix.
+	pastPlan := false
+	for _, c := range comments {
+		body := c.Body
+		if !pastPlan {
+			if linear.IsSystemComment(body) && isPlanComment(body) {
+				pastPlan = true
+			}
+			continue
+		}
+		// Skip system comments after the plan (e.g. a follow-up Noctra notice).
+		if linear.IsSystemComment(body) {
+			continue
+		}
+		// Any non-system, approval-shaped comment after the plan = approved.
+		if linear.IsApprovalComment(body) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isPlanComment reports whether a comment body is the plan-confirm comment
+// Noctra posted.
+func isPlanComment(body string) bool {
+	return len(body) >= len(linear.PlanConfirmCommentPrefix) &&
+		body[:len(linear.PlanConfirmCommentPrefix)] == linear.PlanConfirmCommentPrefix
+}
+
+// processPlanOnly runs the agent in plan-only mode, posts the plan as a Linear
+// comment, and records the pending plan in the state store. The ticket stays
+// in its current state (trigger state / has trigger label) so the next poll
+// cycle can check for approval.
+func (p *Pipeline) processPlanOnly(ctx context.Context, issue linear.Issue) {
+	id := issue.Identifier
+	logger := slog.With("id", id)
+	logger.Info("running plan-only pass")
+
+	backend := p.resolveBackend(issue)
+
+	if p.cfg.TelegramVerbose {
+		p.telegram.Send(ctx, fmt.Sprintf("📋 *%s* — %s\nRunning plan-only pass.",
+			id, notify.EscapeMarkdown(issue.Title)))
+	}
+
+	logFile := filepath.Join(p.cfg.LogDir, id+".log")
+	if err := agent.AttemptHeader(logFile); err != nil {
+		logger.Warn("could not write attempt header", "err", err)
+	}
+
+	// ── Resolve target repo (same logic as process) ──────────────────────────
+	var (
+		resolved repo.Resolved
+		err      error
+	)
+	if ref, branch := issue.Project.RepoDirective(); ref != "" {
+		resolved, err = p.resolver.ResolveDirect(ctx, ref, branch)
+	} else {
+		resolved, err = p.resolver.Resolve(ctx, issue.ProjectName())
+	}
+	if err != nil {
+		logger.Error("repo resolution failed (plan)", "err", err)
+		var nte *repo.NonTransientError
+		if errors.As(err, &nte) {
+			p.skipPermanently(id)
+			if cerr := p.linear.Comment(ctx, issue.ID,
+				fmt.Sprintf("❌ **Noctra: No repo for this ticket**\n\n%s\n\nAdd a `Repo: owner/name` line to this ticket's **Linear project description**.",
+					err.Error())); cerr != nil {
+				slog.Warn("linear Comment failed", "issue_id", issue.ID, "err", cerr)
+			}
+			return
+		}
+		attempts := p.bumpFailed(id)
+		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
+			"❌ **Noctra: repo resolution failed** (attempt %d/%d)\n\n%s",
+			attempts, p.cfg.MaxRetries, err.Error()))
+		return
+	}
+
+	// Create a worktree so the agent can read the codebase.
+	wt, err := repo.CreateWorktree(ctx, p.cfg.WorktreeBase, id, resolved.Path, resolved.MainBranch)
+	if err != nil {
+		logger.Error("worktree creation failed (plan)", "err", err)
+		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
+			"❌ **Noctra: Setup failed**\n\nCould not create worktree for planning pass.\n\nTicket moved back to **%s**.",
+			p.cfg.TriggerState))
+		return
+	}
+
+	prompt := agent.BuildPlanPrompt(agent.BuildPromptInput{
+		Identifier:  id,
+		Title:       issue.Title,
+		Description: issue.Description,
+		Comments:    issue.ClarificationComments(),
+	})
+
+	offset := agent.OffsetBefore(logFile)
+
+	runErr := backend.Run(ctx, agent.RunOptions{
+		Workdir: wt.Path,
+		Prompt:  prompt,
+		LogFile: logFile,
+		Timeout: p.cfg.AgentTimeout,
+	})
+
+	// Check early exits.
+	if p.isKilled(id) {
+		logger.Info("plan-only run killed by user")
+		repo.CleanupWorktree(context.Background(), resolved.Path, p.cfg.WorktreeBase, id)
+		return
+	}
+	if ctx.Err() != nil {
+		logger.Info("plan-only run cancelled (shutdown)")
+		repo.CleanupWorktree(context.Background(), resolved.Path, p.cfg.WorktreeBase, id)
+		return
+	}
+
+	output := agent.ReadAfter(logFile, offset)
+
+	// Record usage from the plan pass (ENG-217).
+	usage := agent.ParseUsage(output)
+	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+	if reason := p.budget.ExceededReason(); reason != "" {
+		p.flagBudgetExceeded(reason)
+	}
+
+	// Always clean up the worktree — the plan pass is read-only.
+	repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
+
+	if errors.Is(runErr, agent.ErrTimedOut) {
+		p.bumpFailed(id)
+		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
+			"⏰ **Noctra: Plan generation timed out**\n\nTicket moved back to **%s**.",
+			p.cfg.TriggerState))
+		return
+	}
+
+	if runErr != nil {
+		attempts := p.bumpFailed(id)
+		logger.Warn("plan-only agent failed", "err", runErr, "attempt", attempts)
+		p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
+			"❌ **Noctra: Plan generation failed** (attempt %d/%d)\n\nThe agent failed to produce a plan. Will retry on next poll cycle.\n\nTicket moved back to **%s**.",
+			attempts, p.cfg.MaxRetries, p.cfg.TriggerState))
+		return
+	}
+
+	plan, ok := agent.ExtractPlan(output)
+	if !ok {
+		// Agent didn't produce a plan between markers — fall back to the
+		// full output as the plan (best effort).
+		plan = agent.ExtractSummary(output)
+		if plan == "" {
+			attempts := p.bumpFailed(id)
+			logger.Warn("plan-only agent produced no plan", "attempt", attempts)
+			p.linearBackToTrigger(ctx, issue.ID, fmt.Sprintf(
+				"❌ **Noctra: No plan produced** (attempt %d/%d)\n\nThe agent completed but did not produce an implementation plan.\n\nTicket moved back to **%s**.",
+				attempts, p.cfg.MaxRetries, p.cfg.TriggerState))
+			return
+		}
+	}
+	logger.Info("plan produced", "plan_length", len(plan))
+
+	// Post the plan as a Linear comment.
+	planComment := fmt.Sprintf(
+		"%s\n\n%s\n\n---\n\nReply with **go**, **lgtm**, or **👍** to approve and start implementation.",
+		linear.PlanConfirmCommentPrefix, plan)
+
+	if err := p.linear.Comment(ctx, issue.ID, planComment); err != nil {
+		logger.Warn("could not post plan comment", "err", err)
+	}
+
+	// Save the plan to the state store.
+	if p.store != nil {
+		if err := p.store.SavePlan(id, state.PlanState{
+			IssueID:   issue.ID,
+			Plan:      plan,
+			PlannedAt: time.Now(),
+		}); err != nil {
+			logger.Warn("could not save plan state", "err", err)
+		}
+	}
+
+	logger.Info("plan posted — awaiting approval", "id", id)
+	p.telegram.Send(ctx, fmt.Sprintf("📋 *%s* — %s\nPlan posted. Waiting for human approval.",
+		id, notify.EscapeMarkdown(issue.Title)))
+}
+
+// processWithPlan runs the full ticket implementation using the approved plan
+// as context. This is the same as process() but uses BuildPlanImplementPrompt
+// instead of BuildPrompt.
+func (p *Pipeline) processWithPlan(ctx context.Context, issue linear.Issue, plan string) {
+	id := issue.Identifier
+	logger := slog.With("id", id)
+	logger.Info("starting implementation with approved plan", "title", issue.Title)
+
+	// Store the plan in the pipeline map so process() can read it and use the
+	// plan-aware prompt builder.
+	p.mu.Lock()
+	if p.approvedPlans == nil {
+		p.approvedPlans = map[string]string{}
+	}
+	p.approvedPlans[id] = plan
+	p.mu.Unlock()
+
+	p.process(ctx, issue)
+
+	p.mu.Lock()
+	delete(p.approvedPlans, id)
+	p.mu.Unlock()
+}

--- a/internal/pipeline/plan.go
+++ b/internal/pipeline/plan.go
@@ -20,6 +20,9 @@ import (
 // flow. True when either the global PLAN_CONFIRM=true is set, or the issue
 // carries the plan-confirm label (e.g. "plan-first").
 func (p *Pipeline) needsPlanConfirm(issue linear.Issue) bool {
+	if p.store == nil {
+		return false
+	}
 	if p.cfg.PlanConfirm {
 		return true
 	}
@@ -98,20 +101,6 @@ func (p *Pipeline) pollPlanApprovals(ctx context.Context, wg *sync.WaitGroup, av
 			issue.Comments = linear.CommentConnection{Nodes: comments}
 		}
 
-		// Remove the plan-confirm label if it's a per-ticket label.
-		if p.planConfirmLabelID != "" && issue.HasLabel(p.cfg.PlanConfirmLabel) {
-			if err := p.linear.RemoveLabel(ctx, issue.ID, p.planConfirmLabelID); err != nil {
-				slog.Warn("could not remove plan-confirm label", "id", identifier, "err", err)
-			}
-		}
-
-		// Delete the plan from state — it's been approved and we're about to
-		// dispatch the implementation.
-		plan := ps.Plan
-		if err := p.store.DeletePlan(identifier); err != nil {
-			slog.Warn("could not delete plan state", "id", identifier, "err", err)
-		}
-
 		p.mu.Lock()
 		if _, dupe := p.active[identifier]; dupe {
 			p.mu.Unlock()
@@ -122,6 +111,20 @@ func (p *Pipeline) pollPlanApprovals(ctx context.Context, wg *sync.WaitGroup, av
 		p.cancels[identifier] = ticketCancel
 		p.totalDispatches++
 		p.mu.Unlock()
+
+		// Remove the plan-confirm label if it's a per-ticket label.
+		if p.planConfirmLabelID != "" && issue.HasLabel(p.cfg.PlanConfirmLabel) {
+			if err := p.linear.RemoveLabel(ctx, issue.ID, p.planConfirmLabelID); err != nil {
+				slog.Warn("could not remove plan-confirm label", "id", identifier, "err", err)
+			}
+		}
+
+		// Delete the plan from state — it's been approved and we've
+		// committed to dispatching the implementation.
+		plan := ps.Plan
+		if err := p.store.DeletePlan(identifier); err != nil {
+			slog.Warn("could not delete plan state", "id", identifier, "err", err)
+		}
 
 		*available--
 
@@ -145,25 +148,21 @@ func (p *Pipeline) checkPlanApproval(ctx context.Context, ps state.PlanState) (b
 		return false, err
 	}
 
-	// Comments are returned in chronological order (last: 50). We look for
-	// an approval comment that appears AFTER the plan comment. We detect the
-	// plan comment by its prefix.
-	pastPlan := false
-	for _, c := range comments {
-		body := c.Body
-		if !pastPlan {
-			if linear.IsSystemComment(body) && isPlanComment(body) {
-				pastPlan = true
-			}
-			continue
+	// Comments are returned in chronological order (last: 50). We iterate
+	// backwards to find the latest plan comment and check if any approval
+	// comment was posted after it. This avoids false-positive approvals
+	// from older plan attempts on re-planned tickets.
+	hasApprovalAfterPlan := false
+	for i := len(comments) - 1; i >= 0; i-- {
+		body := comments[i].Body
+		if linear.IsSystemComment(body) && isPlanComment(body) {
+			return hasApprovalAfterPlan, nil
 		}
-		// Skip system comments after the plan (e.g. a follow-up Noctra notice).
 		if linear.IsSystemComment(body) {
 			continue
 		}
-		// Any non-system, approval-shaped comment after the plan = approved.
 		if linear.IsApprovalComment(body) {
-			return true, nil
+			hasApprovalAfterPlan = true
 		}
 	}
 	return false, nil

--- a/internal/pipeline/plan_test.go
+++ b/internal/pipeline/plan_test.go
@@ -1,0 +1,84 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/ahmadAlMezaal/noctra/internal/config"
+	"github.com/ahmadAlMezaal/noctra/internal/linear"
+)
+
+func TestNeedsPlanConfirm_GlobalEnabled(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{PlanConfirm: true, PlanConfirmLabel: "plan-first"},
+	}
+	issue := linear.Issue{Identifier: "ENG-1", Labels: linear.LabelConnection{}}
+	if !p.needsPlanConfirm(issue) {
+		t.Error("expected needsPlanConfirm=true when PlanConfirm is globally enabled")
+	}
+}
+
+func TestNeedsPlanConfirm_LabelActivation(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{PlanConfirm: false, PlanConfirmLabel: "plan-first"},
+	}
+	issue := linear.Issue{
+		Identifier: "ENG-2",
+		Labels:     linear.LabelConnection{Nodes: []linear.Label{{Name: "plan-first"}}},
+	}
+	if !p.needsPlanConfirm(issue) {
+		t.Error("expected needsPlanConfirm=true when issue has plan-first label")
+	}
+}
+
+func TestNeedsPlanConfirm_NoActivation(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{PlanConfirm: false, PlanConfirmLabel: "plan-first"},
+	}
+	issue := linear.Issue{
+		Identifier: "ENG-3",
+		Labels:     linear.LabelConnection{Nodes: []linear.Label{{Name: "bug"}}},
+	}
+	if p.needsPlanConfirm(issue) {
+		t.Error("expected needsPlanConfirm=false when feature is off and label is absent")
+	}
+}
+
+func TestNeedsPlanConfirm_EmptyLabel(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{PlanConfirm: false, PlanConfirmLabel: ""},
+	}
+	issue := linear.Issue{
+		Identifier: "ENG-4",
+		Labels:     linear.LabelConnection{Nodes: []linear.Label{{Name: "plan-first"}}},
+	}
+	if p.needsPlanConfirm(issue) {
+		t.Error("expected needsPlanConfirm=false when PlanConfirmLabel is empty")
+	}
+}
+
+func TestHasPendingPlan_NilStore(t *testing.T) {
+	p := &Pipeline{store: nil}
+	if p.hasPendingPlan("ENG-1") {
+		t.Error("expected hasPendingPlan=false when store is nil")
+	}
+}
+
+func TestIsPlanComment(t *testing.T) {
+	cases := []struct {
+		body string
+		want bool
+	}{
+		{linear.PlanConfirmCommentPrefix + "\n\nSome plan here.", true},
+		{linear.PlanConfirmCommentPrefix, true},
+		{"Some random comment.", false},
+		{"📋 **Not Noctra**", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.body[:min(len(c.body), 30)], func(t *testing.T) {
+			if got := isPlanComment(c.body); got != c.want {
+				t.Errorf("isPlanComment(%q) = %v, want %v", c.body[:min(len(c.body), 30)], got, c.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/plan_test.go
+++ b/internal/pipeline/plan_test.go
@@ -1,15 +1,28 @@
 package pipeline
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/ahmadAlMezaal/noctra/internal/config"
 	"github.com/ahmadAlMezaal/noctra/internal/linear"
+	"github.com/ahmadAlMezaal/noctra/internal/state"
 )
+
+// testStore opens a throwaway SQLite store in t.TempDir().
+func testStore(t *testing.T) *state.Store {
+	t.Helper()
+	s, err := state.Open(filepath.Join(t.TempDir(), "test-state.db"))
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	return s
+}
 
 func TestNeedsPlanConfirm_GlobalEnabled(t *testing.T) {
 	p := &Pipeline{
-		cfg: &config.Config{PlanConfirm: true, PlanConfirmLabel: "plan-first"},
+		cfg:   &config.Config{PlanConfirm: true, PlanConfirmLabel: "plan-first"},
+		store: testStore(t),
 	}
 	issue := linear.Issue{Identifier: "ENG-1", Labels: linear.LabelConnection{}}
 	if !p.needsPlanConfirm(issue) {
@@ -19,7 +32,8 @@ func TestNeedsPlanConfirm_GlobalEnabled(t *testing.T) {
 
 func TestNeedsPlanConfirm_LabelActivation(t *testing.T) {
 	p := &Pipeline{
-		cfg: &config.Config{PlanConfirm: false, PlanConfirmLabel: "plan-first"},
+		cfg:   &config.Config{PlanConfirm: false, PlanConfirmLabel: "plan-first"},
+		store: testStore(t),
 	}
 	issue := linear.Issue{
 		Identifier: "ENG-2",
@@ -32,7 +46,8 @@ func TestNeedsPlanConfirm_LabelActivation(t *testing.T) {
 
 func TestNeedsPlanConfirm_NoActivation(t *testing.T) {
 	p := &Pipeline{
-		cfg: &config.Config{PlanConfirm: false, PlanConfirmLabel: "plan-first"},
+		cfg:   &config.Config{PlanConfirm: false, PlanConfirmLabel: "plan-first"},
+		store: testStore(t),
 	}
 	issue := linear.Issue{
 		Identifier: "ENG-3",
@@ -43,9 +58,21 @@ func TestNeedsPlanConfirm_NoActivation(t *testing.T) {
 	}
 }
 
+func TestNeedsPlanConfirm_NilStore(t *testing.T) {
+	p := &Pipeline{
+		cfg:   &config.Config{PlanConfirm: true, PlanConfirmLabel: "plan-first"},
+		store: nil,
+	}
+	issue := linear.Issue{Identifier: "ENG-5"}
+	if p.needsPlanConfirm(issue) {
+		t.Error("expected needsPlanConfirm=false when store is nil, even with PlanConfirm enabled")
+	}
+}
+
 func TestNeedsPlanConfirm_EmptyLabel(t *testing.T) {
 	p := &Pipeline{
-		cfg: &config.Config{PlanConfirm: false, PlanConfirmLabel: ""},
+		cfg:   &config.Config{PlanConfirm: false, PlanConfirmLabel: ""},
+		store: testStore(t),
 	}
 	issue := linear.Issue{
 		Identifier: "ENG-4",

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -57,6 +57,19 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// label overrides the configured default.
 	backend := p.resolveBackend(issue)
 
+	// ── Plan-confirm gate (ENG-221) ──────────────────────────────────────────
+	// When plan-confirm is active for this ticket and no approved plan is
+	// queued, run a plan-only pass instead of implementing. The plan is posted
+	// as a Linear comment and the ticket stays in the trigger state until a
+	// human approves.
+	p.mu.Lock()
+	_, hasApprovedPlan := p.approvedPlans[id]
+	p.mu.Unlock()
+	if p.needsPlanConfirm(issue) && !hasApprovedPlan {
+		p.processPlanOnly(ctx, issue)
+		return
+	}
+
 	if p.cfg.TelegramVerbose {
 		p.telegram.Send(ctx, fmt.Sprintf("🎯 *%s* — %s\nNoctra picked it up — working on it.",
 			id, notify.EscapeMarkdown(issue.Title)))
@@ -126,14 +139,24 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	logger.Info("worktree", "path", wt.Path, "branch", wt.Branch)
 
 	// ── Run Claude ───────────────────────────────────────────────────────────
-	prompt := agent.BuildPrompt(agent.BuildPromptInput{
+	promptInput := agent.BuildPromptInput{
 		Identifier:       id,
 		Title:            issue.Title,
 		Description:      issue.Description,
 		Comments:         issue.ClarificationComments(),
 		UseTeams:         p.cfg.UseAgentTeams,
 		AutoReleaseLabel: p.cfg.AutoReleaseLabel,
-	})
+	}
+	var prompt string
+	p.mu.Lock()
+	approvedPlan := p.approvedPlans[id]
+	p.mu.Unlock()
+	if approvedPlan != "" {
+		prompt = agent.BuildPlanImplementPrompt(promptInput, approvedPlan)
+		logger.Info("using approved plan as implementation context")
+	} else {
+		prompt = agent.BuildPrompt(promptInput)
+	}
 
 	logger.Info("running agent",
 		"backend", backend.Name(),

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -71,6 +71,17 @@ type SweepState struct {
 	LastRunAt time.Time `json:"last_run_at,omitempty"`
 }
 
+// PlanState tracks a ticket that has been planned but not yet approved
+// (ENG-221). Keyed by the issue's Linear identifier (e.g. "ENG-42").
+type PlanState struct {
+	// IssueID is the Linear issue UUID (needed for approval-comment fetching).
+	IssueID string `json:"issue_id"`
+	// Plan is the implementation plan the agent produced.
+	Plan string `json:"plan"`
+	// PlannedAt is when the plan was posted.
+	PlannedAt time.Time `json:"planned_at"`
+}
+
 // OAuthState persists the rotating Linear actor=app OAuth credentials (ENG-236)
 // so a restart does not lose a refresh-token rotation.
 type OAuthState struct {
@@ -160,6 +171,12 @@ func (s *Store) initSchema() error {
 		`CREATE TABLE IF NOT EXISTS sweep_states (
 			key TEXT PRIMARY KEY,
 			last_run_at TEXT
+		)`,
+		`CREATE TABLE IF NOT EXISTS plan_states (
+			identifier TEXT PRIMARY KEY,
+			issue_id TEXT NOT NULL DEFAULT '',
+			plan TEXT NOT NULL DEFAULT '',
+			planned_at TEXT
 		)`,
 		`CREATE TABLE IF NOT EXISTS oauth_state (
 			id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -448,6 +465,95 @@ func (s *Store) UpdateSweep(key string, fn func(*SweepState)) error {
 		return fmt.Errorf("write sweep state: %w", err)
 	}
 	return nil
+}
+
+// GetPlan returns the plan state for a ticket, or a zero-value PlanState if
+// no plan has been recorded. (ENG-221)
+func (s *Store) GetPlan(identifier string) PlanState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var r PlanState
+	var plannedAt sql.NullString
+	err := s.db.QueryRow(`SELECT issue_id, plan, planned_at FROM plan_states WHERE identifier = ?`, identifier).
+		Scan(&r.IssueID, &r.Plan, &plannedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PlanState{}
+	}
+	if err != nil {
+		slog.Warn("state get plan failed", "identifier", identifier, "err", err)
+		return PlanState{}
+	}
+	if t, convErr := parseNullTime(plannedAt); convErr == nil {
+		r.PlannedAt = t
+	}
+	return r
+}
+
+// SavePlan persists a plan awaiting human approval. (ENG-221)
+func (s *Store) SavePlan(identifier string, ps PlanState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.db.Exec(`INSERT INTO plan_states (identifier, issue_id, plan, planned_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(identifier) DO UPDATE SET
+			issue_id = excluded.issue_id,
+			plan = excluded.plan,
+			planned_at = excluded.planned_at`,
+		identifier,
+		ps.IssueID,
+		ps.Plan,
+		formatTime(ps.PlannedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("write plan state: %w", err)
+	}
+	return nil
+}
+
+// DeletePlan removes a plan record after approval or rejection. (ENG-221)
+func (s *Store) DeletePlan(identifier string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.db.Exec(`DELETE FROM plan_states WHERE identifier = ?`, identifier)
+	if err != nil {
+		return fmt.Errorf("delete plan state: %w", err)
+	}
+	return nil
+}
+
+// AllPlans returns every pending plan keyed by identifier. (ENG-221)
+func (s *Store) AllPlans() map[string]PlanState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rows, err := s.db.Query(`SELECT identifier, issue_id, plan, planned_at FROM plan_states`)
+	if err != nil {
+		slog.Warn("state all plans failed", "err", err)
+		return nil
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("close plan state rows failed", "err", err)
+		}
+	}()
+	out := map[string]PlanState{}
+	for rows.Next() {
+		var id string
+		var r PlanState
+		var plannedAt sql.NullString
+		if err := rows.Scan(&id, &r.IssueID, &r.Plan, &plannedAt); err != nil {
+			slog.Warn("scan plan state failed", "err", err)
+			return nil
+		}
+		if t, convErr := parseNullTime(plannedAt); convErr == nil {
+			r.PlannedAt = t
+		}
+		out[id] = r
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("iterate plan states failed", "err", err)
+		return nil
+	}
+	return out
 }
 
 func (s *Store) migrateLegacyJSON(path string) error {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -343,6 +343,149 @@ func TestUpdate_ReturnsReadError(t *testing.T) {
 	}
 }
 
+// ── Plan state tests (ENG-221) ──────────────────────────────────────────────
+
+func TestGetPlan_UnknownReturnsZero(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+	got := s.GetPlan("ENG-999")
+	if got != (PlanState{}) {
+		t.Errorf("expected zero PlanState, got %+v", got)
+	}
+}
+
+func TestSavePlan_PersistsAcrossReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	ps := PlanState{
+		IssueID:   "issue-uuid-123",
+		Plan:      "## Summary\nDo the thing.",
+		PlannedAt: now,
+	}
+	if err := s.SavePlan("ENG-42", ps); err != nil {
+		t.Fatalf("SavePlan: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen and verify.
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s2)
+	got := s2.GetPlan("ENG-42")
+	if got.IssueID != "issue-uuid-123" {
+		t.Errorf("IssueID: got %q, want %q", got.IssueID, "issue-uuid-123")
+	}
+	if got.Plan != "## Summary\nDo the thing." {
+		t.Errorf("Plan: got %q", got.Plan)
+	}
+	if !got.PlannedAt.Equal(now) {
+		t.Errorf("PlannedAt: got %v, want %v", got.PlannedAt, now)
+	}
+}
+
+func TestDeletePlan_RemovesRecord(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	if err := s.SavePlan("ENG-42", PlanState{Plan: "plan"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.GetPlan("ENG-42"); got.Plan == "" {
+		t.Fatal("expected plan to be saved")
+	}
+
+	if err := s.DeletePlan("ENG-42"); err != nil {
+		t.Fatalf("DeletePlan: %v", err)
+	}
+	if got := s.GetPlan("ENG-42"); got.Plan != "" {
+		t.Errorf("expected plan to be deleted, got %+v", got)
+	}
+}
+
+func TestDeletePlan_Idempotent(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	// Deleting a non-existent plan should not error.
+	if err := s.DeletePlan("ENG-999"); err != nil {
+		t.Fatalf("DeletePlan on non-existent: %v", err)
+	}
+}
+
+func TestAllPlans_ReturnsAllPending(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	if err := s.SavePlan("ENG-1", PlanState{Plan: "plan 1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SavePlan("ENG-2", PlanState{Plan: "plan 2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := s.AllPlans()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 plans, got %d", len(got))
+	}
+	if got["ENG-1"].Plan != "plan 1" || got["ENG-2"].Plan != "plan 2" {
+		t.Errorf("unexpected plans: %+v", got)
+	}
+}
+
+func TestAllPlans_EmptyWhenNone(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	got := s.AllPlans()
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %+v", got)
+	}
+}
+
+func TestSavePlan_UpsertOverwrites(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	if err := s.SavePlan("ENG-42", PlanState{Plan: "old plan"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SavePlan("ENG-42", PlanState{Plan: "new plan"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := s.GetPlan("ENG-42")
+	if got.Plan != "new plan" {
+		t.Errorf("expected upsert to overwrite, got %q", got.Plan)
+	}
+}
+
 func closeStore(t *testing.T, s *Store) {
 	t.Helper()
 	if err := s.Close(); err != nil {


### PR DESCRIPTION
## ENG-221: Plan-confirm step for vague tickets before implementing

**Linear:** https://linear.app/amazz/issue/ENG-221/plan-confirm-step-for-vague-tickets-before-implementing

## What was implemented

Implemented ENG-221: plan-confirm step for vague tickets before implementing.

**Config** (`internal/config/config.go`):
- Added `PlanConfirm bool` — global opt-in for plan-confirm on all tickets
- Added `PlanConfirmLabel string` (default `"plan-first"`) — per-ticket label activation

**Agent** (`internal/agent/plan_prompt.go` — new file):
- `BuildPlanPrompt()` — plan-only prompt that instructs the agent to read the codebase and produce a detailed implementation plan without writing any code
- `ExtractPlan()` — extracts the plan from between `===NOCTRA PLAN===` / `===END NOCTRA PLAN===` markers
- `BuildPlanImplementPrompt()` — implementation prompt that includes the approved plan as context, used when resuming after approval

**Linear** (`internal/linear/types.go`, `internal/linear/operations.go`):
- `HasLabel()` — checks if an issue carries a given label (case-insensitive)
- `IsApprovalComment()` — detects approval signals: "go", "lgtm", "approved", "approve", "👍"
- `IsSystemComment()` — exported (was lowercase `isSystemComment`) so the plan module can filter system comments
- `PlanConfirmCommentPrefix` — identifies Noctra's plan comments (`📋 **Noctra: Implementation plan**`)
- `FetchIssueComments()` — new query to fetch comments on an issue by ID (used for approval polling)

**State** (`internal/state/state.go`):
- Added `PlanState` type (IssueID, Plan, PlannedAt) and `plan_states` SQLite table
- `GetPlan()`, `SavePlan()`, `DeletePlan()`, `AllPlans()` — CRUD for pending plans

**Pipeline** (`internal/pipeline/plan.go` — new file, `internal/pipeline/pipeline.go`, `internal/pipeline/process.go`):
- `needsPlanConfirm()` — checks if a ticket should go through plan-confirm (global flag or per-ticket label)
- `hasPendingPlan()` — checks if a ticket has a plan awaiting approval in the state store
- `pollPlanApprovals()` — on every poll cycle, checks all pending plans for approval comments and dispatches approved tickets
- `checkPlanApproval()` — fetches issue comments and looks for an approval comment posted after the plan
- `processPlanOnly()` — runs the agent in plan-only mode, posts the plan as a Linear comment, saves to state store
- `processWithPlan()` — dispatches the implementation using the approved plan as context
- Modified `process()` to intercept tickets needing plan-confirm before implementation
- Modified `process()` to use `BuildPlanImplementPrompt` when an approved plan is available
- State store is opened when `PlanConfirm` or `PlanConfirmLabel` is configured
- Plan-confirm label ID is resolved at startup (best-effort)
- Banner displays plan-confirm mode status

**Flow**: Ticket arrives → `needsPlanConfirm()` checks global flag or per-ticket label → plan-only agent pass → plan posted as Linear comment → ticket stays in trigger state with plan saved in state store → on each poll, `pollPlanApprovals()` checks for approval comments → on approval, plan is deleted from state and ticket is dispatched with `BuildPlanImplementPrompt` → normal implementation flow continues.

**Tests**: 30+ new test cases across `agent/plan_prompt_test.go`, `linear/types_test.go`, `state/state_test.go`, and `pipeline/plan_test.go`. All existing tests continue to pass.

**Decisions**:
- Plan-confirm can be activated globally (`PLAN_CONFIRM=true`) or per-ticket via label — both work independently
- Approval detection uses exact match on "go", "lgtm", "approved", "approve", "👍" — must be the entire comment body (not a substring), preventing false positives from longer comments
- Plan comments are detected as system comments (via the `**Noctra` prefix) so they're excluded from clarification comments
- The plan-only pass creates and cleans up a worktree so the agent can read the codebase
- When a plan can't be extracted from markers, `ExtractSummary` is used as a fallback

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*