### PR TITLE
feat: detect Conventional Commits from a GoReleaser changelog config

### DIFF
--- a/internal/repo/conventional.go
+++ b/internal/repo/conventional.go
@@ -42,7 +42,7 @@ func UsesConventionalCommits(repoPath string) bool {
 // goreleaserUsesConventional reports whether a GoReleaser changelog is grouped
 // by conventional types. Both ^feat and ^fix are required so plain configs don't match.
 func goreleaserUsesConventional(repoPath string) bool {
-	for _, name := range []string{".goreleaser.yaml", ".goreleaser.yml"} {
+	for _, name := range []string{".goreleaser.yaml", ".goreleaser.yml", "goreleaser.yaml", "goreleaser.yml"} {
 		data, err := os.ReadFile(filepath.Join(repoPath, name))
 		if err != nil {
 			continue

--- a/internal/repo/conventional.go
+++ b/internal/repo/conventional.go
@@ -21,7 +21,8 @@ var ccConfigFiles = []string{
 var ccPackageRefs = []string{"semantic-release", "commitlint", "commitizen", "standard-version"}
 
 // UsesConventionalCommits reports whether the repo at repoPath uses
-// Conventional Commits, detected via config file or package.json reference.
+// Conventional Commits, detected via a CC/release config file, a package.json
+// reference, or a GoReleaser changelog grouped by conventional types.
 func UsesConventionalCommits(repoPath string) bool {
 	for _, name := range ccConfigFiles {
 		if _, err := os.Stat(filepath.Join(repoPath, name)); err == nil {
@@ -34,6 +35,26 @@ func UsesConventionalCommits(repoPath string) bool {
 			if strings.Contains(s, ref) {
 				return true
 			}
+		}
+	}
+	return goreleaserUsesConventional(repoPath)
+}
+
+// goreleaserUsesConventional reports whether a GoReleaser config groups its
+// changelog by Conventional Commit types. GoReleaser alone doesn't imply
+// Conventional Commits, so we require changelog group regexps anchored on the
+// canonical feat/fix prefixes (e.g. "^feat(\(.+\))?!?:") — present in CC setups,
+// absent from default GoReleaser configs.
+func goreleaserUsesConventional(repoPath string) bool {
+	for _, name := range []string{".goreleaser.yaml", ".goreleaser.yml"} {
+		data, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			continue
+		}
+		s := string(data)
+		if strings.Contains(s, "changelog:") &&
+			strings.Contains(s, "^feat") && strings.Contains(s, "^fix") {
+			return true
 		}
 	}
 	return false

--- a/internal/repo/conventional.go
+++ b/internal/repo/conventional.go
@@ -20,9 +20,8 @@ var ccConfigFiles = []string{
 // ccPackageRefs are package.json substrings indicating a CC/release tool.
 var ccPackageRefs = []string{"semantic-release", "commitlint", "commitizen", "standard-version"}
 
-// UsesConventionalCommits reports whether the repo at repoPath uses
-// Conventional Commits, detected via a CC/release config file, a package.json
-// reference, or a GoReleaser changelog grouped by conventional types.
+// UsesConventionalCommits reports whether the repo uses Conventional Commits,
+// detected via a CC/release config file, package.json, or GoReleaser changelog.
 func UsesConventionalCommits(repoPath string) bool {
 	for _, name := range ccConfigFiles {
 		if _, err := os.Stat(filepath.Join(repoPath, name)); err == nil {
@@ -40,11 +39,8 @@ func UsesConventionalCommits(repoPath string) bool {
 	return goreleaserUsesConventional(repoPath)
 }
 
-// goreleaserUsesConventional reports whether a GoReleaser config groups its
-// changelog by Conventional Commit types. GoReleaser alone doesn't imply
-// Conventional Commits, so we require changelog group regexps anchored on the
-// canonical feat/fix prefixes (e.g. "^feat(\(.+\))?!?:") — present in CC setups,
-// absent from default GoReleaser configs.
+// goreleaserUsesConventional reports whether a GoReleaser changelog is grouped
+// by conventional types. Both ^feat and ^fix are required so plain configs don't match.
 func goreleaserUsesConventional(repoPath string) bool {
 	for _, name := range []string{".goreleaser.yaml", ".goreleaser.yml"} {
 		data, err := os.ReadFile(filepath.Join(repoPath, name))

--- a/internal/repo/conventional_test.go
+++ b/internal/repo/conventional_test.go
@@ -49,6 +49,28 @@ func TestUsesConventionalCommits(t *testing.T) {
 		}
 	})
 
+	t.Run("goreleaser changelog grouped by conventional types", func(t *testing.T) {
+		dir := t.TempDir()
+		yml := "changelog:\n  groups:\n    - title: Features\n      regexp: '^feat(\\(.+\\))?!?:'\n    - title: Bug Fixes\n      regexp: '^fix(\\(.+\\))?!?:'\n"
+		if err := os.WriteFile(filepath.Join(dir, ".goreleaser.yaml"), []byte(yml), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !UsesConventionalCommits(dir) {
+			t.Error("want true when .goreleaser.yaml groups the changelog by conventional types")
+		}
+	})
+
+	t.Run("goreleaser without conventional grouping", func(t *testing.T) {
+		dir := t.TempDir()
+		yml := "builds:\n  - main: ./cmd/app\nchangelog:\n  use: github\n"
+		if err := os.WriteFile(filepath.Join(dir, ".goreleaser.yaml"), []byte(yml), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if UsesConventionalCommits(dir) {
+			t.Error("want false for a GoReleaser config without conventional changelog groups")
+		}
+	})
+
 	t.Run("plain repo", func(t *testing.T) {
 		dir := t.TempDir()
 		if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"x"}`), 0o600); err != nil {


### PR DESCRIPTION
## Problem

`repo.UsesConventionalCommits` only recognized JS tooling (commitlint, semantic-release, commitizen, standard-version) or `package.json` refs. Go repos that drive their changelog from **GoReleaser** — including **Noctra's own repo** — were therefore treated as *non*-conventional.

Consequence: when Noctra implements a ticket in such a repo, it titles the PR/commit `ENG-123: <title>` instead of `feat: <title>`, so those commits fall into the **uncategorized** bucket of the GoReleaser changelog (which groups by conventional type). This is why the recent Noctra-authored PRs came out as `ENG-2xx:` rather than `feat:`.

## Change

Add `goreleaserUsesConventional`: if `.goreleaser.yaml`/`.yml` has a `changelog:` section with group regexps anchored on **both** `^feat` and `^fix`, the repo is treated as Conventional Commits. Requiring both anchors avoids false positives — a default GoReleaser config (no conventional grouping) won't match.

## Test

Extended `TestUsesConventionalCommits` with two cases: a GoReleaser config grouped by conventional types (→ true) and a plain GoReleaser config (→ false). `go build`, `go vet`, `gofmt`, `go test ./internal/repo/` all clean. Verified Noctra's own `.goreleaser.yaml` now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)