### PR TITLE
feat: treat agent NO_CHANGES as a completion, not a re-queue loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,10 @@ TRIGGER_STATE=Next
 # State set after the PR is created
 IN_REVIEW_STATE=In Review
 
+# State a ticket is moved to when the agent reports there's nothing to do
+# (NO_CHANGES). Optional — if the name isn't found, the ticket is just skipped.
+DONE_STATE=Done
+
 # ── Repositories ──────────────────────────────────────────────────────────────
 #
 # Noctra picks the target repo per-ticket from the ticket's Linear PROJECT.

--- a/internal/agent/log.go
+++ b/internal/agent/log.go
@@ -71,13 +71,15 @@ func BlockedLine(output string) string {
 
 var noChangesRe = regexp.MustCompile(`(?im)^NO_CHANGES:\s*(.*)$`)
 
-// NoChangesLine returns the reason from the first "NO_CHANGES: …" line, or "".
+// NoChangesLine returns the reason from the last "NO_CHANGES: …" line, or "".
+// The last match wins (mirroring ReleaseBump) so an echoed prompt instruction
+// or a draft earlier in the log can't trigger a false positive.
 func NoChangesLine(output string) string {
-	m := noChangesRe.FindStringSubmatch(output)
-	if m == nil {
+	matches := noChangesRe.FindAllStringSubmatch(output, -1)
+	if len(matches) == 0 {
 		return ""
 	}
-	return strings.TrimSpace(m[1])
+	return strings.TrimSpace(matches[len(matches)-1][1])
 }
 
 // releaseRe matches the "RELEASE: <bump>" line the prompt asks the agent to

--- a/internal/agent/log.go
+++ b/internal/agent/log.go
@@ -69,6 +69,17 @@ func BlockedLine(output string) string {
 	return m
 }
 
+var noChangesRe = regexp.MustCompile(`(?im)^NO_CHANGES:\s*(.*)$`)
+
+// NoChangesLine returns the reason from the first "NO_CHANGES: …" line, or "".
+func NoChangesLine(output string) string {
+	m := noChangesRe.FindStringSubmatch(output)
+	if m == nil {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
 // releaseRe matches the "RELEASE: <bump>" line the prompt asks the agent to
 // emit after its summary. Case-insensitive, anchored to start of line.
 var releaseRe = regexp.MustCompile(`(?im)^RELEASE:\s*(.+)$`)

--- a/internal/agent/log_test.go
+++ b/internal/agent/log_test.go
@@ -42,6 +42,16 @@ func TestBlockedLine_DetectsNewBlocked(t *testing.T) {
 	}
 }
 
+func TestNoChangesLine_DetectsReasonAndTrims(t *testing.T) {
+	tail := "DEBUG: pwd = /repo\nNO_CHANGES: Site already documents v0.21.1\n"
+	if got := NoChangesLine(tail); got != "Site already documents v0.21.1" {
+		t.Errorf("NoChangesLine: got %q", got)
+	}
+	if NoChangesLine("no marker here") != "" {
+		t.Error("NoChangesLine should be empty without a marker")
+	}
+}
+
 func TestExtractSummary_StripsDebugAndKeepsLastAttempt(t *testing.T) {
 	log := `--- Attempt 2024-01-01T00:00:00 ---
 First attempt that should be ignored.

--- a/internal/agent/log_test.go
+++ b/internal/agent/log_test.go
@@ -52,6 +52,15 @@ func TestNoChangesLine_DetectsReasonAndTrims(t *testing.T) {
 	}
 }
 
+func TestNoChangesLine_UsesLastMatch(t *testing.T) {
+	// An echoed prompt instruction precedes the agent's real answer; the last
+	// match must win so the echo doesn't decide the outcome.
+	out := "say NO_CHANGES: <reason> and stop\n...work...\nNO_CHANGES: Already done\n"
+	if got := NoChangesLine(out); got != "Already done" {
+		t.Errorf("NoChangesLine: got %q, want last match %q", got, "Already done")
+	}
+}
+
 func TestExtractSummary_StripsDebugAndKeepsLastAttempt(t *testing.T) {
 	log := `--- Attempt 2024-01-01T00:00:00 ---
 First attempt that should be ignored.

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -75,6 +75,7 @@ Guidelines: none = docs/chore/internal-only, patch = bug fix, minor = new featur
 - Stay focused on this ticket only — do not modify unrelated code.
 - Follow existing project conventions and patterns exactly.
 - If you get stuck or need human input, say BLOCKED: <reason> and stop.
+- If the ticket is already satisfied and there is genuinely nothing to change, say NO_CHANGES: <reason> and stop — do not make trivial edits just to produce a diff.
 - Do NOT create PRs or push branches — Noctra handles that.
 
 ## When done:
@@ -102,6 +103,7 @@ Provide a brief summary of what was implemented and any important decisions made
 - Stay focused on this ticket only — do not modify unrelated code.
 - Follow existing project conventions and patterns exactly.
 - If you get stuck or need human input, say BLOCKED: <reason> and stop.
+- If the ticket is already satisfied and there is genuinely nothing to change, say NO_CHANGES: <reason> and stop — do not make trivial edits just to produce a diff.
 - Do NOT create PRs or push branches — Noctra handles that.
 
 ## When done:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,7 @@ const (
 	DefaultTriggerMode      = "state"
 	DefaultTriggerState     = "Next"
 	DefaultInReviewState    = "In Review"
+	DefaultDoneState        = "Done"
 	DefaultMainBranch       = "main"
 	DefaultMaxConcurrent    = 3
 	DefaultPollInterval     = 30 * time.Second
@@ -142,6 +143,7 @@ type Config struct {
 	TriggerState            string // watched column name (state mode)
 	TriggerLabel            string // label name to watch (label mode)
 	InReviewState           string
+	DoneState               string
 
 	// Repos
 	RepoPath   string // optional single-repo fallback for unmapped projects
@@ -252,6 +254,7 @@ func Load(scriptDir string) (*Config, error) {
 		TriggerState:            getenv(fileEnv, "TRIGGER_STATE", DefaultTriggerState),
 		TriggerLabel:            getenv(fileEnv, "TRIGGER_LABEL", ""),
 		InReviewState:           getenv(fileEnv, "IN_REVIEW_STATE", DefaultInReviewState),
+		DoneState:               getenv(fileEnv, "DONE_STATE", DefaultDoneState),
 		GitHubTriggerLabel:      getenv(fileEnv, "GITHUB_TRIGGER_LABEL", ""),
 
 		RepoPath:   getenv(fileEnv, "REPO_PATH", ""),

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -593,6 +593,7 @@ func TestResolveStateIDs_SkipsTriggerWhenEmpty(t *testing.T) {
 						"nodes": []map[string]any{
 							{"id": "s_next", "name": "Next"},
 							{"id": "s_review", "name": "In Review"},
+							{"id": "s_done", "name": "Done"},
 						},
 					},
 				}},
@@ -600,8 +601,8 @@ func TestResolveStateIDs_SkipsTriggerWhenEmpty(t *testing.T) {
 		},
 	})
 
-	// With empty triggerName, only in-review is required.
-	ids, err := client.ResolveStateIDs(context.Background(), "ENG", "", "In Review")
+	// With empty triggerName, only in-review is required. Done resolves too.
+	ids, err := client.ResolveStateIDs(context.Background(), "ENG", "", "In Review", "Done")
 	if err != nil {
 		t.Fatalf("ResolveStateIDs: %v", err)
 	}
@@ -610,6 +611,9 @@ func TestResolveStateIDs_SkipsTriggerWhenEmpty(t *testing.T) {
 	}
 	if ids.InReview != "s_review" {
 		t.Errorf("InReview: got %q, want %q", ids.InReview, "s_review")
+	}
+	if ids.Done != "s_done" {
+		t.Errorf("Done: got %q, want %q", ids.Done, "s_done")
 	}
 }
 

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -11,6 +11,7 @@ import (
 type StateIDs struct {
 	Trigger  string
 	InReview string
+	Done     string
 }
 
 // WorkflowStateID is a Linear workflow state with the fields Noctra needs for
@@ -20,11 +21,10 @@ type WorkflowStateID struct {
 	Name string
 }
 
-// ResolveStateIDs looks up the IDs for the trigger and in-review state names
-// within the team identified by teamKey (e.g. "ENG"). When triggerName is
-// empty (label-based trigger mode), the trigger-state lookup is skipped —
-// only the in-review state is required.
-func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inReviewName string) (StateIDs, error) {
+// ResolveStateIDs resolves trigger, in-review, and done state IDs for a team.
+// triggerName empty (label mode) skips the trigger lookup; doneName is optional
+// (empty ids.Done if not found). Only in-review is required.
+func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inReviewName, doneName string) (StateIDs, error) {
 	states, err := c.TeamWorkflowStates(ctx, teamKey)
 	if err != nil {
 		return StateIDs{}, err
@@ -39,6 +39,9 @@ func (c *Client) ResolveStateIDs(ctx context.Context, teamKey, triggerName, inRe
 			ids.Trigger = s.ID
 		case inReviewName:
 			ids.InReview = s.ID
+		}
+		if doneName != "" && s.Name == doneName {
+			ids.Done = s.ID
 		}
 	}
 	if triggerName != "" && ids.Trigger == "" {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -663,6 +663,7 @@ func buildTicketSources(cfg *config.Config, linearClient *linear.Client) []sourc
 				TriggerState:     cfg.TriggerState,
 				TriggerLabel:     cfg.TriggerLabel,
 				InReviewState:    cfg.InReviewState,
+				DoneState:        cfg.DoneState,
 				PlanConfirmLabel: cfg.PlanConfirmLabel,
 			}))
 		case "github":

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -273,6 +273,16 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		return
 	}
 
