### PR TITLE
feat: style Gemini review findings as attributed severity callouts

### DIFF
--- a/internal/pipeline/inline_comment.go
+++ b/internal/pipeline/inline_comment.go
@@ -1,0 +1,42 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ahmadAlMezaal/noctra/internal/review"
+)
+
+// inlineCommentBody renders a review finding as a GitHub-flavoured inline
+// comment: a severity-coloured alert callout (CAUTION/WARNING/NOTE) carrying a
+// Noctra/Gemini attribution header, with the model's comment quoted inside it.
+// The attribution makes clear the comment is automated review output rather
+// than the operator's own (the Pi posts under a personal GitHub account until a
+// dedicated bot identity exists). PostInlineComments appends the hidden reply
+// marker, so this body must not.
+func inlineCommentBody(f review.Finding, model, mode string) string {
+	alert, label := "NOTE", "REVIEW"
+	switch strings.ToLower(f.Severity) {
+	case "high":
+		alert, label = "CAUTION", "HIGH"
+	case "medium":
+		alert, label = "WARNING", "MEDIUM"
+	case "low":
+		alert, label = "NOTE", "LOW"
+	default:
+		if f.Severity != "" {
+			label = strings.ToUpper(f.Severity)
+		}
+	}
+
+	header := fmt.Sprintf("**%s** · 🌙 Noctra review (Gemini `%s` via `%s`)", label, model, mode)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "> [!%s]\n> %s\n>\n", alert, header)
+	for _, line := range strings.Split(strings.TrimSpace(f.Comment), "\n") {
+		b.WriteString("> ")
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/pipeline/inline_comment.go
+++ b/internal/pipeline/inline_comment.go
@@ -7,13 +7,6 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/review"
 )
 
