### PR TITLE
feat: ack PR feedback with a 👀 reaction on re-engagement (ENG-272)

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -451,6 +451,48 @@ func (c *Client) PostInlineComments(ctx context.Context, prURL, commitSHA string
 	return posted
 }
 
+// pullCommentReactionAPIPath builds the REST reactions path for an inline review comment.
+func pullCommentReactionAPIPath(prURL, commentID string) (string, error) {
+	u, err := url.Parse(prURL)
+	if err != nil {
+		return "", fmt.Errorf("parse PR URL %q: %w", prURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("unexpected PR URL shape: %q", prURL)
+	}
+	if strings.TrimSpace(commentID) == "" {
+		return "", fmt.Errorf("empty comment ID for %q", prURL)
+	}
+	return fmt.Sprintf("repos/%s/%s/pulls/comments/%s/reactions", parts[0], parts[1], commentID), nil
+}
+
+// AddEyesReaction posts a best-effort 👀 reaction on a comment to acknowledge
+// feedback. inline picks the API: REST reactions (numeric ID) vs the GraphQL
+// addReaction mutation, since conversation comments only give us a node ID.
+func (c *Client) AddEyesReaction(ctx context.Context, prURL, commentID string, inline bool) error {
+	if strings.TrimSpace(commentID) == "" {
+		return nil
+	}
+	var cmd *exec.Cmd
+	if inline {
+		apiPath, err := pullCommentReactionAPIPath(prURL, commentID)
+		if err != nil {
+			return err
+		}
+		cmd = exec.CommandContext(ctx, "gh", "api", "--method", "POST", apiPath, "-f", "content=eyes")
+	} else {
+		const q = `mutation($id:ID!){addReaction(input:{subjectId:$id,content:EYES}){reaction{content}}}`
+		cmd = exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+q, "-f", "id="+commentID)
+	}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if _, err := cmd.Output(); err != nil {
+		return fmt.Errorf("add eyes reaction: %w (%s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
 // replyToThread posts a reply on a review comment thread via the REST API.
 func (c *Client) replyToThread(ctx context.Context, owner, repo string, prNumber int, commentID int64, body string) error {
 	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%d/comments/%d/replies", owner, repo, prNumber, commentID)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -173,6 +173,31 @@ func TestReviewCommentsAPIPath(t *testing.T) {
 	}
 }
 
+func TestPullCommentReactionAPIPath(t *testing.T) {
+	cases := []struct {
+		url     string
+		id      string
+		want    string
+		wantErr bool
+	}{
+		{"https://github.com/me/auth/pull/12", "999", "repos/me/auth/pulls/comments/999/reactions", false},
+		{"https://github.com/me/auth/pull/12/files", "1", "repos/me/auth/pulls/comments/1/reactions", false},
+		{"https://github.com/me/auth/pull/12", "", "", true},
+		{"https://github.com/me/auth/issues/12", "5", "", true},
+		{"https://github.com/me", "5", "", true},
+	}
+	for _, c := range cases {
+		got, err := pullCommentReactionAPIPath(c.url, c.id)
+		if (err != nil) != c.wantErr {
+			t.Errorf("pullCommentReactionAPIPath(%q,%q): err=%v wantErr=%v", c.url, c.id, err, c.wantErr)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("pullCommentReactionAPIPath(%q,%q) = %q, want %q", c.url, c.id, got, c.want)
+		}
+	}
+}
+
 func TestParseActionsRunURL(t *testing.T) {
 	cases := []struct {
 		in               string

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -204,6 +204,8 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	logger := slog.With("id", identifier, "pr", ch.PR.URL)
 	logger.Info("re-engaging on PR", "events", len(ch.Events), "ci_failed", ch.CIFailure != nil)
 
+	p.ackEngagement(ctx, ch) // 👀 ack before the agent's slow reply
+
 	// Select the backend for this iteration — persisted state (from when the
 	// PR was created) takes priority so follow-up commits use the same backend.
 	backend := p.resolveIterateBackend(ctx, ch.PR.URL, identifier)
@@ -555,6 +557,18 @@ func (p *Pipeline) advanceCursor(ch watch.PRChanges) {
 		}
 	}); err != nil {
 		slog.Warn("pipeline: cursor advance failed", "url", ch.PR.URL, "err", err)
+	}
+}
+
+// ackEngagement posts a best-effort 👀 on each comment that triggered re-engagement.
+func (p *Pipeline) ackEngagement(ctx context.Context, ch watch.PRChanges) {
+	for _, ev := range ch.Events {
+		if ev.Type != watch.EventComment || ev.CommentID == "" {
+			continue
+		}
+		if err := p.gh.AddEyesReaction(ctx, ch.PR.URL, ev.CommentID, ev.Path != ""); err != nil {
+			slog.Warn("ack reaction failed", "pr", ch.PR.URL, "err", err)
+		}
 	}
 }
 

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"log/slog"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,6 +41,7 @@ type Event struct {
 	ReviewState string // populated when Type == EventReview
 	Path        string // file path, populated for inline review comments
 	Line        int    // line number, populated for inline review comments
+	CommentID   string // source comment ID, for reacting; empty for reviews
 }
 
 // CIFailure describes a head commit whose CI has completed with at least one
@@ -150,11 +152,12 @@ func (w *Watcher) diff(pr github.PR, d *github.Details, cursor state.PRState) PR
 			out.NewestComment = c.CreatedAt
 		}
 		ev := Event{
-			Type:   EventComment,
-			Author: c.Author,
-			Body:   c.Body,
-			URL:    c.URL,
-			At:     c.CreatedAt,
+			Type:      EventComment,
+			Author:    c.Author,
+			Body:      c.Body,
+			URL:       c.URL,
+			At:        c.CreatedAt,
+			CommentID: c.ID,
 		}
 		if w.actionable(ev) {
 			out.Events = append(out.Events, ev)
@@ -174,13 +177,14 @@ func (w *Watcher) diff(pr github.PR, d *github.Details, cursor state.PRState) PR
 			out.NewestComment = rc.CreatedAt
 		}
 		ev := Event{
-			Type:   EventComment,
-			Author: rc.Author,
-			Body:   rc.Body,
-			URL:    rc.URL,
-			At:     rc.CreatedAt,
-			Path:   rc.Path,
-			Line:   rc.Line,
+			Type:      EventComment,
+			Author:    rc.Author,
+			Body:      rc.Body,
+			URL:       rc.URL,
+			At:        rc.CreatedAt,
+			Path:      rc.Path,
+			Line:      rc.Line,
+			CommentID: strconv.FormatInt(rc.ID, 10),
 		}
 		if w.actionable(ev) {
 			out.Events = append(out.Events, ev)

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -45,6 +45,48 @@ func TestDiff_NewCommentByHumanIsActionable(t *testing.T) {
 	}
 }
 