+	// ── NO_CHANGES — agent reports the ticket is already satisfied ────────────
+	if nc := agent.NoChangesLine(output); nc != "" {
+		logger.Info("no changes needed", "reason", nc)
+		p.resolveNoChanges(ctx, issue, fmt.Sprintf(
+			"✅ **Noctra: nothing to do**\n\n> %s\n\nNo changes were needed, so this ticket was closed automatically.", nc))
+		p.notifier.Send(ctx, fmt.Sprintf("✅ *%s* — nothing to do\n%s", id, notify.EscapeMarkdown(nc)))
+		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
+		return
+	}
+
 	// ── BLOCKED ──────────────────────────────────────────────────────────────
 	// Count the attempt: the ticket is left in the trigger state, so without a
 	// retry cap it would be re-dispatched every poll until the dispatch budget
@@ -585,6 +595,28 @@ func (p *Pipeline) ticketBackToTrigger(ctx context.Context, ticket source.Ticket
 
 func (p *Pipeline) ticketComment(ctx context.Context, ticket source.Ticket, body string) error {
 	return p.ticketSource(ticket).Comment(ctx, ticket, body)
+}
+
+// resolveNoChanges comments, then moves a no-op ticket to Done (or skips it for
+// the session) so it leaves the trigger state and isn't re-dispatched.
+func (p *Pipeline) resolveNoChanges(ctx context.Context, ticket source.Ticket, body string) {
+	if err := p.ticketComment(ctx, ticket, body); err != nil {
+		slog.Warn("no-changes comment failed", "issue_id", ticket.ID, "err", err)
+	}
+	if dm, ok := p.ticketSource(ticket).(source.DoneMarker); ok {
+		if err := dm.MarkDone(ctx, ticket); err == nil {
+			return
+		} else {
+			slog.Warn("mark-done failed; skipping ticket instead", "issue_id", ticket.ID, "err", err)
+		}
+	}
+	p.markSkipped(ticket.Identifier)
+}
+
+func (p *Pipeline) markSkipped(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.skipped[id] = struct{}{}
 }
 
 func (p *Pipeline) ticketSource(ticket source.Ticket) source.TicketSource {

--- a/internal/source/linear.go
+++ b/internal/source/linear.go
@@ -147,10 +147,23 @@ func (s *LinearSource) MarkReady(ctx context.Context, ticket Ticket, info ReadyI
 }
 
 func (s *LinearSource) MarkDone(ctx context.Context, ticket Ticket) error {
-	if s.states.Done == "" {
+	var firstErr error
+	// In label mode the trigger label — not the state — is what re-fetches a
+	// ticket, so it must be removed or the no-op loops back into dispatch.
+	if s.cfg.TriggerMode == "label" && s.triggerLabelID != "" {
+		if err := s.client.RemoveLabel(ctx, ticket.ID, s.triggerLabelID); err != nil {
+			firstErr = err
+		}
+	}
+	if s.states.Done != "" {
+		if err := s.client.SetState(ctx, ticket.ID, s.states.Done); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	} else if s.cfg.TriggerMode != "label" {
+		// State mode relies on the Done transition to leave the trigger column.
 		return fmt.Errorf("no Done state resolved (check DONE_STATE)")
 	}
-	return s.client.SetState(ctx, ticket.ID, s.states.Done)
+	return firstErr
 }
 
 func (s *LinearSource) Comment(ctx context.Context, ticket Ticket, body string) error {

--- a/internal/source/linear.go
+++ b/internal/source/linear.go
@@ -14,6 +14,7 @@ type LinearConfig struct {
 	TriggerState     string
 	TriggerLabel     string
 	InReviewState    string
+	DoneState        string
 	PlanConfirmLabel string
 }
 
@@ -43,7 +44,7 @@ func (s *LinearSource) Prepare(ctx context.Context) error {
 	if s.cfg.TriggerMode == "label" {
 		triggerStateName = ""
 	}
-	states, err := s.client.ResolveStateIDs(ctx, s.cfg.TeamKey, triggerStateName, s.cfg.InReviewState)
+	states, err := s.client.ResolveStateIDs(ctx, s.cfg.TeamKey, triggerStateName, s.cfg.InReviewState, s.cfg.DoneState)
 	if err != nil {
 		return fmt.Errorf("resolve linear states: %w", err)
 	}
@@ -143,6 +144,13 @@ func (s *LinearSource) MarkReady(ctx context.Context, ticket Ticket, info ReadyI
 		firstErr = err
 	}
 	return firstErr
+}
+
+func (s *LinearSource) MarkDone(ctx context.Context, ticket Ticket) error {
+	if s.states.Done == "" {
+		return fmt.Errorf("no Done state resolved (check DONE_STATE)")
+	}
+	return s.client.SetState(ctx, ticket.ID, s.states.Done)
 }
 
 func (s *LinearSource) Comment(ctx context.Context, ticket Ticket, body string) error {

--- a/internal/source/types.go
+++ b/internal/source/types.go
@@ -23,6 +23,12 @@ type TicketSource interface {
 	Comment(context.Context, Ticket, string) error
 }
 
+// DoneMarker is an optional capability for sources that can move a ticket to a
+// terminal "done" state (used on NO_CHANGES).
+type DoneMarker interface {
+	MarkDone(context.Context, Ticket) error
+}
+
 // ReadyInfo is the source-agnostic status update after Noctra opens a PR.
 type ReadyInfo struct {
 	PRURL        string


### PR DESCRIPTION
Implements **ENG-258**.

## Problem

The agent emitted `BLOCKED: Nothing to do` for a no-op, and Noctra re-queues *every* `BLOCKED` to the trigger state. So a ticket with nothing to do (e.g. an auto-generated `getnoctra.dev: document vX.Y.Z` with nothing to document) loops dispatch→blocked→back-to-`Next` until `MAX_RETRIES`, and every restart resets the counter and restarts the loop. A no-op is a *completion*, not "needs a human."

## Change

- **Prompt**: emit `NO_CHANGES: <reason>` when the ticket is already satisfied (distinct from `BLOCKED:`, reserved for genuinely needing human input).
- **`agent.NoChangesLine`** parses it.
- **Pipeline**: on `NO_CHANGES`, comment + move the ticket to a resolved **Done** state (`DONE_STATE`, default `"Done"`) and stop — no re-queue, no loop, no manual promotion. Sources without Done support fall back to being skipped for the session.
- Wired via an optional **`source.DoneMarker`** interface (Linear implements it); `ResolveStateIDs` now also resolves an optional Done state.

`BLOCKED` behavior (needs human → back to trigger, retry-capped) is unchanged.

## Tests

`TestNoChangesLine_*` (parser) and updated `ResolveStateIDs` test (Done resolution). `go build`, `go vet`, `gofmt`, `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)