### PR TITLE
fix: gofmt doctor_test.go (unblocks lint on main)

### DIFF
--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -224,4 +224,3 @@ func TestGather_AgentBackend_Invalid(t *testing.T) {
 		t.Error("expected an 'agent backend' check in gather() results")
 	}
 }
-


### PR DESCRIPTION
`internal/doctor/doctor_test.go` (merged in #214 / ENG-248) ends with a trailing blank line, which golangci-lint's `gofmt` linter rejects:

```
internal/doctor/doctor_test.go:227:1: File is not properly formatted (gofmt)
```

That leaves **main lint-red**, so every open PR fails the `lint` check on a file it didn't touch. This strips the trailing newline (`gofmt -w`). One-line fix; build + doctor tests pass.

After this merges, the other open PRs (#211, #212, #215) just need a rebase to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)