### PR TITLE
ENG-250: Jira as a trigger source (TicketSource adapter)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,8 @@ LINEAR_API_KEY=lin_api_xxx
 LINEAR_TEAM_KEY=ENG
 
 # Ticket sources to poll. Default is Linear only.
-# Use "github" for GitHub Issues, or comma-separate sources: "linear,github".
+# Use "github" for GitHub Issues, "jira" for Jira Cloud, or comma-separate
+# sources: "linear,github,jira".
 # TICKET_SOURCES=linear
 #
 # GitHub Issues source: repos to scan and the label that triggers dispatch.
@@ -35,6 +36,18 @@ LINEAR_TEAM_KEY=ENG
 # a `Repo:` directive. A `Branch:` directive in the issue body is also honored.
 # GITHUB_ISSUES_REPOS=your-org/your-repo
 # GITHUB_TRIGGER_LABEL=noctra
+#
+# Jira Cloud source (required when TICKET_SOURCES includes "jira"):
+# Polls Jira for issues matching a status or label via JQL.
+# Auth uses email + API token (https://id.atlassian.com/manage-profile/security/api-tokens).
+# The issue description is scanned for `Repo:` / `Branch:` directives.
+# JIRA_BASE_URL=https://your-org.atlassian.net
+# JIRA_USER_EMAIL=you@example.com
+# JIRA_API_TOKEN=your-jira-api-token
+# JIRA_PROJECT=PROJ
+# JIRA_TRIGGER_STATUS=To Do
+# JIRA_TRIGGER_LABEL=noctra
+# JIRA_IN_REVIEW_STATUS=In Review
 
 # How Noctra picks up tickets: "state" or "label"
 #   state — watches a Linear column (e.g. "Next")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,9 @@ const (
 	DefaultSweepInterval = 24 * time.Hour
 	DefaultSweepMaxTasks = 5
 
+	// Jira defaults.
+	DefaultJiraInReviewStatus = "In Review"
+
 	// Plan-confirm (ENG-221) — disabled by default; opt in via .env.
 	DefaultPlanConfirmLabel = "plan-first"
 )
@@ -114,9 +117,18 @@ const (
 // Config is Noctra's resolved runtime configuration.
 type Config struct {
 	// Ticket sources
-	TicketSources      []string // active sources: "linear", "github"
+	TicketSources      []string // active sources: "linear", "github", "jira"
 	GitHubIssuesRepos  []string // owner/name or git URLs polled by the GitHub Issues source
 	GitHubTriggerLabel string
+
+	// Jira
+	JiraBaseURL        string // e.g. "https://your-org.atlassian.net"
+	JiraUserEmail      string // Jira account email for basic auth
+	JiraAPIToken       string // Jira API token
+	JiraProject        string // Jira project key, e.g. "PROJ"
+	JiraTriggerStatus  string // status name that triggers dispatch
+	JiraTriggerLabel   string // optional: label that triggers dispatch instead of status
+	JiraInReviewStatus string // status name after PR is opened
 
 	// Linear
 	LinearAPIKey            string
@@ -279,6 +291,15 @@ func Load(scriptDir string) (*Config, error) {
 		cfg.GitHubTriggerLabel = cfg.TriggerLabel
 	}
 
+	// Jira
+	cfg.JiraBaseURL = getenv(fileEnv, "JIRA_BASE_URL", "")
+	cfg.JiraUserEmail = getenv(fileEnv, "JIRA_USER_EMAIL", "")
+	cfg.JiraAPIToken = getenv(fileEnv, "JIRA_API_TOKEN", "")
+	cfg.JiraProject = getenv(fileEnv, "JIRA_PROJECT", "")
+	cfg.JiraTriggerStatus = getenv(fileEnv, "JIRA_TRIGGER_STATUS", "")
+	cfg.JiraTriggerLabel = getenv(fileEnv, "JIRA_TRIGGER_LABEL", "")
+	cfg.JiraInReviewStatus = getenv(fileEnv, "JIRA_IN_REVIEW_STATUS", DefaultJiraInReviewStatus)
+
 	pollSecs := getint(fileEnv, "POLL_INTERVAL", int(DefaultPollInterval/time.Second))
 	cfg.PollInterval = time.Duration(pollSecs) * time.Second
 
@@ -354,9 +375,9 @@ func (c *Config) Validate() error {
 
 	for _, src := range sources {
 		switch src {
-		case "linear", "github":
+		case "linear", "github", "jira":
 		default:
-			errs = append(errs, fmt.Sprintf("TICKET_SOURCES entries must be \"linear\" or \"github\", got %q", src))
+			errs = append(errs, fmt.Sprintf("TICKET_SOURCES entries must be \"linear\", \"github\", or \"jira\", got %q", src))
 		}
 	}
 	if usesSource(sources, "github") {
@@ -365,6 +386,23 @@ func (c *Config) Validate() error {
 		}
 		if c.GitHubTriggerLabel == "" {
 			errs = append(errs, "GITHUB_TRIGGER_LABEL or TRIGGER_LABEL is required when TICKET_SOURCES includes github")
+		}
+	}
+	if usesSource(sources, "jira") {
+		if c.JiraBaseURL == "" {
+			errs = append(errs, "JIRA_BASE_URL is required when TICKET_SOURCES includes jira")
+		}
+		if c.JiraUserEmail == "" {
+			errs = append(errs, "JIRA_USER_EMAIL is required when TICKET_SOURCES includes jira")
+		}
+		if c.JiraAPIToken == "" {
+			errs = append(errs, "JIRA_API_TOKEN is required when TICKET_SOURCES includes jira")
+		}
+		if c.JiraProject == "" {
+			errs = append(errs, "JIRA_PROJECT is required when TICKET_SOURCES includes jira")
+		}
+		if c.JiraTriggerStatus == "" && c.JiraTriggerLabel == "" {
+			errs = append(errs, "JIRA_TRIGGER_STATUS or JIRA_TRIGGER_LABEL is required when TICKET_SOURCES includes jira")
 		}
 	}
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -631,6 +631,16 @@ func buildTicketSources(cfg *config.Config, linearClient *linear.Client) []sourc
 				Repos:        cfg.GitHubIssuesRepos,
 				TriggerLabel: cfg.GitHubTriggerLabel,
 			}))
