### PR TITLE
ENG-220: Auto-merge PR when the Linear ticket moves to Done

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,11 @@ const (
 
 	// Plan-confirm (ENG-221) — disabled by default; opt in via .env.
 	DefaultPlanConfirmLabel = "plan-first"
+
+	// Auto-merge (ENG-220) — disabled by default; opt in via .env.
+	DefaultDoneState      = "Done"
+	DefaultMergeMethod    = "squash"
+	DefaultMergePollInterval = 2 * time.Minute
 )
 
 // Config is Noctra's resolved runtime configuration.
@@ -201,6 +206,13 @@ type Config struct {
 	// for human approval before implementing.
 	PlanConfirm      bool   // global opt-in for plan-confirm on all tickets
 	PlanConfirmLabel string // label name that activates plan-confirm per-ticket (default "plan-first")
+
+	// Auto-merge (ENG-220) — off by default; opt in via .env.
+	AutoMergeOnDone       bool          // opt-in flag to enable auto-merge when ticket moves to done
+	DoneState             string        // the state name that triggers merge (default "Done")
+	MergeMethod           string        // "squash" (default), "merge", or "rebase"
+	DeleteBranchAfterMerge bool        // whether to delete the branch after merge
+	MergePollInterval     time.Duration // interval to poll for done tickets (default 2m)
 
 	// Derived paths
 	ScriptDir    string
@@ -318,6 +330,14 @@ func Load(scriptDir string) (*Config, error) {
 	cfg.PlanConfirm = getbool(fileEnv, "PLAN_CONFIRM", false)
 	cfg.PlanConfirmLabel = getenv(fileEnv, "PLAN_CONFIRM_LABEL", DefaultPlanConfirmLabel)
 
+	// Auto-merge (ENG-220)
+	cfg.AutoMergeOnDone = getbool(fileEnv, "AUTO_MERGE_ON_DONE", false)
+	cfg.DoneState = getenv(fileEnv, "DONE_STATE", DefaultDoneState)
+	cfg.MergeMethod = strings.ToLower(strings.TrimSpace(getenv(fileEnv, "MERGE_METHOD", DefaultMergeMethod)))
+	cfg.DeleteBranchAfterMerge = getbool(fileEnv, "DELETE_BRANCH_AFTER_MERGE", false)
+	mergePollSecs := getint(fileEnv, "MERGE_POLL_INTERVAL", int(DefaultMergePollInterval/time.Second))
+	cfg.MergePollInterval = time.Duration(mergePollSecs) * time.Second
+
 	return cfg, nil
 }
 
@@ -386,6 +406,17 @@ func (c *Config) Validate() error {
 	case "pause", "shutdown":
 	default:
 		errs = append(errs, fmt.Sprintf("RATE_LIMIT_STRATEGY must be \"pause\" or \"shutdown\", got %q", c.RateLimitStrategy))
+	}
+
+	if c.AutoMergeOnDone {
+		switch c.MergeMethod {
+		case "squash", "merge", "rebase":
+		default:
+			errs = append(errs, fmt.Sprintf("MERGE_METHOD must be \"squash\", \"merge\", or \"rebase\", got %q", c.MergeMethod))
+		}
+		if c.DoneState == "" {
+			errs = append(errs, "DONE_STATE is required when AUTO_MERGE_ON_DONE is enabled")
+		}
 	}
 
 	if c.RepoPath != "" && !isGitRepo(c.RepoPath) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,8 +111,8 @@ const (
 	DefaultPlanConfirmLabel = "plan-first"
 
 	// Auto-merge (ENG-220) — disabled by default; opt in via .env.
-	DefaultDoneState      = "Done"
-	DefaultMergeMethod    = "squash"
+	DefaultDoneState         = "Done"
+	DefaultMergeMethod       = "squash"
 	DefaultMergePollInterval = 2 * time.Minute
 )
 
@@ -208,11 +208,11 @@ type Config struct {
 	PlanConfirmLabel string // label name that activates plan-confirm per-ticket (default "plan-first")
 
 	// Auto-merge (ENG-220) — off by default; opt in via .env.
-	AutoMergeOnDone       bool          // opt-in flag to enable auto-merge when ticket moves to done
-	DoneState             string        // the state name that triggers merge (default "Done")
-	MergeMethod           string        // "squash" (default), "merge", or "rebase"
-	DeleteBranchAfterMerge bool        // whether to delete the branch after merge
-	MergePollInterval     time.Duration // interval to poll for done tickets (default 2m)
+	AutoMergeOnDone        bool          // opt-in flag to enable auto-merge when ticket moves to done
+	DoneState              string        // the state name that triggers merge (default "Done")
+	MergeMethod            string        // "squash" (default), "merge", or "rebase"
+	DeleteBranchAfterMerge bool          // whether to delete the branch after merge
+	MergePollInterval      time.Duration // interval to poll for done tickets (default 2m)
 
 	// Derived paths
 	ScriptDir    string

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -431,6 +431,103 @@ func (c *Client) resolveThread(ctx context.Context, threadID string) error {
 	return nil
 }
 
+// MergePROptions controls how a PR is merged.
+type MergePROptions struct {
+	Method       string // "squash", "merge", or "rebase"
+	DeleteBranch bool   // whether to delete the branch after merge
+}
+
+// MergePRResult holds the result of attempting to merge a PR.
+type MergePRResult struct {
+	Success   bool
+	Merged    bool
+	Mergeable bool
+	Message   string // explanation if merge failed
+}
+
+// MergePR attempts to merge a PR via `gh pr merge`. It checks if the PR is
+// mergeable and all required checks pass before merging. Returns a result
+// indicating success or the reason for failure.
+func (c *Client) MergePR(ctx context.Context, prURL string, opts MergePROptions) MergePRResult {
+	// Validate merge method
+	method := strings.ToLower(strings.TrimSpace(opts.Method))
+	if method == "" {
+		method = "squash"
+	}
+	if method != "squash" && method != "merge" && method != "rebase" {
+		return MergePRResult{
+			Success: false,
+			Message: fmt.Sprintf("invalid merge method %q", method),
+		}
+	}
+
+	// Fetch PR details to check status
+	details, err := c.GetPR(ctx, prURL)
+	if err != nil {
+		return MergePRResult{
+			Success: false,
+			Message: fmt.Sprintf("failed to fetch PR details: %v", err),
+		}
+	}
+
+	// Check if PR is mergeable
+	if details.State != "OPEN" {
+		return MergePRResult{
+			Success:   false,
+			Mergeable: false,
+			Message:   fmt.Sprintf("PR is not open (state: %s)", details.State),
+		}
+	}
+
+	// Check if all required checks are passing
+	failing := false
+	for _, check := range details.StatusCheckRollup {
+		if check.Status != "COMPLETED" || check.Conclusion != "SUCCESS" {
+			failing = true
+			break
+		}
+	}
+	if failing {
+		var reasons []string
+		for _, check := range details.StatusCheckRollup {
+			if check.Status != "COMPLETED" || check.Conclusion != "SUCCESS" {
+				reasons = append(reasons, fmt.Sprintf("%s (%s/%s)", check.Name, check.Status, check.Conclusion))
+			}
+		}
+		return MergePRResult{
+			Success:   false,
+			Mergeable: true,
+			Message:   fmt.Sprintf("checks not passing: %s", strings.Join(reasons, "; ")),
+		}
+	}
+
+	// All checks passed, attempt merge
+	var stderr strings.Builder
+	args := []string{"pr", "merge", prURL, "--" + method}
+	if opts.DeleteBranch {
+		args = append(args, "--delete-branch")
+	}
+	// Don't auto-approve; let the user review if needed
+	args = append(args, "--auto")
+
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil {
+		return MergePRResult{
+			Success:   false,
+			Mergeable: true,
+			Message:   fmt.Sprintf("gh pr merge failed: %v (%s)", err, strings.TrimSpace(stderr.String())),
+		}
+	}
+
+	return MergePRResult{
+		Success: true,
+		Merged:  true,
+		Message: strings.TrimSpace(string(stdout)),
+	}
+}
+
 // parsePRURL extracts owner, repo name, and PR number from a GitHub PR URL
 // like https://github.com/owner/repo/pull/42.
 func parsePRURL(prURL string) (owner, repo string, number int, err error) {

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -601,7 +601,7 @@ func TestResolveStateIDs_SkipsTriggerWhenEmpty(t *testing.T) {
 	})
 
 	// With empty triggerName, only in-review is required.
-	ids, err := client.ResolveStateIDs(context.Background(), "ENG", "", "In Review")
+	ids, err := client.ResolveStateIDs(context.Background(), "ENG", "", "In Review", "")
 	if err != nil {
 		t.Fatalf("ResolveStateIDs: %v", err)
 	}

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -11,6 +11,7 @@ import (
 type StateIDs struct {
 	Trigger  string
 	InReview string
+	Done     string
 }
 
 // WorkflowStateID is a Linear workflow state with the fields Noctra needs for
@@ -23,8 +24,9 @@ type WorkflowStateID struct {
 // ResolveStateIDs looks up the IDs for the trigger and in-review state names
 // within the team identified by teamKey (e.g. "ENG"). When triggerName is
 // empty (label-based trigger mode), the trigger-state lookup is skipped —
-// only the in-review state is required.
-func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inReviewName string) (StateIDs, error) {
+// only the in-review state is required. doneName is optional; an empty value
+// means done-state resolution is skipped.
+func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inReviewName, doneName string) (StateIDs, error) {
 	states, err := c.TeamWorkflowStates(ctx, teamKey)
 	if err != nil {
 		return StateIDs{}, err
@@ -39,6 +41,8 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 			ids.Trigger = s.ID
 		case inReviewName:
 			ids.InReview = s.ID
+		case doneName:
+			ids.Done = s.ID
 		}
 	}
 	if triggerName != "" && ids.Trigger == "" {
@@ -48,6 +52,10 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 	if ids.InReview == "" {
 		return StateIDs{}, fmt.Errorf("state %q not found in team %q (available: %v)",
 			inReviewName, teamKey, available)
+	}
+	if doneName != "" && ids.Done == "" {
+		return StateIDs{}, fmt.Errorf("state %q not found in team %q (available: %v)",
+			doneName, teamKey, available)
 	}
 	return ids, nil
 }
@@ -101,6 +109,20 @@ func (c *Client) ResolveStateID(ctx context.Context, teamKey, stateName string) 
 		}
 	}
 	return "", available, fmt.Errorf("state %q not found in team %q", stateName, teamKey)
+}
+
+// ResolveDoneStateID looks up the done state ID for a team, respecting the
+// provided stateName override. If stateName is empty, returns empty string
+// and no error (done-state resolution is optional when auto-merge is disabled).
+func (c *Client) ResolveDoneStateID(ctx context.Context, teamKey, stateName string) (string, error) {
+	if stateName == "" {
+		return "", nil
+	}
+	id, _, err := c.ResolveStateID(ctx, teamKey, stateName)
+	if err != nil {
+		return "", fmt.Errorf("resolve done state: %w", err)
+	}
+	return id, nil
 }
 
 // FetchTriggerIssues returns every issue currently in the named state, across

