### PR TITLE
ENG-228: Learning loop: feed human post-merge edits back as per-repo signal

### DIFF
--- a/internal/agent/fix_prompt.go
+++ b/internal/agent/fix_prompt.go
@@ -48,6 +48,7 @@ type FixPromptInput struct {
 	PRURL       string
 	Feedback    []FeedbackItem
 	CI          []CIItem
+	RepoLessons string // per-repo lessons
 }
 
 // BuildFixPrompt renders a fix prompt for Claude when reviewers (or bots in
@@ -95,6 +96,12 @@ func BuildFixPrompt(in FixPromptInput) string {
 		}
 	}
 
+	lessonsSection := ""
+	if in.RepoLessons != "" {
+		lessonsSection = "\n\n## Repository Lessons & Conventions (from post-merge human edits to previous PRs):\n" +
+			in.RepoLessons + "\n"
+	}
+
 	return fmt.Sprintf(`There is new activity on the PR you opened for this Linear ticket — review feedback and/or failing CI. Address it on the same branch; your changes will be pushed as a follow-up commit.
 
 ## Ticket: %s — %s
@@ -103,7 +110,7 @@ func BuildFixPrompt(in FixPromptInput) string {
 ## PR
 #%d — %s
 
-%s## Rules
+%s%s## Rules
 
 - Address ONLY the feedback and CI failures listed above. Do not refactor unrelated code or pick up new work.
 - If CI is failing, reproduce it locally (run the relevant tests / linter), fix the root cause, and re-run to confirm it passes.
@@ -115,7 +122,7 @@ func BuildFixPrompt(in FixPromptInput) string {
 ## When done
 
 Summarise what you addressed and how, and call out anything you deliberately skipped (with the reason).
-`, in.Identifier, in.Title, desc, in.PRNumber, in.PRURL, sections.String())
+`, in.Identifier, in.Title, desc, in.PRNumber, in.PRURL, lessonsSection, sections.String())
 }
 
 func sectionLabel(kind, state string) string {

--- a/internal/agent/fix_prompt_test.go
+++ b/internal/agent/fix_prompt_test.go
@@ -112,3 +112,19 @@ func TestSectionLabel(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildFixPrompt_IncludesLessons(t *testing.T) {
+	out := BuildFixPrompt(FixPromptInput{
+		Identifier:  "ENG-42",
+		Title:       "Title",
+		PRNumber:    59,
+		PRURL:       "url",
+		RepoLessons: "- Lesson A\n- Lesson B",
+	})
+	if !strings.Contains(out, "## Repository Lessons & Conventions") {
+		t.Errorf("expected lessons heading in fix prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "- Lesson A") {
+		t.Errorf("expected lesson content in fix prompt:\n%s", out)
+	}
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -19,6 +19,8 @@ type BuildPromptInput struct {
 	// AutoReleaseLabel enables the RELEASE: instruction in the prompt,
 	// asking the agent to suggest a semver bump level.
 	AutoReleaseLabel bool
+	// RepoLessons contains per-repo lessons and conventions from human post-merge edits.
+	RepoLessons string
 }
 
 // BuildPrompt returns the prompt sent to Claude for a ticket. Two flavors:
@@ -36,6 +38,12 @@ func BuildPrompt(in BuildPromptInput) string {
 			strings.Join(in.Comments, "\n\n")
 	}
 
+	lessonsSection := ""
+	if in.RepoLessons != "" {
+		lessonsSection = "\n\n## Repository Lessons & Conventions (from post-merge human edits to previous PRs):\n" +
+			in.RepoLessons
+	}
+
 	releaseInstruction := ""
 	if in.AutoReleaseLabel {
 		releaseInstruction = `