+		case "jira":
+			sources = append(sources, source.NewJira(source.JiraConfig{
+				BaseURL:        cfg.JiraBaseURL,
+				UserEmail:      cfg.JiraUserEmail,
+				APIToken:       cfg.JiraAPIToken,
+				Project:        cfg.JiraProject,
+				TriggerStatus:  cfg.JiraTriggerStatus,
+				TriggerLabel:   cfg.JiraTriggerLabel,
+				InReviewStatus: cfg.JiraInReviewStatus,
+			}))
 		}
 	}
 	return sources

--- a/internal/source/jira.go
+++ b/internal/source/jira.go
@@ -247,21 +247,28 @@ func adfToText(doc *jiraADFDocument) string {
 		return ""
 	}
 	var b strings.Builder
-	for i, node := range doc.Content {
-		if i > 0 {
-			b.WriteByte('\n')
-		}
+	for _, node := range doc.Content {
 		adfNodeText(&b, node)
 	}
-	return b.String()
+	return strings.TrimSpace(b.String())
 }
 
 func adfNodeText(b *strings.Builder, node jiraADFContent) {
+	if node.Type == "hardBreak" {
+		b.WriteByte('\n')
+		return
+	}
 	if node.Text != "" {
 		b.WriteString(node.Text)
 	}
 	for _, child := range node.Content {
 		adfNodeText(b, child)
+	}
+	if node.Type == "paragraph" || node.Type == "heading" || node.Type == "listItem" || node.Type == "blockquote" || node.Type == "codeBlock" {
+		s := b.String()
+		if len(s) > 0 && s[len(s)-1] != '\n' {
+			b.WriteByte('\n')
+		}
 	}
 }
 