+func TestDiff_PopulatesCommentIDForReactions(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	pr := github.PR{URL: "https://github.com/me/repo/pull/1", Number: 1}
+	details := &github.Details{
+		State: "OPEN",
+		Comments: []github.Comment{{
+			ID:        "IC_node123",
+			Author:    github.Actor{Login: "alice", Type: "User"},
+			Body:      "Please fix the typo",
+			CreatedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		}},
+		ReviewComments: []github.ReviewComment{{
+			ID:        987654,
+			Author:    github.Actor{Login: "alice", Type: "User"},
+			Body:      "keep the mutex held here",
+			CreatedAt: time.Date(2026, 5, 30, 12, 1, 0, 0, time.UTC),
+			Path:      "internal/state/state.go",
+			Line:      122,
+		}},
+	}
+
+	ch := w.diff(pr, details, state.PRState{})
+	if len(ch.Events) != 2 {
+		t.Fatalf("expected 2 actionable events, got %d", len(ch.Events))
+	}
+
+	var conv, inline *Event
+	for i := range ch.Events {
+		if ch.Events[i].Path == "" {
+			conv = &ch.Events[i]
+		} else {
+			inline = &ch.Events[i]
+		}
+	}
+	if conv == nil || conv.CommentID != "IC_node123" {
+		t.Errorf("conversation comment: want CommentID=IC_node123 (node ID), got %+v", conv)
+	}
+	if inline == nil || inline.CommentID != "987654" {
+		t.Errorf("inline review comment: want CommentID=987654 (REST ID), got %+v", inline)
+	}
+}
+
 func TestIsBotDirectedCommand(t *testing.T) {
 	skip := []string{
 		"@codex review",


### PR DESCRIPTION
## What & why

When auto-iterate picks up new PR feedback, there's a multi-minute gap between Noctra *detecting* the comment and the backend agent *finishing* and replying — during which the human sees silence. This adds an immediate **👀 reaction** on the triggering comment(s) at the start of `iteratePR`, before the agent runs, so the author knows Noctra has the feedback.

Key point: detection latency is bounded by the PR poll interval (2m), but the acknowledgement is **not** — once a comment is detected, the reaction fires instantly. **No polling change needed.**

## How

- `watch.Event` gains a `CommentID` field, populated from `Comment.ID` (GraphQL node ID — conversation comments) and `ReviewComment.ID` (REST numeric ID — inline review comments).
- `github.Client.AddEyesReaction(prURL, commentID, inline)`:
  - inline → REST `POST repos/{o}/{r}/pulls/comments/{id}/reactions` (`content=eyes`)
  - conversation → GraphQL `addReaction(subjectId, EYES)` (the REST issues endpoint needs a numeric ID we don't get from `gh pr view`)
  - best-effort: errors are returned for logging, never fatal.
- `Pipeline.ackEngagement` fires it for each triggering comment event, right after the `re-engaging` log.

## Testing

- New unit tests: `pullCommentReactionAPIPath` (path/edge cases) and `watch.diff` populating `CommentID` for both comment kinds.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

Closes ENG-272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)