### PR TITLE
ENG-248: doctor: show the active agent backend in the report

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -42,6 +42,13 @@ func gather(scriptDir string) []check {
 		clis = []string{"git", "gh", config.AgentCLIs()[config.DefaultAgentBackend]}
 	}
 	for _, cli := range clis {
+		if loadErr == nil && cli == cfg.AgentCLI() {
+			checks = append(checks, check{
+				name:   "agent backend",
+				ok:     true,
+				detail: fmt.Sprintf("%s (%s)", cfg.AgentBackend, cfg.AgentCLI()),
+			})
+		}
 		checks = append(checks, checkCLI(cli))
 	}
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -43,11 +43,20 @@ func gather(scriptDir string) []check {
 	}
 	for _, cli := range clis {
 		if loadErr == nil && cli == cfg.AgentCLI() {
-			checks = append(checks, check{
-				name:   "agent backend",
-				ok:     true,
-				detail: fmt.Sprintf("%s (%s)", cfg.AgentBackend, cfg.AgentCLI()),
-			})
+			if _, valid := config.AgentCLIs()[cfg.AgentBackend]; valid {
+				checks = append(checks, check{
+					name:   "agent backend",
+					ok:     true,
+					detail: fmt.Sprintf("%s (%s)", cfg.AgentBackend, cfg.AgentCLI()),
+				})
+			} else {
+				checks = append(checks, check{
+					name:   "agent backend",
+					ok:     false,
+					detail: fmt.Sprintf("unsupported backend %q", cfg.AgentBackend),
+					hint:   "AGENT_BACKEND must be \"claude\", \"codex\", \"copilot\", or \"antigravity\"",
+				})
+			}
 		}
 		checks = append(checks, checkCLI(cli))
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -146,3 +146,55 @@ func TestRunJSON_ReturnsErrorOnFailure(t *testing.T) {
 		t.Error("expected JSON output even when checks fail")
 	}
 }
+
+func TestGather_AgentBackend(t *testing.T) {
+	tests := []struct {
+		backend string
+		cli     string
+	}{
+		{"antigravity", "agy"},
+		{"claude", "claude"},
+		{"copilot", "copilot"},
+		{"codex", "codex"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.backend, func(t *testing.T) {
+			t.Setenv("AGENT_BACKEND", tc.backend)
+
+			checks := gather(t.TempDir())
+
+			backendIndex := -1
+			cliIndex := -1
+
+			for i, c := range checks {
+				if c.name == "agent backend" {
+					backendIndex = i
+					if !c.ok {
+						t.Error("expected agent backend check to be ok=true")
+					}
+					expectedDetail := tc.backend + " (" + tc.cli + ")"
+					if c.detail != expectedDetail {
+						t.Errorf("expected detail %q, got %q", expectedDetail, c.detail)
+					}
+				}
+				if c.name == tc.cli {
+					cliIndex = i
+				}
+			}
+
+			if backendIndex == -1 {
+				t.Error("expected an 'agent backend' check in gather() results")
+			}
+			if cliIndex == -1 {
+				t.Error("expected CLI check in gather() results")
+			}
+
+			if backendIndex != -1 && cliIndex != -1 {
+				if backendIndex != cliIndex-1 {
+					t.Errorf("expected 'agent backend' check to be directly before '%s' check, but backend index is %d and CLI index is %d", tc.cli, backendIndex, cliIndex)
+				}
+			}
+		})
+	}
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -198,3 +198,30 @@ func TestGather_AgentBackend(t *testing.T) {
 		})
 	}
 }
+
+func TestGather_AgentBackend_Invalid(t *testing.T) {
+	t.Setenv("AGENT_BACKEND", "invalidbackend")
+
+	checks := gather(t.TempDir())
+
+	found := false
+	for _, c := range checks {
+		if c.name == "agent backend" {
+			found = true
+			if c.ok {
+				t.Error("expected agent backend check to fail for invalid backend")
+			}
+			if !strings.Contains(c.detail, "unsupported") {
+				t.Errorf("expected detail to mention unsupported, got %q", c.detail)
+			}
+			if !strings.Contains(c.hint, "must be") {
+				t.Errorf("expected hint to instruct valid choices, got %q", c.hint)
+			}
+		}
+	}
+
+	if !found {
+		t.Error("expected an 'agent backend' check in gather() results")
+	}
+}
+


### PR DESCRIPTION
## ENG-248: doctor: show the active agent backend in the report

**Linear:** https://linear.app/amazz/issue/ENG-248/doctor-show-the-active-agent-backend-in-the-report

## What was implemented

Implemented the ENG-248 ticket by adding an informational check for the active agent backend in `gather()` inside `internal/doctor/doctor.go`. The check displays the configured backend and its respective CLI (e.g. `antigravity (agy)`) and is positioned right before the path validation for that backend. Verified output formatting for both standard report and json modes, added a comprehensive table-driven unit test verifying all candidate backends, and ran the test suite successfully.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Google Antigravity*
<!-- noctra-authored -->