@@ -50,7 +58,7 @@ Guidelines: none = docs/chore/internal-only, patch = bug fix, minor = new featur
 		return fmt.Sprintf(`You are a lead agent implementing a ticket. You have a team of agents available.
 
 ## Ticket: %s — %s
-%s%s
+%s%s%s
 
 ## Your approach:
 1. First, read the codebase to understand the project structure, conventions, and testing patterns.
@@ -75,13 +83,13 @@ Provide a brief summary of what was implemented and any important decisions made
 ===NOCTRA SUMMARY===
 <your summary here>
 ===END NOCTRA SUMMARY===
-%s`, in.Identifier, in.Title, desc, discussion, releaseInstruction)
+%s`, in.Identifier, in.Title, desc, discussion, lessonsSection, releaseInstruction)
 	}
 
 	return fmt.Sprintf(`You are implementing a ticket.
 
 ## Ticket: %s — %s
-%s%s
+%s%s%s
 
 ## Instructions:
 1. Read the codebase to understand the project structure and conventions.
@@ -102,5 +110,5 @@ Provide a brief summary of what was implemented and any important decisions made
 ===NOCTRA SUMMARY===
 <your summary here>
 ===END NOCTRA SUMMARY===
-%s`, in.Identifier, in.Title, desc, discussion, releaseInstruction)
+%s`, in.Identifier, in.Title, desc, discussion, lessonsSection, releaseInstruction)
 }

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -89,3 +89,18 @@ func TestBuildPrompt_ReleaseInstructionInTeamsFlavor(t *testing.T) {
 		t.Errorf("teams prompt should include RELEASE instruction when AutoReleaseLabel=true:\n%s", out)
 	}
 }