-// inlineCommentBody renders a review finding as a GitHub-flavoured inline
-// comment: a severity-coloured alert callout (CAUTION/WARNING/NOTE) carrying a
-// Noctra/Gemini attribution header, with the model's comment quoted inside it.
-// The attribution makes clear the comment is automated review output rather
-// than the operator's own (the Pi posts under a personal GitHub account until a
-// dedicated bot identity exists). PostInlineComments appends the hidden reply
-// marker, so this body must not.
 func inlineCommentBody(f review.Finding, model, mode string) string {
 	alert, label := "NOTE", "REVIEW"
 	switch strings.ToLower(f.Severity) {

--- a/internal/pipeline/inline_comment_test.go
+++ b/internal/pipeline/inline_comment_test.go
@@ -1,0 +1,53 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ahmadAlMezaal/noctra/internal/review"
+)
+
+func TestInlineCommentBody(t *testing.T) {
+	tests := []struct {
+		name      string
+		severity  string
+		wantAlert string
+		wantLabel string
+	}{
+		{"high maps to caution", "high", "[!CAUTION]", "**HIGH**"},
+		{"medium maps to warning", "medium", "[!WARNING]", "**MEDIUM**"},
+		{"low maps to note", "low", "[!NOTE]", "**LOW**"},
+		{"unknown severity falls back to note", "blocker", "[!NOTE]", "**BLOCKER**"},
+		{"empty severity falls back to review note", "", "[!NOTE]", "**REVIEW**"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := review.Finding{Severity: tt.severity, Comment: "Guard against empty input."}
+			got := inlineCommentBody(f, "gemini-2.5-pro", "api")
+
+			if !strings.HasPrefix(got, "> "+tt.wantAlert) {
+				t.Errorf("body should open with %q callout, got:\n%s", tt.wantAlert, got)
+			}
+			if !strings.Contains(got, tt.wantLabel) {
+				t.Errorf("body missing severity label %q, got:\n%s", tt.wantLabel, got)
+			}
+			if !strings.Contains(got, "🌙 Noctra review (Gemini `gemini-2.5-pro` via `api`)") {
+				t.Errorf("body missing Noctra/Gemini attribution, got:\n%s", got)
+			}
+			if !strings.Contains(got, "> Guard against empty input.") {
+				t.Errorf("comment should be quoted inside the callout, got:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestInlineCommentBodyQuotesMultilineComment(t *testing.T) {
+	f := review.Finding{Severity: "high", Comment: "Line one.\nLine two."}
+	got := inlineCommentBody(f, "gemini-2.5-pro", "api")
+	if !strings.Contains(got, "> Line one.\n> Line two.") {
+		t.Errorf("every comment line should be blockquoted, got:\n%s", got)
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Errorf("body should not have a trailing newline, got:\n%q", got)
+	}
+}

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -587,10 +587,7 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		headSHA := gitHead(ctx, wt.Path)
 		ics := make([]github.InlineComment, 0, len(reviewFindings))
 		for _, f := range reviewFindings {
-			body := strings.TrimSpace(f.Comment)
-			if f.Severity != "" {
-				body = fmt.Sprintf("**%s priority**\n\n%s", strings.ToUpper(f.Severity), body)
-			}
+			body := inlineCommentBody(f, p.review.Model, p.review.Mode)
 			ics = append(ics, github.InlineComment{Path: f.Path, Line: f.Line, Body: body})
 		}
 		posted := p.gh.PostInlineComments(ctx, prURL, headSHA, ics)

--- a/internal/review/gemini.go
+++ b/internal/review/gemini.go
@@ -157,7 +157,7 @@ func buildStructuredPrompt(ticketTitle, ticketDescription, diff string) string {
 Return a JSON review:
 - "verdict": "PASS" if it is good to merge (minor nits are fine), otherwise "FAIL".
 - "summary": a 1-3 sentence overall assessment.
-- "findings": specific issues, each anchored to a changed line. For each finding set "path" (the file path exactly as it appears in the diff), "line" (a line number that appears as an added/changed line in the diff), "severity" ("high"/"medium"/"low"), and "comment" (the problem and a suggested fix). Only include findings you can anchor to a changed line; put anything broader in the summary. Use an empty array if there are none.`,
+- "findings": specific issues, each anchored to a changed line. For each finding set "path" (the file path exactly as it appears in the diff), "line" (a line number that appears as an added/changed line in the diff), "severity" ("high"/"medium"/"low"), and "comment" (the problem and a suggested fix; wrap any code, suggested replacements, or HTML in a fenced Markdown code block — a triple-backtick fence — rather than inline code spans, so it renders correctly on GitHub instead of as raw markup). Only include findings you can anchor to a changed line; put anything broader in the summary. Use an empty array if there are none.`,
 		ticketTitle, ticketDescription, diff)
 }
 


### PR DESCRIPTION
## What & why

Three small improvements to how Gemini review-gate findings appear as inline PR comments, surfaced while testing the review gate end-to-end:

1. **Severity as coloured callouts** — each finding now renders as a GitHub alert callout instead of plain `**HIGH priority**` bold text:
   - `high` → `[!CAUTION]` (red)
   - `medium` → `[!WARNING]` (amber)
   - `low` → `[!NOTE]` (blue)
2. **Attribution** — every inline comment carries a visible `🌙 Noctra review (Gemini <model> via <mode>)` header, so the comments read as automated review output rather than the operator's own. (The Pi posts under a personal GitHub account until a dedicated `noctra[bot]` identity exists — see ENG-212.)
3. **Code rendering fix** — the review prompt now tells Gemini to wrap code/HTML in fenced code blocks rather than inline code spans. Previously a suggested `<h1>…</h1>` snippet rendered as a raw heading + stray `;` chip in the posted comment.

## Sample output

A HIGH finding now posts:

```markdown
> [!CAUTION]
> **HIGH** · 🌙 Noctra review (Gemini `gemini-2.5-pro` via `api`)
>
> Interpolating `name` into HTML is an XSS risk. Escape it first:
> ```js
> return `<h1>Hello, ${escapeHtml(name)}</h1>`;
> ```
```

## Changes

- `internal/pipeline/inline_comment.go` (new) — pure `inlineCommentBody()` formatter.
- `internal/pipeline/process.go` — inline-comment loop uses the formatter.
- `internal/review/gemini.go` — review prompt instructs fenced code blocks.
- `internal/pipeline/inline_comment_test.go` (new) — severity mapping, attribution, multi-line quoting.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)