### PR TITLE
ci: lowercase GHCR image ref in native multi-arch docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # github.repository can contain uppercase (the owner login); Docker refs
+      # must be lowercase. metadata-action lowercases its own output, but the
+      # raw name we feed to build-push-action's `outputs:` does not, so derive it.
+      - name: Lowercase image name
+        id: img
+        run: echo "name=${IMAGE,,}" >> "$GITHUB_OUTPUT"
+        env:
+          IMAGE: ${{ env.IMAGE }}
+
       - id: meta
         uses: docker/metadata-action@v6
         with:
@@ -85,7 +94,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version || github.sha }}
-          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ steps.img.outputs.name }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
@@ -134,6 +143,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase image name
+        id: img
+        run: echo "name=${IMAGE,,}" >> "$GITHUB_OUTPUT"
+        env:
+          IMAGE: ${{ env.IMAGE }}
+
       - id: meta
         uses: docker/metadata-action@v6
         with:
@@ -148,8 +163,8 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+            $(printf '${{ steps.img.outputs.name }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ steps.img.outputs.name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Problem

The native multi-arch docker workflow (#198) failed on `main` — both arch builds errored with:

> `failed to parse ref "ghcr.io/ahmadAlMezaal/noctra": invalid reference format: repository name (ahmadAlMezaal/noctra) must be lowercase`

`github.repository` includes the owner login (`ahmadAlMezaal`), which has uppercase letters. Docker refs must be lowercase. The **old** single-job workflow only ever touched the image name through `metadata-action`, which auto-lowercases its output — so it worked. The new push-by-digest build feeds a **raw** image name to `build-push-action`'s `outputs:` and to `docker buildx imagetools`, neither of which lowercases. Hence the break.

## Fix

Derive a lowercased image name (`${IMAGE,,}`) in the `build` and `merge` jobs and use it for every raw ref (build `outputs:`, `imagetools create`, `imagetools inspect`). Tags from `metadata-action` were already lowercase, so they're unchanged.

## Note on verification

The PR `validate` job builds amd64-only with `push=false` and no image name, so it does **not** exercise this code path — same limitation as #198. The real proof is the `docker` run on `main` after merge: the `build` matrix + `merge` job should go green and `imagetools inspect` should list both `linux/amd64` and `linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)