### PR TITLE
feat: spread sweep tasks across repos with a round-robin planner

### DIFF
--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -34,6 +34,7 @@ type Scheduler struct {
 	now           func() time.Time
 	lastRef       time.Time
 	nextScheduled time.Time
+	repoRotation  int
 }
 
 func NewScheduler(store *state.Store, resolver RepoResolver, tasks []Task, interval time.Duration, maxTasks int, schedule *CronSchedule, sweepRepos []string) *Scheduler {
@@ -163,6 +164,12 @@ func (s *Scheduler) Plan(ctx context.Context) []Job {
 			repoJobs[i] = Job{Task: task, RepoPath: rp, RepoSlug: slug, MainBranch: mainBranch}
 		}
 		groups = append(groups, repoJobs)
+	}
+
+	if n := len(groups); n > 0 {
+		off := s.repoRotation % n
+		groups = append(groups[off:], groups[:off]...)
+		s.repoRotation++
 	}
 
 	jobs := roundRobin(groups, s.maxTasks)

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -132,7 +132,13 @@ func (s *Scheduler) Plan(ctx context.Context) []Job {
 		return nil
 	}
 
-	var jobs []Job
+	type repoQueue struct {
+		path       string
+		slug       string
+		mainBranch string
+		eligible   []Task
+	}
+	var queues []repoQueue
 	for _, rp := range repoPaths {
 		if ctx.Err() != nil {
 			break
@@ -141,12 +147,8 @@ func (s *Scheduler) Plan(ctx context.Context) []Job {
 		if slug == "" {
 			continue
 		}
-		mainBranch := repo.DefaultBranchOf(ctx, rp)
-
+		var eligible []Task
 		for _, task := range s.tasks {
-			if len(jobs) >= s.maxTasks {
-				break
-			}
 			key := state.SweepKey(slug, task.Name)
 			ss := s.store.GetSweep(key)
 			if !ss.LastRunAt.IsZero() && s.now().Sub(ss.LastRunAt) < task.Cooldown {
@@ -156,14 +158,43 @@ func (s *Scheduler) Plan(ctx context.Context) []Job {
 					"cooldown_remaining", task.Cooldown-s.now().Sub(ss.LastRunAt))
 				continue
 			}
+			eligible = append(eligible, task)
+		}
+		if len(eligible) == 0 {
+			continue
+		}
+		queues = append(queues, repoQueue{
+			path:       rp,
+			slug:       slug,
+			mainBranch: repo.DefaultBranchOf(ctx, rp),
+			eligible:   eligible,
+		})
+	}
+
+	// Round-robin one task per repo per pass, so the maxTasks budget spreads
+	// across repos instead of one repo's task list monopolising it.
+	var jobs []Job
+	for len(jobs) < s.maxTasks {
+		progressed := false
+		for i := range queues {
+			if len(jobs) >= s.maxTasks {
+				break
+			}
+			q := &queues[i]
+			if len(q.eligible) == 0 {
+				continue
+			}
+			task := q.eligible[0]
+			q.eligible = q.eligible[1:]
 			jobs = append(jobs, Job{
 				Task:       task,
-				RepoPath:   rp,
-				RepoSlug:   slug,
-				MainBranch: mainBranch,
+				RepoPath:   q.path,
+				RepoSlug:   q.slug,
+				MainBranch: q.mainBranch,
 			})
+			progressed = true
 		}
-		if len(jobs) >= s.maxTasks {
+		if !progressed {
 			break
 		}
 	}

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -132,13 +132,7 @@ func (s *Scheduler) Plan(ctx context.Context) []Job {
 		return nil
 	}
 
-	type repoQueue struct {
-		path       string
-		slug       string
-		mainBranch string
-		eligible   []Task
-	}
-	var queues []repoQueue
+	var groups [][]Job
 	for _, rp := range repoPaths {
 		if ctx.Err() != nil {
 			break
@@ -163,48 +157,48 @@ func (s *Scheduler) Plan(ctx context.Context) []Job {
 		if len(eligible) == 0 {
 			continue
 		}
-		queues = append(queues, repoQueue{
-			path:       rp,
-			slug:       slug,
-			mainBranch: repo.DefaultBranchOf(ctx, rp),
-			eligible:   eligible,
-		})
+		mainBranch := repo.DefaultBranchOf(ctx, rp)
+		repoJobs := make([]Job, len(eligible))
+		for i, task := range eligible {
+			repoJobs[i] = Job{Task: task, RepoPath: rp, RepoSlug: slug, MainBranch: mainBranch}
+		}
+		groups = append(groups, repoJobs)
 	}
 
-	// Round-robin one task per repo per pass, so the maxTasks budget spreads
-	// across repos instead of one repo's task list monopolising it.
-	var jobs []Job
-	for len(jobs) < s.maxTasks {
-		progressed := false
-		for i := range queues {
-			if len(jobs) >= s.maxTasks {
-				break
-			}
-			q := &queues[i]
-			if len(q.eligible) == 0 {
-				continue
-			}
-			task := q.eligible[0]
-			q.eligible = q.eligible[1:]
-			jobs = append(jobs, Job{
-				Task:       task,
-				RepoPath:   q.path,
-				RepoSlug:   q.slug,
-				MainBranch: q.mainBranch,
-			})
-			progressed = true
-		}
-		if !progressed {
-			break
-		}
-	}
-
+	jobs := roundRobin(groups, s.maxTasks)
 	slog.Info("sweep plan",
 		"repos", len(repoPaths),
 		"tasks", len(s.tasks),
 		"eligible", len(jobs),
 		"max", s.maxTasks)
 	return jobs
+}
+
+// roundRobin interleaves items across groups — one per group per pass — and
+// returns at most limit items, so the budget spreads across groups instead of
+// being exhausted by the first. Order within each group is preserved; inputs
+// are not mutated.
+func roundRobin[T any](groups [][]T, limit int) []T {
+	if limit <= 0 {
+		return nil
+	}
+	var out []T
+	for pass := 0; len(out) < limit; pass++ {
+		progressed := false
+		for _, g := range groups {
+			if len(out) >= limit {
+				break
+			}
+			if pass < len(g) {
+				out = append(out, g[pass])
+				progressed = true
+			}
+		}
+		if !progressed {
+			break
+		}
+	}
+	return out
 }
 
 // RecordRun persists that a task just ran on a repo.

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -169,6 +169,41 @@ func TestScheduler_PlanRespectsMaxTasks(t *testing.T) {
 	}
 }
 
+func TestScheduler_PlanSpreadsAcrossRepos(t *testing.T) {
+	reposBase := t.TempDir()
+	initTestRepo(t, reposBase, "repo-a")
+	initTestRepo(t, reposBase, "repo-b")
+	initTestRepo(t, reposBase, "repo-c")
+
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+
+	// 3 repos, each offering 3 tasks, budget 4. Round-robin should hand the
+	// first 3 slots to one task each from a, b, c — not 3 tasks from repo-a.
+	tasks := []Task{
+		testTask("t1", time.Hour),
+		testTask("t2", time.Hour),
+		testTask("t3", time.Hour),
+	}
+	s := NewScheduler(store, resolver(reposBase), tasks, time.Hour, 4, nil, nil)
+
+	jobs := s.Plan(context.Background())
+	if len(jobs) != 4 {
+		t.Fatalf("expected 4 jobs, got %d", len(jobs))
+	}
+	repos := map[string]int{}
+	for _, j := range jobs {
+		repos[j.RepoSlug]++
+	}
+	if len(repos) != 3 {
+		t.Errorf("expected jobs across all 3 repos, got %v", repos)
+	}
+	for slug, n := range repos {
+		if n > 2 {
+			t.Errorf("repo %s got %d jobs; round-robin should cap the spread", slug, n)
+		}
+	}
+}
+
 func TestScheduler_PlanRespectsCooldown(t *testing.T) {
 	reposBase := t.TempDir()
 	initTestRepo(t, reposBase, "my-repo")

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -169,6 +169,36 @@ func TestScheduler_PlanRespectsMaxTasks(t *testing.T) {
 	}
 }
 
+func TestRoundRobin(t *testing.T) {
+	eq := func(got, want []int) bool {
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	groups := [][]int{{1, 2, 3}, {4, 5}, {6}}
+	if got := roundRobin(groups, 4); !eq(got, []int{1, 4, 6, 2}) {
+		t.Errorf("limited spread: got %v, want [1 4 6 2]", got)
+	}
+	// Limit beyond the total drains every group, still interleaved.
+	if got := roundRobin([][]int{{1, 2}, {3}}, 10); !eq(got, []int{1, 3, 2}) {
+		t.Errorf("drain: got %v, want [1 3 2]", got)
+	}
+	if got := roundRobin(groups, 0); got != nil {
+		t.Errorf("zero limit: got %v, want nil", got)
+	}
+	// Inputs must not be mutated.
+	if len(groups[0]) != 3 {
+		t.Errorf("roundRobin mutated its input: %v", groups)
+	}
+}
+
 func TestScheduler_PlanSpreadsAcrossRepos(t *testing.T) {
 	reposBase := t.TempDir()
 	initTestRepo(t, reposBase, "repo-a")

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -199,6 +199,34 @@ func TestRoundRobin(t *testing.T) {
 	}
 }
 
+func TestScheduler_PlanRotatesLeadRepoAcrossCycles(t *testing.T) {
+	reposBase := t.TempDir()
+	initTestRepo(t, reposBase, "repo-a")
+	initTestRepo(t, reposBase, "repo-b")
+	initTestRepo(t, reposBase, "repo-c")
+
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	tasks := []Task{testTask("t1", time.Hour), testTask("t2", time.Hour)}
+
+	s := NewScheduler(store, resolver(reposBase), tasks, time.Hour, 1, nil, nil)
+
+	var leads []string
+	for i := 0; i < 3; i++ {
+		jobs := s.Plan(context.Background())
+		if len(jobs) != 1 {
+			t.Fatalf("cycle %d: expected 1 job, got %d", i, len(jobs))
+		}
+		leads = append(leads, jobs[0].RepoSlug)
+	}
+	seen := map[string]bool{}
+	for _, l := range leads {
+		seen[l] = true
+	}
+	if len(seen) != 3 {
+		t.Errorf("lead repo should rotate across 3 cycles, got %v", leads)
+	}
+}
+
 func TestScheduler_PlanSpreadsAcrossRepos(t *testing.T) {
 	reposBase := t.TempDir()
 	initTestRepo(t, reposBase, "repo-a")


### PR DESCRIPTION
## Problem

With multiple repos in `SWEEP_REPOS`, every sweep run only touched **one** repo and opened ~3 PRs there — the other repos were ignored until that repo's tasks all hit cooldown (7–14 days).

Root cause is in `scheduler.Plan`: it filled the `SWEEP_MAX_TASKS` budget **depth-first, repo by repo**:

```go
for _, rp := range repoPaths {        // repo #1 first
    for _, task := range s.tasks {     // 7 tasks registered
        if len(jobs) >= s.maxTasks { break }   // budget = 5
        ...
    }
}
```

Since one repo offers 7 tasks (≥ the budget of 5), repo #1 consumed every slot before the loop ever reached repos #2–4.

## Fix

`Plan` now collects each repo's eligible (off-cooldown) tasks into a queue, then **round-robins one task per repo per pass** until the budget is hit. The `maxTasks` budget spreads across repos — ~1 task per repo instead of N from one. Cooldown and `maxTasks` semantics are unchanged; the single-repo case behaves identically.

## Note on concurrency

This fixes task *distribution*. The number that actually **dispatch per cycle** is still capped by `MAX_CONCURRENT` (currently 3, shared with ticket dispatch + PR auto-iterate). So with 4 repos: 3 distinct repos get a PR this cycle, the 4th next cycle (it stays eligible since it never ran). Bump `MAX_CONCURRENT` to ≥4 to cover all four in one cycle.

## Tests
- `TestScheduler_PlanSpreadsAcrossRepos` — 3 repos × 3 tasks, budget 4 → jobs land across all 3 repos, none gets more than 2.
- Existing `PlanRespectsMaxTasks` / `PlanRespectsCooldown` / `SweepRepos*` tests still pass.
- `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)