--- a/internal/pipeline/automerge.go
+++ b/internal/pipeline/automerge.go
@@ -1,0 +1,143 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/github"
+	"github.com/ahmadAlMezaal/noctra/internal/notify"
+)
+
+// runAutoMerger is the auto-merge-on-done loop that runs alongside the Linear-poll
+// loop. Started by Run when cfg.AutoMergeOnDone is true and the store initialized
+// without error.
+func (p *Pipeline) runAutoMerger(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	slog.Info("auto-merge scheduler starting",
+		"interval", p.cfg.MergePollInterval,
+		"done_state", p.cfg.DoneState,
+		"merge_method", p.cfg.MergeMethod,
+		"delete_branch", p.cfg.DeleteBranchAfterMerge,
+	)
+
+	ticker := time.NewTicker(p.cfg.MergePollInterval)
+	defer ticker.Stop()
+
+	// Initial scan after a brief delay so the Linear-startup output clears.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(5 * time.Second):
+	}
+	p.autoMergePollOnce(ctx, wg)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.autoMergePollOnce(ctx, wg)
+		}
+	}
+}
+
+// autoMergePollOnce scans all tracked tickets for ones in the done state,
+// fetches their PRs, and attempts to merge if checks pass.
+func (p *Pipeline) autoMergePollOnce(ctx context.Context, wg *sync.WaitGroup) {
+	// Fetch all tracked PRs from the state store
+	prStates := p.store.All()
+	if len(prStates) == 0 {
+		return
+	}
+
+	// Dedupe ticket IDs from PR states
+	ticketIDs := make(map[string]struct{})
+	for _, pr := range prStates {
+		if pr.TicketID != "" {
+			ticketIDs[pr.TicketID] = struct{}{}
+		}
+	}
+
+	if len(ticketIDs) == 0 {
+		return
+	}
+
+	// Check each tracked ticket to see if it's in the done state
+	for ticketID := range ticketIDs {
+		// Avoid spawning goroutines; check synchronously to avoid too many concurrent ops
+		p.checkAndMergeTicket(ctx, ticketID)
+	}
+}
+
+// checkAndMergeTicket checks if a ticket is in the done state and merges
+// its associated PR if all checks pass.
+func (p *Pipeline) checkAndMergeTicket(ctx context.Context, ticketID string) {
+	// Fetch the ticket to check its current state
+	issue, err := p.linear.GetIssueByIdentifier(ctx, ticketID)
+	if err != nil {
+		slog.Warn("auto-merge: fetch ticket failed", "ticket_id", ticketID, "err", err)
+		return
+	}
+
+	// Check if ticket is in the done state
+	if issue.StateName() != p.cfg.DoneState {
+		return
+	}
+
+	// Ticket is in done state; find its PR(s) and merge
+	prURLs := p.store.AllByTicketID(ticketID)
+	if len(prURLs) == 0 {
+		slog.Debug("auto-merge: no PR found for ticket in done state", "ticket_id", ticketID)
+		return
+	}
+
+	for _, prURL := range prURLs {
+		p.mergePRForDoneTicket(ctx, ticketID, issue.ID, prURL)
+	}
+}
+
+// mergePRForDoneTicket attempts to merge a PR for a ticket that's now in the
+// done state. On failure, it posts a comment explaining why the merge failed.
+func (p *Pipeline) mergePRForDoneTicket(ctx context.Context, ticketID, issueID, prURL string) {
+	gh := github.New()
+	opts := github.MergePROptions{
+		Method:       p.cfg.MergeMethod,
+		DeleteBranch: p.cfg.DeleteBranchAfterMerge,
+	}
+
+	result := gh.MergePR(ctx, prURL, opts)
+
+	if result.Success && result.Merged {
+		slog.Info("auto-merge: PR merged", "ticket_id", ticketID, "pr_url", prURL, "message", result.Message)
+		p.notifier.Send(ctx, fmt.Sprintf(
+			"✅ *Auto-merged* %s\n%s\n%s",
+			ticketID,
+			notify.EscapeMarkdown(result.Message),
+			prURL,
+		))
+		return
+	}
+
+	// Merge failed; comment on the ticket explaining why
+	slog.Warn("auto-merge: merge failed", "ticket_id", ticketID, "pr_url", prURL, "message", result.Message)
+	p.notifier.Send(ctx, fmt.Sprintf(
+		"⚠️ *Could not auto-merge* %s\n%s\n%s",
+		ticketID,
+		notify.EscapeMarkdown(result.Message),
+		prURL,
+	))
+
+	// Post a comment on Linear explaining the merge failure
+	commentBody := fmt.Sprintf(
+		"**Noctra: Cannot auto-merge PR**\n\n%s\n\n%s",
+		result.Message,
+		prURL,
+	)
+	if err := p.linear.Comment(ctx, issueID, commentBody); err != nil {
+		slog.Warn("auto-merge: failed to comment on issue", "ticket_id", ticketID, "err", err)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -254,6 +254,13 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		go p.runSweepLoop(ctx, &wg)
 	}
 
+	// Auto-merge scheduler runs its own loop if enabled. Shares the WaitGroup
+	// so shutdown drains in-flight merges.
+	if p.cfg.AutoMergeOnDone && p.store != nil {
+		wg.Add(1)
+		go p.runAutoMerger(ctx, &wg)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -624,6 +631,7 @@ func buildTicketSources(cfg *config.Config, linearClient *linear.Client) []sourc
 				TriggerState:     cfg.TriggerState,
 				TriggerLabel:     cfg.TriggerLabel,
 				InReviewState:    cfg.InReviewState,
+				DoneState:        cfg.DoneState,
 				PlanConfirmLabel: cfg.PlanConfirmLabel,
 			}))
 		case "github":
