### PR TITLE
feat: conventional commits for CC repos + reply on no-diff reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ PR poll loop → github.ListNoctraPRs → github.GetPR (comments+reviews+statusC
 - Trusted-reviewer rule (`watch.actionable`): humans always actionable; bots only if their login is in `TRUSTED_REVIEWERS`. (CI is not gated by this — it's not a person.)
 - Guards: per-PR `MAX_PR_ITERATIONS` cap, **shared** across review + CI re-engagements (timeouts/rate-limits don't count), restart-safe cursor in `state`, `pipeline.active` dedupe so a ticket can't be freshly-dispatched and iterated at once.
 - Cursors: comment/review are **timestamps** (naturally ordered; conversation + inline comments share the comment cursor). CI is keyed by **head commit SHA** (`LastCISHA`) — acted on once per commit, since a fix changes the SHA and makes a fresh failure eligible again.
-- Noctra does **not** post back to the GitHub PR thread (no replies, no thread resolution); it pushes a follow-up commit and notifies via Telegram/Linear.
+- After re-engaging, Noctra replies to and resolves the PR's unresolved review threads (`github.ReplyAndResolveThreads`): "Addressed in `<sha>`." when it pushed a follow-up commit, or a "no change needed" note when the iteration produced no diff (so a no-diff review isn't silent on GitHub). It also notifies via Telegram/Linear.
+- Commit subjects and the PR title follow Conventional Commits when the target repo uses them (`repo.UsesConventionalCommits` detects commitlint/semantic-release config). The type comes from the agent's release-bump suggestion (`patch`→`fix`, `minor`→`feat`, `major`→`feat!` + `BREAKING CHANGE`), so release tooling like semantic-release versions correctly; otherwise the default `feat: implement <id> — <title>` / `<id>: <title>` format is kept.
 
 ## Autonomous maintenance sweeps (optional)
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -267,10 +267,8 @@ type reviewThread struct {
 }
 
 // ReplyAndResolveThreads replies to and resolves all unresolved review threads
-// on a PR with a short note referencing the new commit SHA. Best-effort:
-// individual failures are logged, never returned. Mirrors the existing
-// "non-fatal on failure" posture for inline-comment fetches.
-func (c *Client) ReplyAndResolveThreads(ctx context.Context, prURL, sha string) {
+// on a PR with the given note. Best-effort: failures are logged, never returned.
+func (c *Client) ReplyAndResolveThreads(ctx context.Context, prURL, replyBody string) {
 	owner, repo, number, err := parsePRURL(prURL)
 	if err != nil {
 		slog.Warn("github: cannot parse PR URL for thread resolution", "url", prURL, "err", err)
@@ -286,8 +284,6 @@ func (c *Client) ReplyAndResolveThreads(ctx context.Context, prURL, sha string) 
 	if len(threads) == 0 {
 		return
 	}
-
-	replyBody := fmt.Sprintf("Addressed in %s.", sha)
 
 	resolved := 0
 	for _, t := range threads {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -374,7 +374,7 @@ echo "{}"
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	New().ReplyAndResolveThreads(context.Background(), "https://github.com/me/repo/pull/7", "abc1234")
+	New().ReplyAndResolveThreads(context.Background(), "https://github.com/me/repo/pull/7", "Addressed in abc1234.")
 
 	log, err := os.ReadFile(logFile)
 	if err != nil {

--- a/internal/pipeline/conventional.go
+++ b/internal/pipeline/conventional.go
@@ -1,0 +1,28 @@
+package pipeline
+
+import "fmt"
+
+// conventionalType maps a semver bump to a Conventional Commits type and
+// whether it's breaking. Returns ("", false) for an empty/"none" bump.
+func conventionalType(bump string) (typ string, breaking bool) {
+	switch bump {
+	case "patch":
+		return "fix", false
+	case "minor":
+		return "feat", false
+	case "major":
+		return "feat", true
+	default:
+		return "", false
+	}
+}
+
+// conventionalSubject formats a Conventional Commits subject, keeping the
+// ticket ID as a suffix, e.g. "feat: add X (ENG-42)" / "feat!: drop Y (ENG-42)".
+func conventionalSubject(typ string, breaking bool, title, id string) string {
+	bang := ""
+	if breaking {
+		bang = "!"
+	}
+	return fmt.Sprintf("%s%s: %s (%s)", typ, bang, title, id)
+}

--- a/internal/pipeline/conventional_test.go
+++ b/internal/pipeline/conventional_test.go
@@ -1,0 +1,32 @@
+package pipeline
+
+import "testing"
+
+func TestConventionalType(t *testing.T) {
+	cases := []struct {
+		bump     string
+		wantType string
+		wantBrk  bool
+	}{
+		{"patch", "fix", false},
+		{"minor", "feat", false},
+		{"major", "feat", true},
+		{"none", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		typ, brk := conventionalType(c.bump)
+		if typ != c.wantType || brk != c.wantBrk {
+			t.Errorf("conventionalType(%q) = (%q,%v), want (%q,%v)", c.bump, typ, brk, c.wantType, c.wantBrk)
+		}
+	}
+}
+
+func TestConventionalSubject(t *testing.T) {
+	if got := conventionalSubject("fix", false, "fix the bug", "ENG-7"); got != "fix: fix the bug (ENG-7)" {
+		t.Errorf("got %q", got)
+	}
+	if got := conventionalSubject("feat", true, "drop v1 API", "ENG-9"); got != "feat!: drop v1 API (ENG-9)" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -415,7 +415,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		logger.Info("pushed follow-up commit", "sha", sha, "branch", wt.Branch)
 
 		// Reply to and resolve addressed review threads (best-effort).
-		p.gh.ReplyAndResolveThreads(ctx, ch.PR.URL, sha)
+		p.gh.ReplyAndResolveThreads(ctx, ch.PR.URL, fmt.Sprintf("Addressed in %s.", sha))
 
 		// Completion heads-up (always — mirrors the 🔄 start ping and the
 		// ✅ "PR ready" ping the main ticket flow sends on success).
@@ -423,6 +423,9 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			notify.EscapeMarkdown(identifier), ch.PR.Number, engagementSummary(ch)))
 	} else {
 		logger.Info("no diff produced")
+		// Reply + resolve so a no-diff review isn't silent on GitHub.
+		p.gh.ReplyAndResolveThreads(ctx, ch.PR.URL,
+			"Noctra reviewed this but made no change — it appears already addressed or no longer applicable. Re-open if you'd like it revisited.")
 		p.notifier.Send(ctx, fmt.Sprintf("✅ *%s* — reviewed PR #%d, no code changes needed",
 			notify.EscapeMarkdown(identifier), ch.PR.Number))
 	}

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -410,10 +410,24 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// Commit only if there's staged work — if Claude already committed its own
 	// changes, the staged set is empty and a plain `git commit` would fail with
 	// "nothing to commit" and bounce a valid implementation (ENG-182).
-	commitMsg := appendCoAuthorTrailer(
-		fmt.Sprintf("feat: implement %s — %s\n\nImplemented by Noctra using %s\n\nLinear: %s",
-			id, issue.Title, backend.Label(), issue.URL),
-		backend.CoAuthor())
+	// In Conventional Commits repos, derive the commit type from the agent's
+	// release bump so subject + PR title drive release tooling. bump is reused
+	// for the release label below.
+	bump := agent.ReleaseBump(output)
+	ccType, breaking := conventionalType(bump)
+	useCC := ccType != "" && repo.UsesConventionalCommits(resolved.Path)
+
+	prTitle := fmt.Sprintf("%s: %s", id, issue.Title)
+	commitSubject := fmt.Sprintf("feat: implement %s — %s", id, issue.Title)
+	if useCC {
+		subj := conventionalSubject(ccType, breaking, issue.Title, id)
+		prTitle, commitSubject = subj, subj
+	}
+	commitBody := fmt.Sprintf("Implemented by Noctra using %s\n\nLinear: %s", backend.Label(), issue.URL)
+	if useCC && breaking {
+		commitBody += fmt.Sprintf("\n\nBREAKING CHANGE: %s", issue.Title)
+	}
+	commitMsg := appendCoAuthorTrailer(commitSubject+"\n\n"+commitBody, backend.CoAuthor())
 
 	staged, err := hasStagedChanges(ctx, wt.Path)
 	if err != nil {
@@ -463,7 +477,7 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	// ── gh pr create ─────────────────────────────────────────────────────────
 	prURL, err := ghCreatePR(ctx, resolved.Path,
-		fmt.Sprintf("%s: %s", id, issue.Title),
+		prTitle,
 		prBody, resolved.MainBranch, wt.Branch)
 	if err != nil {
 		logger.Error("gh pr create failed", "err", err)
@@ -476,7 +490,6 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 
 	// ── Auto-release label (ENG-231) ────────────────────────────────────────
 	if p.cfg.AutoReleaseLabel {
-		bump := agent.ReleaseBump(output)
 		label := agent.ReleaseLabel(bump, p.cfg.DefaultReleaseBump)
 		if label != "" {
 			if err := ghAddLabel(ctx, resolved.Path, prURL, label); err != nil {

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -411,11 +411,17 @@ func (p *Pipeline) process(ctx context.Context, issue linear.Issue) {
 	// changes, the staged set is empty and a plain `git commit` would fail with
 	// "nothing to commit" and bounce a valid implementation (ENG-182).
 	// In Conventional Commits repos, derive the commit type from the agent's
-	// release bump so subject + PR title drive release tooling. bump is reused
-	// for the release label below.
+	// release bump so subject + PR title drive release tooling. When no bump is
+	// available (e.g. AUTO_RELEASE_LABEL off), fall back to DefaultReleaseBump
+	// so a CC repo still gets a valid conventional type (else commitlint/CI
+	// rejects the title). bump is reused for the release label below.
 	bump := agent.ReleaseBump(output)
+	usesCC := repo.UsesConventionalCommits(resolved.Path)
+	if bump == "" && usesCC {
+		bump = p.cfg.DefaultReleaseBump
+	}
 	ccType, breaking := conventionalType(bump)
-	useCC := ccType != "" && repo.UsesConventionalCommits(resolved.Path)
+	useCC := ccType != "" && usesCC
 
 	prTitle := fmt.Sprintf("%s: %s", id, issue.Title)
 	commitSubject := fmt.Sprintf("feat: implement %s — %s", id, issue.Title)

--- a/internal/repo/conventional.go
+++ b/internal/repo/conventional.go
@@ -1,0 +1,33 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ccConfigFiles signal a repo uses commitlint or semantic-release.
+var ccConfigFiles = []string{
+	".releaserc", ".releaserc.json", ".releaserc.yaml", ".releaserc.yml",
+	".releaserc.js", ".releaserc.cjs", "release.config.js", "release.config.cjs",
+	"commitlint.config.js", "commitlint.config.cjs", "commitlint.config.ts",
+	".commitlintrc", ".commitlintrc.json", ".commitlintrc.yaml",
+	".commitlintrc.yml", ".commitlintrc.js", ".commitlintrc.cjs",
+}
+
+// UsesConventionalCommits reports whether the repo at repoPath uses
+// Conventional Commits, detected via config file or package.json reference.
+func UsesConventionalCommits(repoPath string) bool {
+	for _, name := range ccConfigFiles {
+		if _, err := os.Stat(filepath.Join(repoPath, name)); err == nil {
+			return true
+		}
+	}
+	if data, err := os.ReadFile(filepath.Join(repoPath, "package.json")); err == nil {
+		s := string(data)
+		if strings.Contains(s, "semantic-release") || strings.Contains(s, "commitlint") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/repo/conventional.go
+++ b/internal/repo/conventional.go
@@ -6,14 +6,19 @@ import (
 	"strings"
 )
 
-// ccConfigFiles signal a repo uses commitlint or semantic-release.
+// ccConfigFiles signal a repo uses a Conventional Commits / release tool
+// (commitlint, semantic-release, commitizen, standard-version).
 var ccConfigFiles = []string{
 	".releaserc", ".releaserc.json", ".releaserc.yaml", ".releaserc.yml",
 	".releaserc.js", ".releaserc.cjs", "release.config.js", "release.config.cjs",
 	"commitlint.config.js", "commitlint.config.cjs", "commitlint.config.ts",
 	".commitlintrc", ".commitlintrc.json", ".commitlintrc.yaml",
 	".commitlintrc.yml", ".commitlintrc.js", ".commitlintrc.cjs",
+	".czrc", ".cz.json", ".versionrc", ".versionrc.json", ".versionrc.js",
 }
+
+// ccPackageRefs are package.json substrings indicating a CC/release tool.
+var ccPackageRefs = []string{"semantic-release", "commitlint", "commitizen", "standard-version"}
 
 // UsesConventionalCommits reports whether the repo at repoPath uses
 // Conventional Commits, detected via config file or package.json reference.
@@ -25,8 +30,10 @@ func UsesConventionalCommits(repoPath string) bool {
 	}
 	if data, err := os.ReadFile(filepath.Join(repoPath, "package.json")); err == nil {
 		s := string(data)
-		if strings.Contains(s, "semantic-release") || strings.Contains(s, "commitlint") {
-			return true
+		for _, ref := range ccPackageRefs {
+			if strings.Contains(s, ref) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/repo/conventional_test.go
+++ b/internal/repo/conventional_test.go
@@ -1,0 +1,46 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUsesConventionalCommits(t *testing.T) {
+	t.Run("config file present", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, ".releaserc.json"), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !UsesConventionalCommits(dir) {
+			t.Error("want true when a semantic-release config exists")
+		}
+	})
+
+	t.Run("package.json reference", func(t *testing.T) {
+		dir := t.TempDir()
+		pkg := `{"devDependencies":{"semantic-release":"^23.0.0"}}`
+		if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkg), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !UsesConventionalCommits(dir) {
+			t.Error("want true when package.json references semantic-release")
+		}
+	})
+
+	t.Run("plain repo", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"x"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if UsesConventionalCommits(dir) {
+			t.Error("want false for a repo with no CC markers")
+		}
+	})
+
+	t.Run("missing repo", func(t *testing.T) {
+		if UsesConventionalCommits(filepath.Join(t.TempDir(), "nope")) {
+			t.Error("want false for a nonexistent path")
+		}
+	})
+}

--- a/internal/repo/conventional_test.go
+++ b/internal/repo/conventional_test.go
@@ -28,6 +28,27 @@ func TestUsesConventionalCommits(t *testing.T) {
 		}
 	})
 
+	t.Run("standard-version config file", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, ".versionrc"), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !UsesConventionalCommits(dir) {
+			t.Error("want true when a .versionrc exists")
+		}
+	})
+
+	t.Run("commitizen in package.json", func(t *testing.T) {
+		dir := t.TempDir()
+		pkg := `{"devDependencies":{"commitizen":"^4.0.0"}}`
+		if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkg), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !UsesConventionalCommits(dir) {
+			t.Error("want true when package.json references commitizen")
+		}
+	})
+
 	t.Run("plain repo", func(t *testing.T) {
 		dir := t.TempDir()
 		if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"x"}`), 0o600); err != nil {


### PR DESCRIPTION
Two related improvements to how Noctra names commits/PRs and how it engages on review threads.

## 1. Follow the target repo's commit convention

**Problem:** Noctra hardcodes `feat: implement <id> — <title>` for commits and `<id>: <title>` for PR titles. For a repo whose releases are driven by Conventional Commits (e.g. **semantic-release**), this is wrong:
- every implementation is `feat:` regardless of whether the ticket is a bugfix → wrong version bump;
- the PR title isn't conventional at all → on **squash-merge** (where GitHub uses the PR title as the commit subject) it triggers **no release**.

**Fix:** when the target repo uses Conventional Commits (`repo.UsesConventionalCommits` — detects commitlint / semantic-release config files or a `package.json` reference), the commit subject **and** the PR title are formatted conventionally, with the type derived from the agent's existing release-bump suggestion:

| bump | type |
|------|------|
| patch | `fix:` |
| minor | `feat:` |
| major | `feat!:` + `BREAKING CHANGE:` footer |

The ticket ID is kept as a suffix (`feat: <title> (ENG-42)`). Non-CC repos keep the existing format. Covers both squash- and merge-commit strategies (title and commit both fixed). The bump is also reused for the existing release label (was computed twice).

> Note: the conventional type needs the agent's `RELEASE:` line, which is emitted when `AUTO_RELEASE_LABEL=true`. With it off, the default format is kept.

## 2. Don't ghost reviewers on no-diff iterations

**Problem:** `ReplyAndResolveThreads` only ran when Noctra pushed a follow-up commit. When an iteration decided no change was needed (`no diff produced`), it was **silent on GitHub** — only Telegram/Discord got a ping. That's the "why didn't Noctra respond/resolve?" case.

**Fix:** `ReplyAndResolveThreads` now takes the reply body; the no-diff branch posts a "no change needed — re-open if you disagree" note and resolves the threads, matching the commit-path behavior.

## Tests
- `repo.UsesConventionalCommits`: config-file, package.json, plain-repo, missing-path cases.
- `conventionalType` / `conventionalSubject` mappings (incl. breaking).
- `ReplyAndResolveThreads` test updated for the new signature.
- `go build`/`test`/`vet`/`gofmt` all clean.

## Docs
- CLAUDE.md auto-iterate section updated (corrects the now-stale "no replies, no thread resolution" line and documents the conventional-commit rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)