+
+func TestBuildPrompt_IncludesLessons(t *testing.T) {
+	out := BuildPrompt(BuildPromptInput{
+		Identifier:  "ENG-1",
+		Title:       "Test",
+		Description: "Desc",
+		RepoLessons: "- Lesson A\n- Lesson B",
+	})
+	if !strings.Contains(out, "## Repository Lessons & Conventions") {
+		t.Errorf("expected lessons heading in prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "- Lesson A") {
+		t.Errorf("expected lesson content in prompt:\n%s", out)
+	}
+}

--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -1,0 +1,145 @@
+package lessons
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os/exec"
+	"strings"
+
+	"github.com/ahmadAlMezaal/noctra/internal/github"
+	"github.com/ahmadAlMezaal/noctra/internal/repo"
+	"github.com/ahmadAlMezaal/noctra/internal/review"
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+)
+
+// ProcessMergedPRs scans all tracked PRs in the store, checks if they have merged
+// (or closed), computes the diff of human edits if merged, calls the Gemini review
+// gate to update per-repo durable notes, and marks them as processed.
+func ProcessMergedPRs(ctx context.Context, store *state.Store, gh *github.Client, resolver *repo.Resolver, reviewGate *review.Gate) {
+	if store == nil || gh == nil || resolver == nil {
+		return
+	}
+
+	prs := store.All()
+	for prURL, cursor := range prs {
+		if cursor.MergedProcessed {
+			continue
+		}
+
+		logger := slog.With("pr", prURL, "ticket", cursor.TicketID)
+
+		// 1. Fetch the latest PR details from GitHub to see its state
+		details, err := gh.GetPR(ctx, prURL)
+		if err != nil {
+			logger.Warn("lessons: failed to get PR details", "err", err)
+			continue
+		}
+
+		if details.State == "OPEN" {
+			// Still open, check back later.
+			continue
+		}
+
+		if details.State == "CLOSED" {
+			// Closed without merge. Nothing to summarize, just mark processed.
+			logger.Info("lessons: PR closed without merging; marking processed")
+			if err := store.Update(prURL, func(r *state.PRState) {
+				r.MergedProcessed = true
+			}); err != nil {
+				logger.Warn("lessons: failed to update PR state", "err", err)
+			}
+			continue
+		}
+
+		if details.State == "MERGED" {
+			logger.Info("lessons: PR merged; processing human post-merge edits")
+			if err := processMergedPR(ctx, store, resolver, reviewGate, prURL, cursor); err != nil {
+				logger.Error("lessons: failed to process merged PR", "err", err)
+			}
+
+			// Regardless of success/failure, mark it as processed so we don't block
+			// the polling loop or retry indefinitely on failing git diffs or API errors.
+			if err := store.Update(prURL, func(r *state.PRState) {
+				r.MergedProcessed = true
+			}); err != nil {
+				logger.Warn("lessons: failed to update PR state", "err", err)
+			}
+		}
+	}
+}
+
+func processMergedPR(ctx context.Context, store *state.Store, resolver *repo.Resolver, reviewGate *review.Gate, prURL string, cursor state.PRState) error {
+	ownerRepo, err := extractOwnerRepoFromPRURL(prURL)
+	if err != nil {
+		return fmt.Errorf("extract owner/repo: %w", err)
+	}
+
+	resolved, err := resolver.ResolveDirect(ctx, ownerRepo, "")
+	if err != nil {
+		return fmt.Errorf("resolve repo: %w", err)
+	}
+	repoDir := resolved.Path
+
+	// Fetch the PR head to FETCH_HEAD
+	prNumStr := prURL[strings.LastIndex(prURL, "/")+1:]
+	fetchCmd := exec.CommandContext(ctx, "git", "-C", repoDir, "fetch", "origin", fmt.Sprintf("pull/%s/head", prNumStr))
+	if err := fetchCmd.Run(); err != nil {
+		return fmt.Errorf("git fetch PR head (pull/%s/head): %w", prNumStr, err)
+	}
+
+	if cursor.LastPushedSHA == "" {
+		return fmt.Errorf("no LastPushedSHA recorded for this PR; cannot compute human edits")
+	}
+
+	// Diff between Noctra's last pushed commit and FETCH_HEAD (the final merged PR branch head)
+	diffCmd := exec.CommandContext(ctx, "git", "-C", repoDir, "diff", cursor.LastPushedSHA, "FETCH_HEAD")
+	var diffOut bytes.Buffer
+	diffCmd.Stdout = &diffOut
+	if err := diffCmd.Run(); err != nil {
+		return fmt.Errorf("git diff %s..FETCH_HEAD: %w", cursor.LastPushedSHA, err)
+	}
+
+	diffStr := diffOut.String()
+	if strings.TrimSpace(diffStr) == "" {
+		slog.Info("lessons: no human edits detected (empty diff)", "pr", prURL)
+		return nil
+	}
+
+	if reviewGate == nil || !reviewGate.Enabled() {
+		return errors.New("Gemini review gate is not enabled/configured; cannot summarize human edits")
+	}
+
+	repoSlug := repo.Slug(ownerRepo)
+	existingLessons, err := store.GetLessons(repoSlug)
+	if err != nil {
+		return fmt.Errorf("get existing lessons: %w", err)
+	}
+
+	newLessons, err := reviewGate.SummarizeLessons(ctx, existingLessons, diffStr)
+	if err != nil {
+		return fmt.Errorf("summarize lessons: %w", err)
+	}
+
+	if err := store.SaveLessons(repoSlug, newLessons); err != nil {
+		return fmt.Errorf("save lessons: %w", err)
+	}
+
+	slog.Info("lessons: successfully consolidated repo lessons", "repo", repoSlug, "lessons_len", len(newLessons))
+	return nil
+}
+
+func extractOwnerRepoFromPRURL(prURL string) (string, error) {
+	u, err := url.Parse(prURL)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("PR URL path too short: %q", u.Path)
+	}
+	return parts[0] + "/" + parts[1], nil
+}

--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -110,7 +110,7 @@ func processMergedPR(ctx context.Context, store *state.Store, resolver *repo.Res
 	}
 
 	if reviewGate == nil || !reviewGate.Enabled() {
-		return errors.New("Gemini review gate is not enabled/configured; cannot summarize human edits")
+		return errors.New("gemini review gate is not enabled/configured; cannot summarize human edits")
 	}
 
 	repoSlug := repo.Slug(ownerRepo)