@@ -667,6 +675,10 @@ func (p *Pipeline) banner() {
 		}
 		sweepMode = fmt.Sprintf("On (%s, max %d tasks, %s)", cadence, p.cfg.SweepMaxTasks, scope)
 	}
+	autoMergeMode := "Disabled"
+	if p.cfg.AutoMergeOnDone {
+		autoMergeMode = fmt.Sprintf("On (%s, poll %s)", p.cfg.MergeMethod, p.cfg.MergePollInterval)
+	}
 
 	// Repos are routed per-ticket from each Linear project's "Repo:" directive
 	// and cloned on demand, so there's no static list at startup — report the
@@ -709,6 +721,7 @@ func (p *Pipeline) banner() {
 		planConfirmMode = fmt.Sprintf("Per-ticket (label %q)", p.cfg.PlanConfirmLabel)
 	}
 	fmt.Printf("   Sweep:          %s\n", sweepMode)
+	fmt.Printf("   Auto-merge:     %s\n", autoMergeMode)
 	fmt.Printf("   Plan-confirm:   %s\n", planConfirmMode)
 	fmt.Printf("   Max concurrent: %d\n", p.cfg.MaxConcurrent)
 	fmt.Printf("   Poll interval:  %s\n", p.cfg.PollInterval)

--- a/internal/source/linear.go
+++ b/internal/source/linear.go
@@ -14,6 +14,7 @@ type LinearConfig struct {
 	TriggerState     string
 	TriggerLabel     string
 	InReviewState    string
+	DoneState        string // optional, for auto-merge feature
 	PlanConfirmLabel string
 }
 
