### PR TITLE
fix: plan-confirm uses p.notifier, not removed p.telegram field

### DIFF
--- a/internal/pipeline/plan.go
+++ b/internal/pipeline/plan.go
@@ -187,7 +187,7 @@ func (p *Pipeline) processPlanOnly(ctx context.Context, issue linear.Issue) {
 	backend := p.resolveBackend(issue)
 
 	if p.cfg.TelegramVerbose {
-		p.telegram.Send(ctx, fmt.Sprintf("📋 *%s* — %s\nRunning plan-only pass.",
+		p.notifier.Send(ctx, fmt.Sprintf("📋 *%s* — %s\nRunning plan-only pass.",
 			id, notify.EscapeMarkdown(issue.Title)))
 	}
 
@@ -329,7 +329,7 @@ func (p *Pipeline) processPlanOnly(ctx context.Context, issue linear.Issue) {
 	}
 
 	logger.Info("plan posted — awaiting approval", "id", id)
-	p.telegram.Send(ctx, fmt.Sprintf("📋 *%s* — %s\nPlan posted. Waiting for human approval.",
+	p.notifier.Send(ctx, fmt.Sprintf("📋 *%s* — %s\nPlan posted. Waiting for human approval.",
 		id, notify.EscapeMarkdown(issue.Title)))
 }
 


### PR DESCRIPTION
## Problem

`main` does not compile. PR #200 (plan-confirm / ENG-221) references `p.telegram.Send(...)` in `internal/pipeline/plan.go`, but `Pipeline` has no `telegram` field — notifications go through `p.notifier` (`*notify.Multi`) since the Slack/Discord notifier refactor (#199). #200 was branched before that refactor and merged textually-clean but semantically broken:

```
internal/pipeline/plan.go:190:5: p.telegram undefined (type *Pipeline has no field or method telegram)
internal/pipeline/plan.go:332:4: p.telegram undefined (type *Pipeline has no field or method telegram)
```

## Fix

Swap the two `p.telegram.Send(ctx, …)` calls for `p.notifier.Send(ctx, …)`. Identical `(ctx, string)` signature, so it's a drop-in — and plan-confirm messages now also reach Slack/Discord, not just Telegram.

`go build ./...`, `go vet ./...`, and `go test ./...` are all clean on this branch.

> Note: this also unblocks #208 (Antigravity backend) — its CI is red only because it inherits this broken `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)