--- a/internal/lessons/lessons_test.go
+++ b/internal/lessons/lessons_test.go
@@ -60,7 +60,11 @@ esac
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	defer func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("failed to close store: %v", err)
+		}
+	}()
 
 	// Setup tracked PRs
 	const pr1 = "https://github.com/owner/repo/pull/1"

--- a/internal/lessons/lessons_test.go
+++ b/internal/lessons/lessons_test.go
@@ -1,0 +1,140 @@
+package lessons
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ahmadAlMezaal/noctra/internal/github"
+	"github.com/ahmadAlMezaal/noctra/internal/repo"
+	"github.com/ahmadAlMezaal/noctra/internal/review"
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+)
+
+func TestProcessMergedPRs(t *testing.T) {
+	// Create mock binaries
+	dir := t.TempDir()
+
+	// Mock 'gh' script
+	ghScript := `#!/bin/sh
+case "$*" in
+	*view*pull/1*)
+		echo '{"url":"https://github.com/owner/repo/pull/1","number":1,"state":"MERGED","headRefOid":"def456"}'
+		;;
+	*view*pull/2*)
+		echo '{"url":"https://github.com/owner/repo/pull/2","number":2,"state":"CLOSED","headRefOid":"xyz789"}'
+		;;
+	*view*pull/3*)
+		echo '{"url":"https://github.com/owner/repo/pull/3","number":3,"state":"OPEN","headRefOid":"uvw012"}'
+		;;
+	*)
+		exit 1
+		;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(ghScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock 'git' script
+	gitScript := `#!/bin/sh
+case "$*" in
+	*diff*)
+		echo "dummy human edit diff content"
+		;;
+	*)
+		exit 0
+		;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(gitScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Create test state store
+	dbPath := filepath.Join(dir, "state.db")
+	store, err := state.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// Setup tracked PRs
+	const pr1 = "https://github.com/owner/repo/pull/1"
+	const pr2 = "https://github.com/owner/repo/pull/2"
+	const pr3 = "https://github.com/owner/repo/pull/3"
+
+	// Merged, has last pushed SHA
+	if err := store.Update(pr1, func(r *state.PRState) {
+		r.TicketID = "ENG-1"
+		r.LastPushedSHA = "abc123"
+		r.MergedProcessed = false
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Closed, not merged
+	if err := store.Update(pr2, func(r *state.PRState) {
+		r.TicketID = "ENG-2"
+		r.LastPushedSHA = "abc123"
+		r.MergedProcessed = false
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open
+	if err := store.Update(pr3, func(r *state.PRState) {
+		r.TicketID = "ENG-3"
+		r.LastPushedSHA = "abc123"
+		r.MergedProcessed = false
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ghClient := github.New()
+	resolver := &repo.Resolver{
+		ReposBase: dir,
+		RepoPath:  dir,
+	}
+
+	// Mock review gate using a dummy API key to make it "enabled"
+	reviewGate := review.New("dummy_key", "gemini-2.5-pro")
+	geminiScript := `#!/bin/sh
+echo "Lesson 1: updated lessons from mock"
+`
+	if err := os.WriteFile(filepath.Join(dir, "gemini"), []byte(geminiScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	reviewGate.Mode = "cli"
+
+	ProcessMergedPRs(context.Background(), store, ghClient, resolver, reviewGate)
+
+	// Check if merged PR was processed and updated the lessons
+	p1State := store.Get(pr1)
+	if !p1State.MergedProcessed {
+		t.Error("expected pr1 MergedProcessed to be true")
+	}
+
+	lessons, err := store.GetLessons("owner-repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lessons == "" {
+		t.Error("expected lessons to be non-empty for owner-repo")
+	}
+
+	// Check if closed PR was marked processed (but no lessons update expected)
+	p2State := store.Get(pr2)
+	if !p2State.MergedProcessed {
+		t.Error("expected pr2 MergedProcessed to be true")
+	}
+
+	// Check if open PR was skipped (MergedProcessed should still be false)
+	p3State := store.Get(pr3)
+	if p3State.MergedProcessed {
+		t.Error("expected pr3 MergedProcessed to be false")
+	}
+}

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ahmadAlMezaal/noctra/internal/agent"
 	"github.com/ahmadAlMezaal/noctra/internal/github"
+	"github.com/ahmadAlMezaal/noctra/internal/lessons"
 	"github.com/ahmadAlMezaal/noctra/internal/notify"
 	"github.com/ahmadAlMezaal/noctra/internal/repo"
 	"github.com/ahmadAlMezaal/noctra/internal/state"
@@ -56,6 +57,8 @@ func (p *Pipeline) runWatcher(ctx context.Context, wg *sync.WaitGroup) {
 // events, and dispatch iteratePR goroutines for everything that is actionable
 // (and not at the iteration cap).
 func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
+	lessons.ProcessMergedPRs(ctx, p.store, p.gh, p.resolver, p.review)
+
 	scanCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	changes, err := p.watcher.Scan(scanCtx)
 	cancel()
@@ -288,6 +291,14 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		}
 	}
 
+	var repoLessons string
+	if p.store != nil {
+		repoSlug := repo.Slug(filepath.Base(resolved.Path))
+		if l, err := p.store.GetLessons(repoSlug); err == nil {
+			repoLessons = l
+		}
+	}
+
 	prompt := agent.BuildFixPrompt(agent.FixPromptInput{
 		Identifier:  identifier,
 		Title:       title,
@@ -296,6 +307,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		PRURL:       ch.PR.URL,
 		Feedback:    items,
 		CI:          ciItems,
+		RepoLessons: repoLessons,
 	})
 
 	logFile := filepath.Join(p.cfg.LogDir, identifier+".log")
@@ -413,6 +425,16 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		}
 		sha := gitHeadShort(ctx, wt.Path)
 		logger.Info("pushed follow-up commit", "sha", sha, "branch", wt.Branch)
+
+		// Persist the full pushed HEAD commit SHA in state for lessons tracking
+		fullSHA := gitHead(ctx, wt.Path)
+		if fullSHA != "" {
+			if err := p.store.Update(ch.PR.URL, func(r *state.PRState) {
+				r.LastPushedSHA = fullSHA
+			}); err != nil {
+				logger.Warn("could not persist LastPushedSHA in PR state", "err", err)
+			}
+		}
 
 		// Reply to and resolve addressed review threads (best-effort).
 		p.gh.ReplyAndResolveThreads(ctx, ch.PR.URL, fmt.Sprintf("Addressed in %s.", sha))

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -139,6 +139,14 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	}
 	logger.Info("worktree", "path", wt.Path, "branch", wt.Branch)
 
+	var repoLessons string
+	if p.store != nil {
+		repoSlug := repo.Slug(filepath.Base(resolved.Path))
+		if l, err := p.store.GetLessons(repoSlug); err == nil {
+			repoLessons = l
+		}
+	}
+
 	// ── Run Claude ───────────────────────────────────────────────────────────
 	promptInput := agent.BuildPromptInput{
 		Identifier:       id,
@@ -147,6 +155,7 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		Comments:         issue.ClarificationComments(),
 		UseTeams:         p.cfg.UseAgentTeams,
 		AutoReleaseLabel: p.cfg.AutoReleaseLabel,
+		RepoLessons:      repoLessons,
 	}
 	var prompt string
 	p.mu.Lock()
@@ -541,9 +550,13 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	// Persist the chosen backend so auto-iterate uses the same one for
 	// follow-up commits on this PR.
 	if p.store != nil {
+		headSHA := gitHead(ctx, wt.Path)
 		if err := p.store.Update(prURL, func(r *state.PRState) {
 			r.TicketID = id
 			r.AgentBackend = backend.Name()
+			if headSHA != "" {
+				r.LastPushedSHA = headSHA
+			}
 		}); err != nil {
 			logger.Warn("could not persist backend in PR state", "err", err)
 		}
@@ -728,6 +741,17 @@ func ghAddLabel(ctx context.Context, repoPath, prURL, label string) error {
 // gitHeadShort returns the abbreviated HEAD commit SHA, or "" on error.
 func gitHeadShort(ctx context.Context, workdir string) string {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--short", "HEAD")
+	cmd.Dir = workdir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitHead returns the full HEAD commit SHA, or "" on error.
+func gitHead(ctx context.Context, workdir string) string {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "HEAD")
 	cmd.Dir = workdir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/review/gemini.go
+++ b/internal/review/gemini.go
@@ -252,3 +252,45 @@ func reviewVerdict(text string) string {
 	}
 	return ""
 }
+
+// SummarizeLessons uses Gemini to consolidate a new post-merge diff with existing lessons.
+func (g *Gate) SummarizeLessons(ctx context.Context, existingLessons, diff string) (string, error) {
+	if !g.Enabled() {
+		return "", errors.New("gemini not enabled")
+	}
+
+	const capBytes = 60000
+	if len(diff) > capBytes {
+		diff = diff[:capBytes] + "\n\n[Diff truncated...]"
+	}
+
+	prompt := fmt.Sprintf(`You are updating a compact, durable list of lessons and conventions for a repository based on human post-merge edits to AI-generated code.
+
+Existing lessons/conventions for this repository:
+%s
+
+New human edits (diff of changes made by human on top of the AI's version):
+%s
+
+Incorporate any new correction patterns, missing conventions, or style guidelines from the new edits into the existing list.
+Follow these rules:
+1. Keep the final list extremely concise and action-oriented.
+2. Keep the final list under 10 bullet points / 300 words total (size-bounded).
+3. Directly focus on what the AI got wrong and how to avoid/fix it in the future.
+4. Output ONLY the updated, consolidated list of lessons/conventions. Do not include any conversational filler, markdown headers like "Here is the updated list", or wrappers.
+
+Updated lessons list:`,
+		existingLessons, diff)
+
+	var result Result
+	var err error
+	if g.Mode == "cli" {
+		result, err = g.reviewCLI(ctx, prompt)
+	} else {
+		result, err = g.reviewAPI(ctx, prompt)
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.Body), nil
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -62,6 +62,12 @@ type PRState struct {
 	// LastIteratedAt is the timestamp of the most recent re-engage. Mostly for
 	// telemetry; also useful for spotting stuck iteration loops.
 	LastIteratedAt time.Time `json:"last_iterated_at,omitempty"`
+
+	// LastPushedSHA is the git commit SHA that Noctra last pushed to this PR's branch.
+	LastPushedSHA string `json:"last_pushed_sha,omitempty"`
+
+	// MergedProcessed reports whether human post-merge edits for this PR have been processed.
+	MergedProcessed bool `json:"merged_processed,omitempty"`
 }
 
 // SweepState is the per-task-per-repo record for autonomous maintenance
@@ -169,7 +175,16 @@ func (s *Store) initSchema() error {
 			last_review_at TEXT,
 			last_ci_sha TEXT NOT NULL DEFAULT '',
 			iterations INTEGER NOT NULL DEFAULT 0,
-			last_iterated_at TEXT
+			last_iterated_at TEXT,
+			last_pushed_sha TEXT NOT NULL DEFAULT '',
+			merged_processed INTEGER NOT NULL DEFAULT 0
+		)`,
+		`ALTER TABLE pr_states ADD COLUMN last_pushed_sha TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE pr_states ADD COLUMN merged_processed INTEGER NOT NULL DEFAULT 0`,
+		`CREATE TABLE IF NOT EXISTS repo_lessons (
+			repo TEXT PRIMARY KEY,
+			lessons TEXT NOT NULL DEFAULT '',
+			updated_at TEXT
 		)`,
 		`CREATE TABLE IF NOT EXISTS sweep_states (
 			key TEXT PRIMARY KEY,
@@ -246,7 +261,7 @@ func (s *Store) Get(prURL string) PRState {
 func (s *Store) getPRLocked(prURL string) (PRState, error) {
 	var r PRState
 	var lastComment, lastReview, lastIterated sql.NullString
-	err := s.db.QueryRow(`SELECT ticket_id, agent_backend, last_comment_at, last_review_at, last_ci_sha, iterations, last_iterated_at
+	err := s.db.QueryRow(`SELECT ticket_id, agent_backend, last_comment_at, last_review_at, last_ci_sha, iterations, last_iterated_at, last_pushed_sha, merged_processed
 		FROM pr_states WHERE pr_url = ?`, prURL).Scan(
 		&r.TicketID,
 		&r.AgentBackend,
@@ -255,6 +270,8 @@ func (s *Store) getPRLocked(prURL string) (PRState, error) {
 		&r.LastCISHA,
 		&r.Iterations,
 		&lastIterated,
+		&r.LastPushedSHA,
+		&r.MergedProcessed,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return PRState{}, nil
@@ -288,7 +305,7 @@ func (s *Store) All() map[string]PRState {
 }
 
 func (s *Store) allLocked() (map[string]PRState, error) {
-	rows, err := s.db.Query(`SELECT pr_url, ticket_id, agent_backend, last_comment_at, last_review_at, last_ci_sha, iterations, last_iterated_at
+	rows, err := s.db.Query(`SELECT pr_url, ticket_id, agent_backend, last_comment_at, last_review_at, last_ci_sha, iterations, last_iterated_at, last_pushed_sha, merged_processed
 		FROM pr_states ORDER BY pr_url`)
 	if err != nil {
 		return nil, fmt.Errorf("list pr states: %w", err)
@@ -313,6 +330,8 @@ func (s *Store) allLocked() (map[string]PRState, error) {
 			&r.LastCISHA,
 			&r.Iterations,
 			&lastIterated,
+			&r.LastPushedSHA,
+			&r.MergedProcessed,
 		); err != nil {
 			return nil, fmt.Errorf("scan pr state: %w", err)
 		}
@@ -349,8 +368,8 @@ func (s *Store) Update(prURL string, fn func(*PRState)) error {
 	}
 	fn(&r)
 	_, err = s.db.Exec(`INSERT INTO pr_states (
-			pr_url, ticket_id, agent_backend, last_comment_at, last_review_at, last_ci_sha, iterations, last_iterated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			pr_url, ticket_id, agent_backend, last_comment_at, last_review_at, last_ci_sha, iterations, last_iterated_at, last_pushed_sha, merged_processed
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(pr_url) DO UPDATE SET
 			ticket_id = excluded.ticket_id,
 			agent_backend = excluded.agent_backend,
@@ -358,7 +377,9 @@ func (s *Store) Update(prURL string, fn func(*PRState)) error {
 			last_review_at = excluded.last_review_at,
 			last_ci_sha = excluded.last_ci_sha,
 			iterations = excluded.iterations,
-			last_iterated_at = excluded.last_iterated_at`,
+			last_iterated_at = excluded.last_iterated_at,
+			last_pushed_sha = excluded.last_pushed_sha,
+			merged_processed = excluded.merged_processed`,
 		prURL,
 		r.TicketID,
 		r.AgentBackend,
@@ -367,6 +388,8 @@ func (s *Store) Update(prURL string, fn func(*PRState)) error {
 		r.LastCISHA,
 		r.Iterations,
 		formatTime(r.LastIteratedAt),
+		r.LastPushedSHA,
+		r.MergedProcessed,
 	)
 	if err != nil {
 		return fmt.Errorf("write pr state: %w", err)
@@ -668,6 +691,46 @@ func removeNewStateDB(path string) {
 			slog.Warn("remove failed state db after migration error", "path", candidate, "err", err)
 		}
 	}
+}
+
+// GetLessons returns the lessons for a repository, or empty string if none exist.
+func (s *Store) GetLessons(repo string) (string, error) {
+	if s == nil {
+		return "", nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var lessons string
+	err := s.db.QueryRow(`SELECT lessons FROM repo_lessons WHERE repo = ?`, repo).Scan(&lessons)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read repo lessons: %w", err)
+	}
+	return lessons, nil
+}
+
+// SaveLessons persists lessons for a repository.
+func (s *Store) SaveLessons(repo string, lessons string) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.db.Exec(`INSERT INTO repo_lessons (repo, lessons, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(repo) DO UPDATE SET
+			lessons = excluded.lessons,
+			updated_at = excluded.updated_at`,
+		repo,
+		lessons,
+		formatTime(time.Now()),
+	)
+	if err != nil {
+		return fmt.Errorf("write repo lessons: %w", err)
+	}
+	return nil
 }
 
 func formatTime(t time.Time) sql.NullString {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -486,6 +486,51 @@ func TestSavePlan_UpsertOverwrites(t *testing.T) {
 	}
 }
 
+func TestLessons(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	// Unset should return empty string.
+	got, err := s.GetLessons("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("expected empty lessons, got %q", got)
+	}
+
+	// Save and retrieve should work.
+	const lessons = "- Lesson 1: follow code conventions\n- Lesson 2: write tests"
+	if err := s.SaveLessons("owner/repo", lessons); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = s.GetLessons("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != lessons {
+		t.Errorf("expected lessons %q, got %q", lessons, got)
+	}
+
+	// Upsert should overwrite.
+	const newLessons = "- Lesson 1 updated"
+	if err := s.SaveLessons("owner/repo", newLessons); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = s.GetLessons("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != newLessons {
+		t.Errorf("expected lessons %q, got %q", newLessons, got)
+	}
+}
+
 func closeStore(t *testing.T, s *Store) {
 	t.Helper()
 	if err := s.Close(); err != nil {


### PR DESCRIPTION
## ENG-228: Learning loop: feed human post-merge edits back as per-repo signal

**Linear:** https://linear.app/amazz/issue/ENG-228/learning-loop-feed-human-post-merge-edits-back-as-per-repo-signal

## What was implemented

* **Lessons Table and PR State Schema Extensions**: Extended `internal/state` with two new columns in the `pr_states` table (`last_pushed_sha` and `merged_processed`) to track the exact HEAD commit pushed by Noctra and whether the PR's merge has been analyzed. Added a new `repo_lessons` table to persist size-bounded, durable repo-specific notes.
* **Merged PR Polling & Correction Capture**: Created a new package `internal/lessons` that scans the state store for newly merged or closed PRs. For merged PRs, it fetches the final PR branch state, computes the git diff of post-merge human edits relative to Noctra's last pushed commit, and uses Gemini to summarize new corrections and consolidate them with any existing conventions for that repository.
* **Context Ingestion into Prompts**: Updated both implementation (`prompt.go`) and fix (`fix_prompt.go`) prompt templates to format and inject a dedicated `Repository Lessons & Conventions` section. If lessons are stored for the target repository, they are automatically fetched and passed to the agent context during subsequent runs on the same repository.
* **Unit Testing**: Added thorough test coverage in `internal/state/state_test.go`, `internal/agent/prompt_test.go`, `internal/agent/fix_prompt_test.go`, and created `internal/lessons/lessons_test.go` utilizing mock scripts for `git`, `gh`, and `gemini` commands to test the merge processing loop.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Google Antigravity*
<!-- noctra-authored -->