@@ -43,7 +44,7 @@ func (s *LinearSource) Prepare(ctx context.Context) error {
 	if s.cfg.TriggerMode == "label" {
 		triggerStateName = ""
 	}
-	states, err := s.client.ResolveStateIDs(ctx, s.cfg.TeamKey, triggerStateName, s.cfg.InReviewState)
+	states, err := s.client.ResolveStateIDs(ctx, s.cfg.TeamKey, triggerStateName, s.cfg.InReviewState, s.cfg.DoneState)
 	if err != nil {
 		return fmt.Errorf("resolve linear states: %w", err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -344,7 +344,11 @@ func (s *Store) AllByTicketID(ticketID string) []string {
 		slog.Warn("state all by ticket failed", "ticket_id", ticketID, "err", err)
 		return nil
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("close rows failed", "err", err)
+		}
+	}()
 
 	var out []string
 	for rows.Next() {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -334,6 +334,30 @@ func (s *Store) allLocked() (map[string]PRState, error) {
 	return out, nil
 }
 
+// AllByTicketID returns all PR URLs associated with the given ticket ID.
+func (s *Store) AllByTicketID(ticketID string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rows, err := s.db.Query(`SELECT pr_url FROM pr_states WHERE ticket_id = ? ORDER BY pr_url`, ticketID)
+	if err != nil {
+		slog.Warn("state all by ticket failed", "ticket_id", ticketID, "err", err)
+		return nil
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var prURL string
+		if err := rows.Scan(&prURL); err != nil {
+			slog.Warn("scan pr url failed", "ticket_id", ticketID, "err", err)
+			continue
+		}
+		out = append(out, prURL)
+	}
+	return out
+}
+
 // Update mutates the record for prURL in place via fn and writes it. A nil fn
 // is a no-op. fn is called while the store is locked; do not call back into the
 // Store from inside fn.


### PR DESCRIPTION
## ENG-220: Auto-merge PR when the Linear ticket moves to Done

**Linear:** https://linear.app/amazz/issue/ENG-220/auto-merge-pr-when-the-linear-ticket-moves-to-done

## What was implemented

Implemented ENG-220: Auto-merge PR when Linear ticket moves to Done. Added opt-in feature (AUTO_MERGE_ON_DONE) that periodically scans tracked tickets, detects when they transition to a configurable "Done" state, and automatically merges their associated PRs via `gh pr merge` if all required checks are green. On merge failure, posts detailed Linear comments explaining why (failing checks, conflicts, etc). Fully configurable: merge method (squash/merge/rebase), optional branch delete, and poll interval. Feature is off by default and requires explicit enablement.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using GitHub Copilot*
<!-- noctra-authored -->