@@ -364,19 +371,32 @@ func (s *JiraSource) getComments(ctx context.Context, key string) ([]Comment, er
 
 func (s *JiraSource) addComment(ctx context.Context, key, text string) error {
 	// Jira Cloud API v3 expects ADF (Atlassian Document Format) for comments.
+	// Newlines are not allowed in ADF text nodes, so we split by newline and
+	// insert hardBreak nodes.
+	lines := strings.Split(text, "\n")
+	content := make([]any, 0, len(lines)*2)
+	for i, line := range lines {
+		if i > 0 {
+			content = append(content, map[string]any{
+				"type": "hardBreak",
+			})
+		}
+		if line != "" {
+			content = append(content, map[string]any{
+				"type": "text",
+				"text": line,
+			})
+		}
+	}
+
 	payload := map[string]any{
 		"body": map[string]any{
 			"type":    "doc",
 			"version": 1,
 			"content": []any{
 				map[string]any{
-					"type": "paragraph",
-					"content": []any{
-						map[string]any{
-							"type": "text",
-							"text": text,
-						},
-					},
+					"type":    "paragraph",
+					"content": content,
 				},
 			},
 		},

--- a/internal/source/jira.go
+++ b/internal/source/jira.go
@@ -1,0 +1,495 @@
+package source
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// JiraConfig contains the settings for the Jira Cloud source.
+type JiraConfig struct {
+	BaseURL        string // e.g. "https://your-org.atlassian.net"
+	UserEmail      string // Jira account email for basic auth
+	APIToken       string // Jira API token (https://id.atlassian.com/manage-profile/security/api-tokens)
+	Project        string // Jira project key, e.g. "PROJ"
+	TriggerStatus  string // status name that triggers dispatch, e.g. "To Do"
+	InReviewStatus string // status name after PR is opened, e.g. "In Review"
+	TriggerLabel   string // optional: label that triggers dispatch instead of status
+}
+
+// JiraSource polls Jira Cloud for issues matching a status or label using the
+// REST API v3 with basic auth (email + API token).
+type JiraSource struct {
+	cfg    JiraConfig
+	client *http.Client
+}
+
+func NewJira(cfg JiraConfig) *JiraSource {
+	return &JiraSource{cfg: cfg, client: &http.Client{}}
+}
+
+func (s *JiraSource) Name() string { return "jira" }
+
+func (s *JiraSource) Prepare(context.Context) error {
+	if strings.TrimSpace(s.cfg.BaseURL) == "" {
+		return fmt.Errorf("JIRA_BASE_URL is required when jira is an active ticket source")
+	}
+	if strings.TrimSpace(s.cfg.UserEmail) == "" {
+		return fmt.Errorf("JIRA_USER_EMAIL is required when jira is an active ticket source")
+	}
+	if strings.TrimSpace(s.cfg.APIToken) == "" {
+		return fmt.Errorf("JIRA_API_TOKEN is required when jira is an active ticket source")
+	}
+	if strings.TrimSpace(s.cfg.Project) == "" {
+		return fmt.Errorf("JIRA_PROJECT is required when jira is an active ticket source")
+	}
+	if strings.TrimSpace(s.cfg.TriggerStatus) == "" && strings.TrimSpace(s.cfg.TriggerLabel) == "" {
+		return fmt.Errorf("JIRA_TRIGGER_STATUS or JIRA_TRIGGER_LABEL is required when jira is an active ticket source")
+	}
+	if strings.TrimSpace(s.cfg.InReviewStatus) == "" {
+		return fmt.Errorf("JIRA_IN_REVIEW_STATUS is required when jira is an active ticket source")
+	}
+	// Trim trailing slash from base URL for consistent path joining.
+	s.cfg.BaseURL = strings.TrimRight(s.cfg.BaseURL, "/")
+	return nil
+}
+
+func (s *JiraSource) Fetch(ctx context.Context) ([]Ticket, error) {
+	jql := s.buildFetchJQL()
+	issues, err := s.searchIssues(ctx, jql)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Ticket, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, s.ticket(issue))
+	}
+	return out, nil
+}
+
+func (s *JiraSource) FetchByIdentifier(ctx context.Context, identifier string) (Ticket, error) {
+	issue, err := s.getIssue(ctx, identifier)
+	if err != nil {
+		return Ticket{}, err
+	}
+	return s.ticket(issue), nil
+}
+
+func (s *JiraSource) FetchComments(ctx context.Context, ticket Ticket) ([]Comment, error) {
+	comments, err := s.getComments(ctx, ticket.Identifier)
+	if err != nil {
+		return nil, err
+	}
+	return comments, nil
+}
+
+func (s *JiraSource) RemovePlanLabel(context.Context, Ticket) error {
+	return nil
+}
+
+func (s *JiraSource) BackToTrigger(ctx context.Context, ticket Ticket, body string) error {
+	// Jira status transitions are complex (workflow-dependent), so
+	// BackToTrigger only posts a comment. The issue stays in whatever state
+	// it's in — the JQL trigger query won't re-fetch it unless it's still
+	// in the trigger status.
+	return s.Comment(ctx, ticket, body)
+}
+
+func (s *JiraSource) MarkReady(ctx context.Context, ticket Ticket, info ReadyInfo) error {
+	var firstErr error
+	// Transition to the in-review status.
+	if err := s.transitionTo(ctx, ticket.Identifier, s.cfg.InReviewStatus); err != nil {
+		firstErr = err
+	}
+	// Remove the trigger label if we're in label mode.
+	if s.cfg.TriggerLabel != "" {
+		if err := s.removeLabel(ctx, ticket.Identifier, s.cfg.TriggerLabel); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	body := fmt.Sprintf(
+		"🌙 *Noctra created a PR* (via %s)\n\n*PR:* %s\n\nTransitioned to *%s*. Ready for your review!",
+		info.BackendLabel, info.PRURL, info.ReviewState)
+	if err := s.Comment(ctx, ticket, body); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+func (s *JiraSource) Comment(ctx context.Context, ticket Ticket, body string) error {
+	return s.addComment(ctx, ticket.Identifier, body)
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+func (s *JiraSource) buildFetchJQL() string {
+	if s.cfg.TriggerLabel != "" {
+		return fmt.Sprintf(`project = %q AND labels = %q AND statusCategory != "Done" ORDER BY created ASC`,
+			s.cfg.Project, s.cfg.TriggerLabel)
+	}
+	return fmt.Sprintf(`project = %q AND status = %q ORDER BY created ASC`,
+		s.cfg.Project, s.cfg.TriggerStatus)
+}
+
+// ticket converts a Jira API issue response to the source-neutral Ticket shape.
+func (s *JiraSource) ticket(issue jiraIssue) Ticket {
+	desc := issue.descriptionText()
+	repoRef, repoBranch := ParseRepoDirective(desc)
+
+	labels := make([]Label, 0, len(issue.Fields.Labels))
+	for _, l := range issue.Fields.Labels {
+		labels = append(labels, Label{Name: l})
+	}
+
+	comments := make([]Comment, 0, len(issue.Fields.Comment.Comments))
+	for _, c := range issue.Fields.Comment.Comments {
+		comments = append(comments, Comment{
+			Body:   c.bodyText(),
+			Author: c.Author.DisplayName,
+		})
+	}
+
+	return Ticket{
+		Source:      "jira",
+		ID:          issue.ID,
+		Identifier:  issue.Key,
+		Title:       issue.Fields.Summary,
+		Description: desc,
+		URL:         s.cfg.BaseURL + "/browse/" + issue.Key,
+		ProjectName: issue.Fields.Project.Key,
+		RepoRef:     repoRef,
+		RepoBranch:  repoBranch,
+		Comments:    comments,
+		Labels:      labels,
+		SourceData: jiraMeta{
+			BaseURL: s.cfg.BaseURL,
+			Key:     issue.Key,
+		},
+	}
+}
+
+// ── Jira REST API types ───────────────────────────────────────────────────────
+
+type jiraIssue struct {
+	ID     string     `json:"id"`
+	Key    string     `json:"key"`
+	Fields jiraFields `json:"fields"`
+}
+
+type jiraFields struct {
+	Summary     string           `json:"summary"`
+	Description *jiraADFDocument `json:"description"` // ADF (Atlassian Document Format) or null
+	Status      jiraStatus       `json:"status"`
+	Project     jiraProject      `json:"project"`
+	Labels      []string         `json:"labels"`
+	Comment     jiraCommentPage  `json:"comment"`
+}
+
+type jiraStatus struct {
+	Name string `json:"name"`
+}
+
+type jiraProject struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+type jiraCommentPage struct {
+	Comments []jiraComment `json:"comments"`
+}
+
+type jiraComment struct {
+	Body   *jiraADFDocument `json:"body"` // ADF or null
+	Author jiraUser         `json:"author"`
+}
+
+type jiraUser struct {
+	DisplayName string `json:"displayName"`
+}
+
+// jiraADFDocument is a minimal representation of Atlassian Document Format. We
+// flatten it to plain text for the agent prompt / Repo: directive parsing.
+type jiraADFDocument struct {
+	Type    string           `json:"type"`
+	Content []jiraADFContent `json:"content"`
+}
+
+type jiraADFContent struct {
+	Type    string           `json:"type"`
+	Text    string           `json:"text,omitempty"`
+	Content []jiraADFContent `json:"content,omitempty"`
+}
+
+// descriptionText flattens the Jira ADF description to plain text.
+func (issue jiraIssue) descriptionText() string {
+	if issue.Fields.Description == nil {
+		return ""
+	}
+	return adfToText(issue.Fields.Description)
+}
+
+// bodyText flattens an ADF comment body to plain text.
+func (c jiraComment) bodyText() string {
+	if c.Body == nil {
+		return ""
+	}
+	return adfToText(c.Body)
+}
+
+// adfToText extracts plain text from an Atlassian Document Format tree.
+func adfToText(doc *jiraADFDocument) string {
+	if doc == nil {
+		return ""
+	}
+	var b strings.Builder
+	for i, node := range doc.Content {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		adfNodeText(&b, node)
+	}
+	return b.String()
+}
+
+func adfNodeText(b *strings.Builder, node jiraADFContent) {
+	if node.Text != "" {
+		b.WriteString(node.Text)
+	}
+	for _, child := range node.Content {
+		adfNodeText(b, child)
+	}
+}
+
+type jiraMeta struct {
+	BaseURL string
+	Key     string
+}
+
+// ── Jira REST API calls ───────────────────────────────────────────────────────
+
+func (s *JiraSource) authHeader() string {
+	cred := s.cfg.UserEmail + ":" + s.cfg.APIToken
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(cred))
+}
+
+func (s *JiraSource) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	url := s.cfg.BaseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", s.authHeader())
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return s.client.Do(req)
+}
+
+func (s *JiraSource) searchIssues(ctx context.Context, jql string) ([]jiraIssue, error) {
+	payload := map[string]any{
+		"jql":        jql,
+		"maxResults": 100,
+		"fields":     []string{"summary", "description", "status", "project", "labels", "comment"},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.doRequest(ctx, http.MethodPost, "/rest/api/3/search", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("jira search: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("jira search: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+	var result struct {
+		Issues []jiraIssue `json:"issues"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("jira search: decode: %w", err)
+	}
+	return result.Issues, nil
+}
+
+func (s *JiraSource) getIssue(ctx context.Context, key string) (jiraIssue, error) {
+	resp, err := s.doRequest(ctx, http.MethodGet,
+		fmt.Sprintf("/rest/api/3/issue/%s?fields=summary,description,status,project,labels,comment", key), nil)
+	if err != nil {
+		return jiraIssue{}, fmt.Errorf("jira get issue %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return jiraIssue{}, fmt.Errorf("jira get issue %s: HTTP %d: %s", key, resp.StatusCode, string(respBody))
+	}
+	var issue jiraIssue
+	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
+		return jiraIssue{}, fmt.Errorf("jira get issue %s: decode: %w", key, err)
+	}
+	return issue, nil
+}
+
+func (s *JiraSource) getComments(ctx context.Context, key string) ([]Comment, error) {
+	resp, err := s.doRequest(ctx, http.MethodGet,
+		fmt.Sprintf("/rest/api/3/issue/%s/comment", key), nil)
+	if err != nil {
+		return nil, fmt.Errorf("jira get comments %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("jira get comments %s: HTTP %d: %s", key, resp.StatusCode, string(respBody))
+	}
+	var result jiraCommentPage
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("jira get comments %s: decode: %w", key, err)
+	}
+	out := make([]Comment, 0, len(result.Comments))
+	for _, c := range result.Comments {
+		out = append(out, Comment{
+			Body:   c.bodyText(),
+			Author: c.Author.DisplayName,
+		})
+	}
+	return out, nil
+}
+
+func (s *JiraSource) addComment(ctx context.Context, key, text string) error {
+	// Jira Cloud API v3 expects ADF (Atlassian Document Format) for comments.
+	payload := map[string]any{
+		"body": map[string]any{
+			"type":    "doc",
+			"version": 1,
+			"content": []any{
+				map[string]any{
+					"type": "paragraph",
+					"content": []any{
+						map[string]any{
+							"type": "text",
+							"text": text,
+						},
+					},
+				},
+			},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	resp, err := s.doRequest(ctx, http.MethodPost,
+		fmt.Sprintf("/rest/api/3/issue/%s/comment", key), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("jira add comment %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("jira add comment %s: HTTP %d: %s", key, resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func (s *JiraSource) transitionTo(ctx context.Context, key, targetStatus string) error {
+	// Jira transitions are workflow-dependent. We need to:
+	// 1. List available transitions for the issue.
+	// 2. Find the one whose "to" status name matches targetStatus.
+	// 3. Execute that transition.
+	resp, err := s.doRequest(ctx, http.MethodGet,
+		fmt.Sprintf("/rest/api/3/issue/%s/transitions", key), nil)
+	if err != nil {
+		return fmt.Errorf("jira list transitions %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("jira list transitions %s: HTTP %d: %s", key, resp.StatusCode, string(respBody))
+	}
+	var result struct {
+		Transitions []jiraTransition `json:"transitions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("jira list transitions %s: decode: %w", key, err)
+	}
+
+	targetLower := strings.ToLower(strings.TrimSpace(targetStatus))
+	var transitionID string
+	for _, t := range result.Transitions {
+		if strings.ToLower(strings.TrimSpace(t.To.Name)) == targetLower {
+			transitionID = t.ID
+			break
+		}
+	}
+	if transitionID == "" {
+		return fmt.Errorf("jira transition %s: no transition to status %q available (have: %s)",
+			key, targetStatus, formatTransitionNames(result.Transitions))
+	}
+
+	payload := map[string]any{
+		"transition": map[string]string{"id": transitionID},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	resp2, err := s.doRequest(ctx, http.MethodPost,
+		fmt.Sprintf("/rest/api/3/issue/%s/transitions", key), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("jira execute transition %s: %w", key, err)
+	}
+	defer resp2.Body.Close()
+	// Jira returns 204 No Content on successful transition.
+	if resp2.StatusCode != http.StatusNoContent {
+		respBody, _ := io.ReadAll(resp2.Body)
+		return fmt.Errorf("jira execute transition %s: HTTP %d: %s", key, resp2.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func (s *JiraSource) removeLabel(ctx context.Context, key, label string) error {
+	payload := map[string]any{
+		"update": map[string]any{
+			"labels": []map[string]string{
+				{"remove": label},
+			},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	resp, err := s.doRequest(ctx, http.MethodPut,
+		fmt.Sprintf("/rest/api/3/issue/%s", key), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("jira remove label %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+	// Jira returns 204 No Content on successful update.
+	if resp.StatusCode != http.StatusNoContent {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("jira remove label %s: HTTP %d: %s", key, resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+type jiraTransition struct {
+	ID   string     `json:"id"`
+	Name string     `json:"name"`
+	To   jiraStatus `json:"to"`
+}
+
+func formatTransitionNames(transitions []jiraTransition) string {
+	names := make([]string, 0, len(transitions))
+	for _, t := range transitions {
+		names = append(names, fmt.Sprintf("%q", t.To.Name))
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/source/jira_test.go
+++ b/internal/source/jira_test.go
@@ -153,6 +153,60 @@ func TestJiraADFToTextNil(t *testing.T) {
 	}
 }
 
+func TestJiraADFToTextRich(t *testing.T) {
+	doc := &jiraADFDocument{
+		Type: "doc",
+		Content: []jiraADFContent{
+			{Type: "paragraph", Content: []jiraADFContent{
+				{Type: "text", Text: "Line 1"},
+				{Type: "hardBreak"},
+				{Type: "text", Text: "Line 2"},
+			}},
+			{Type: "bulletList", Content: []jiraADFContent{
+				{Type: "listItem", Content: []jiraADFContent{
+					{Type: "paragraph", Content: []jiraADFContent{
+						{Type: "text", Text: "Item 1"},
+					}},
+				}},
+				{Type: "listItem", Content: []jiraADFContent{
+					{Type: "paragraph", Content: []jiraADFContent{
+						{Type: "text", Text: "Item 2"},
+					}},
+				}},
+			}},
+		},
+	}
+	got := adfToText(doc)
+	want := "Line 1\nLine 2\nItem 1\nItem 2"
+	if got != want {
+		t.Fatalf("adfToText rich = %q; want %q", got, want)
+	}
+}
+
+func TestJiraADFToTextRepoDirectiveSeparateParagraphs(t *testing.T) {
+	// Repo: and Branch: in separate paragraphs must produce separate lines
+	// so ParseRepoDirective can find both.
+	doc := &jiraADFDocument{
+		Type: "doc",
+		Content: []jiraADFContent{
+			{Type: "paragraph", Content: []jiraADFContent{
+				{Type: "text", Text: "Repo: acme/api"},
+			}},
+			{Type: "paragraph", Content: []jiraADFContent{
+				{Type: "text", Text: "Branch: develop"},
+			}},
+		},
+	}
+	got := adfToText(doc)
+	if !strings.Contains(got, "Repo: acme/api") {
+		t.Fatalf("missing Repo directive in %q", got)
+	}
+	ref, branch := ParseRepoDirective(got)
+	if ref != "acme/api" || branch != "develop" {
+		t.Fatalf("ParseRepoDirective(%q) = %q, %q; want acme/api, develop", got, ref, branch)
+	}
+}
+
 func TestJiraBuildFetchJQLStatus(t *testing.T) {
 	src := NewJira(JiraConfig{
 		Project:       "PROJ",

--- a/internal/source/jira_test.go
+++ b/internal/source/jira_test.go
@@ -1,0 +1,260 @@
+package source
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestJiraTicketUsesKeyAsIdentifier(t *testing.T) {
+	src := NewJira(JiraConfig{
+		BaseURL:        "https://test.atlassian.net",
+		TriggerStatus:  "To Do",
+		InReviewStatus: "In Review",
+		Project:        "PROJ",
+	})
+	ticket := src.ticket(jiraIssue{
+		ID:  "10001",
+		Key: "PROJ-42",
+		Fields: jiraFields{
+			Summary: "Fix login flow",
+			Description: &jiraADFDocument{
+				Type: "doc",
+				Content: []jiraADFContent{
+					{Type: "paragraph", Content: []jiraADFContent{
+						{Type: "text", Text: "Details about the issue"},
+					}},
+				},
+			},
+			Status:  jiraStatus{Name: "To Do"},
+			Project: jiraProject{Key: "PROJ", Name: "Project"},
+			Labels:  []string{"noctra", "agent:codex"},
+			Comment: jiraCommentPage{Comments: []jiraComment{
+				{
+					Body: &jiraADFDocument{
+						Type: "doc",
+						Content: []jiraADFContent{
+							{Type: "paragraph", Content: []jiraADFContent{
+								{Type: "text", Text: "Please keep the old redirect path."},
+							}},
+						},
+					},
+					Author: jiraUser{DisplayName: "Alice"},
+				},
+			}},
+		},
+	})
+	if ticket.Identifier != "PROJ-42" {
+		t.Fatalf("Identifier = %q; want PROJ-42", ticket.Identifier)
+	}
+	if ticket.Source != "jira" {
+		t.Fatalf("Source = %q; want jira", ticket.Source)
+	}
+	if ticket.ID != "10001" {
+		t.Fatalf("ID = %q; want 10001", ticket.ID)
+	}
+	if ticket.URL != "https://test.atlassian.net/browse/PROJ-42" {
+		t.Fatalf("URL = %q", ticket.URL)
+	}
+	if ticket.Title != "Fix login flow" {
+		t.Fatalf("Title = %q", ticket.Title)
+	}
+	if ticket.Description != "Details about the issue" {
+		t.Fatalf("Description = %q", ticket.Description)
+	}
+	if ticket.ProjectName != "PROJ" {
+		t.Fatalf("ProjectName = %q", ticket.ProjectName)
+	}
+	if got := ticket.BackendLabel(); got != "codex" {
+		t.Fatalf("BackendLabel = %q; want codex", got)
+	}
+	if got, want := ticket.ClarificationComments(), []string{"Alice: Please keep the old redirect path."}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("ClarificationComments = %#v; want %#v", got, want)
+	}
+}
+
+func TestJiraTicketHonorsRepoDirective(t *testing.T) {
+	src := NewJira(JiraConfig{
+		BaseURL:        "https://test.atlassian.net",
+		TriggerStatus:  "To Do",
+		InReviewStatus: "In Review",
+		Project:        "PROJ",
+	})
+	ticket := src.ticket(jiraIssue{
+		ID:  "10002",
+		Key: "PROJ-7",
+		Fields: jiraFields{
+			Summary: "Route elsewhere",
+			Description: &jiraADFDocument{
+				Type: "doc",
+				Content: []jiraADFContent{
+					{Type: "paragraph", Content: []jiraADFContent{
+						{Type: "text", Text: "Repo: acme/api\nBranch: develop"},
+					}},
+				},
+			},
+			Status:  jiraStatus{Name: "To Do"},
+			Project: jiraProject{Key: "PROJ"},
+		},
+	})
+	if ticket.RepoRef != "acme/api" || ticket.RepoBranch != "develop" {
+		t.Fatalf("repo directive = %q, %q; want acme/api, develop", ticket.RepoRef, ticket.RepoBranch)
+	}
+}
+
+func TestJiraTicketNoDescription(t *testing.T) {
+	src := NewJira(JiraConfig{
+		BaseURL:        "https://test.atlassian.net",
+		TriggerStatus:  "To Do",
+		InReviewStatus: "In Review",
+		Project:        "PROJ",
+	})
+	ticket := src.ticket(jiraIssue{
+		ID:  "10003",
+		Key: "PROJ-99",
+		Fields: jiraFields{
+			Summary:     "No body",
+			Description: nil,
+			Status:      jiraStatus{Name: "To Do"},
+			Project:     jiraProject{Key: "PROJ"},
+		},
+	})
+	if ticket.Description != "" {
+		t.Fatalf("Description = %q; want empty", ticket.Description)
+	}
+	if ticket.RepoRef != "" {
+		t.Fatalf("RepoRef = %q; want empty", ticket.RepoRef)
+	}
+}
+
+func TestJiraADFToText(t *testing.T) {
+	doc := &jiraADFDocument{
+		Type: "doc",
+		Content: []jiraADFContent{
+			{Type: "paragraph", Content: []jiraADFContent{
+				{Type: "text", Text: "Hello "},
+				{Type: "text", Text: "world"},
+			}},
+			{Type: "paragraph", Content: []jiraADFContent{
+				{Type: "text", Text: "Second paragraph"},
+			}},
+		},
+	}
+	got := adfToText(doc)
+	want := "Hello world\nSecond paragraph"
+	if got != want {
+		t.Fatalf("adfToText = %q; want %q", got, want)
+	}
+}
+
+func TestJiraADFToTextNil(t *testing.T) {
+	if got := adfToText(nil); got != "" {
+		t.Fatalf("adfToText(nil) = %q; want empty", got)
+	}
+}
+
+func TestJiraBuildFetchJQLStatus(t *testing.T) {
+	src := NewJira(JiraConfig{
+		Project:       "PROJ",
+		TriggerStatus: "To Do",
+	})
+	got := src.buildFetchJQL()
+	want := `project = "PROJ" AND status = "To Do" ORDER BY created ASC`
+	if got != want {
+		t.Fatalf("buildFetchJQL (status) = %q; want %q", got, want)
+	}
+}
+
+func TestJiraBuildFetchJQLLabel(t *testing.T) {
+	src := NewJira(JiraConfig{
+		Project:       "PROJ",
+		TriggerLabel:  "noctra",
+		TriggerStatus: "To Do",
+	})
+	got := src.buildFetchJQL()
+	want := `project = "PROJ" AND labels = "noctra" AND statusCategory != "Done" ORDER BY created ASC`
+	if got != want {
+		t.Fatalf("buildFetchJQL (label) = %q; want %q", got, want)
+	}
+}
+
+func TestJiraPrepareValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  JiraConfig
+		want string
+	}{
+		{
+			name: "missing base URL",
+			cfg:  JiraConfig{UserEmail: "x", APIToken: "x", Project: "X", TriggerStatus: "X", InReviewStatus: "X"},
+			want: "JIRA_BASE_URL",
+		},
+		{
+			name: "missing user email",
+			cfg:  JiraConfig{BaseURL: "https://x.atlassian.net", APIToken: "x", Project: "X", TriggerStatus: "X", InReviewStatus: "X"},
+			want: "JIRA_USER_EMAIL",
+		},
+		{
+			name: "missing API token",
+			cfg:  JiraConfig{BaseURL: "https://x.atlassian.net", UserEmail: "x", Project: "X", TriggerStatus: "X", InReviewStatus: "X"},
+			want: "JIRA_API_TOKEN",
+		},
+		{
+			name: "missing project",
+			cfg:  JiraConfig{BaseURL: "https://x.atlassian.net", UserEmail: "x", APIToken: "x", TriggerStatus: "X", InReviewStatus: "X"},
+			want: "JIRA_PROJECT",
+		},
+		{
+			name: "missing trigger",
+			cfg:  JiraConfig{BaseURL: "https://x.atlassian.net", UserEmail: "x", APIToken: "x", Project: "X", InReviewStatus: "X"},
+			want: "JIRA_TRIGGER_STATUS",
+		},
+		{
+			name: "missing in-review status",
+			cfg:  JiraConfig{BaseURL: "https://x.atlassian.net", UserEmail: "x", APIToken: "x", Project: "X", TriggerStatus: "X"},
+			want: "JIRA_IN_REVIEW_STATUS",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := NewJira(tt.cfg)
+			err := src.Prepare(nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := err.Error(); !strings.Contains(got, tt.want) {
+				t.Fatalf("error = %q; want to contain %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJiraPrepareTrimsBaseURL(t *testing.T) {
+	src := NewJira(JiraConfig{
+		BaseURL:        "https://test.atlassian.net/",
+		UserEmail:      "x@x.com",
+		APIToken:       "token",
+		Project:        "P",
+		TriggerStatus:  "Open",
+		InReviewStatus: "In Review",
+	})
+	if err := src.Prepare(nil); err != nil {
+		t.Fatal(err)
+	}
+	if src.cfg.BaseURL != "https://test.atlassian.net" {
+		t.Fatalf("BaseURL = %q; trailing slash not trimmed", src.cfg.BaseURL)
+	}
+}
+
+func TestJiraPrepareLabelModeSatisfiesTrigger(t *testing.T) {
+	src := NewJira(JiraConfig{
+		BaseURL:        "https://test.atlassian.net",
+		UserEmail:      "x@x.com",
+		APIToken:       "token",
+		Project:        "P",
+		TriggerLabel:   "noctra",
+		InReviewStatus: "In Review",
+	})
+	if err := src.Prepare(nil); err != nil {
+		t.Fatalf("Prepare() unexpected error: %v", err)
+	}
+}

--- a/internal/source/jira_test.go
+++ b/internal/source/jira_test.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -217,7 +218,7 @@ func TestJiraPrepareValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			src := NewJira(tt.cfg)
-			err := src.Prepare(nil)
+			err := src.Prepare(context.Background())
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -237,7 +238,7 @@ func TestJiraPrepareTrimsBaseURL(t *testing.T) {
 		TriggerStatus:  "Open",
 		InReviewStatus: "In Review",
 	})
-	if err := src.Prepare(nil); err != nil {
+	if err := src.Prepare(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if src.cfg.BaseURL != "https://test.atlassian.net" {
@@ -254,7 +255,7 @@ func TestJiraPrepareLabelModeSatisfiesTrigger(t *testing.T) {
 		TriggerLabel:   "noctra",
 		InReviewStatus: "In Review",
 	})
-	if err := src.Prepare(nil); err != nil {
+	if err := src.Prepare(context.Background()); err != nil {
 		t.Fatalf("Prepare() unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## ENG-250: Jira as a trigger source (TicketSource adapter)

**Linear:** https://linear.app/amazz/issue/ENG-250/jira-as-a-trigger-source-ticketsource-adapter

## What was implemented

Implemented Jira Cloud as a `TicketSource` adapter (ENG-250), following the same pattern as the GitHub Issues adapter from ENG-249/PR #217.

**New files:**
- `internal/source/jira.go` — Full `TicketSource` implementation (`Prepare`/`Fetch`/`FetchByIdentifier`/`FetchComments`/`RemovePlanLabel`/`BackToTrigger`/`MarkReady`/`Comment`) using the Jira Cloud REST API v3 with basic auth (email + API token). No external dependencies — uses `net/http` + `encoding/json` directly.
- `internal/source/jira_test.go` — Unit tests for ticket conversion, ADF→text extraction, JQL construction, `Repo:`/`Branch:` directive parsing, and `Prepare()` validation.

**Modified files:**
- `internal/config/config.go` — Added 7 Jira config fields (`JIRA_BASE_URL`, `JIRA_USER_EMAIL`, `JIRA_API_TOKEN`, `JIRA_PROJECT`, `JIRA_TRIGGER_STATUS`, `JIRA_TRIGGER_LABEL`, `JIRA_IN_REVIEW_STATUS`), `DefaultJiraInReviewStatus` constant, `.env` loading, and `Validate()` source-conditional validation (jira-only runs require no Linear/GitHub keys).
- `internal/pipeline/pipeline.go` — Registered `"jira"` case in `buildTicketSources`, wiring `JiraConfig` from the pipeline's `Config`.
- `.env.example` — Documented all Jira config variables with usage notes.

**Key decisions:**
- Uses the **native Jira key** (e.g. `PROJ-123`) as `Ticket.Identifier` — no synthetic prefix like GitHub's `GH-*`. Jira keys are already globally unique and human-meaningful.
- **ADF (Atlassian Document Format)** descriptions/comments are flattened to plain text for the agent prompt and `Repo:`/`Branch:` directive parsing via a recursive `adfToText()` helper.
- `MarkReady()` performs a **status transition** (via the Jira transitions API — workflow-aware) + trigger label removal + PR notification comment.
- `BackToTrigger()` posts a comment only (Jira workflow transitions are complex/non-reversible, matching the GitHub adapter's approach).
- Trigger can be either a **status** (`JIRA_TRIGGER_STATUS`) or a **label** (`JIRA_TRIGGER_LABEL`) via JQL, giving flexibility to different Jira workflow setups.
- Zero external dependencies added — the adapter uses only stdlib packages.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*
<!-- noctra-authored -->