### PR TITLE
ci: skip the getnoctra.dev site ticket for patch releases

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -35,6 +35,7 @@ jobs:
     outputs:
       next_version: ${{ steps.version.outputs.next_version }}
       no_release: ${{ steps.check-label.outputs.no_release }}
+      bump_type: ${{ steps.check-label.outputs.bump_type }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -155,9 +156,14 @@ jobs:
   # File a site-update ticket once the release is published. Called here (not via
   # an `on: release` trigger) because the release above is created with
   # GITHUB_TOKEN, which does not trigger other workflows.
+  #
+  # Patch releases are skipped: they're internal fixes that almost never change
+  # anything user-facing on getnoctra.dev, and a per-patch ticket just churns
+  # (the agent ends up self-BLOCKing it). Minor/major releases still file a
+  # ticket; manual tags via release.yml are unaffected (deliberate).
   sync-site:
     needs: tag-on-merge
-    if: needs.tag-on-merge.outputs.no_release != 'true'
+    if: needs.tag-on-merge.outputs.no_release != 'true' && needs.tag-on-merge.outputs.bump_type != 'patch'
     uses: ./.github/workflows/site-sync-on-release.yml
     with:
       tag: ${{ needs.tag-on-merge.outputs.next_version }}


### PR DESCRIPTION
## Why

`site-sync-on-release.yml` files a *"getnoctra.dev: document vX.Y.Z"* ticket (straight into **Next**, so Noctra dispatches it immediately) on **every** release — including patch releases. Patches are internal fixes that almost never touch anything user-facing, so each one spawns a ticket the agent then has to self-`BLOCKED:` ("Nothing on the site needs updating for v0.17.1"). That's churn + Telegram/Discord noise for nothing.

## What

Gate the `sync-site` job in `tag-on-merge.yml` on `bump_type != 'patch'` (and expose `bump_type` from the `tag-on-merge` job's outputs).

- **Patch** releases → no site ticket.
- **Minor / major** releases → still file one (those carry features that may need site updates).
- **Manual tags** (`release.yml`) → unaffected; deliberate releases still file.
- The agent's existing self-`BLOCKED:` response stays as a safety net for minor/major releases that turn out not to need a site change.

One-file change; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)