### PR TITLE
ENG-274: Dashboard P1 — snapshot API + minimal read UI + token auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -255,6 +255,18 @@ SWEEP_INTERVAL=86400
 # Max tasks dispatched per sweep cycle.
 SWEEP_MAX_TASKS=5
 
+# ── Dashboard (optional, off by default) ───────────────────────────────────────
+# Read-only web UI showing active runs, queue, skipped tickets, and budget.
+# Set DASHBOARD_ADDR to enable (e.g. ":8080" or "127.0.0.1:8080").
+# If only a port is given (":8080"), Noctra binds to localhost automatically.
+# DASHBOARD_TOKEN is required — the server refuses to start without it.
+
+# Listen address for the dashboard HTTP server. Empty = dashboard disabled.
+# DASHBOARD_ADDR=:8080
+
+# Bearer token required on every request (header or ?token= query param).
+# DASHBOARD_TOKEN=
+
 # Where Noctra persists PR cursors, sweep cooldowns, OAuth, and history.
 # Defaults to $HOME/.noctra/state.db.
 # STATE_DB=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,6 +218,11 @@ type Config struct {
 	PlanConfirm      bool   // global opt-in for plan-confirm on all tickets
 	PlanConfirmLabel string // label name that activates plan-confirm per-ticket (default "plan-first")
 
+	// Dashboard (ENG-274) — off by default. When DASHBOARD_ADDR is set,
+	// serves a read-only snapshot UI on that address.
+	DashboardAddr  string // listen address (e.g. ":8080"); empty = dashboard disabled
+	DashboardToken string // required Bearer token for all dashboard requests
+
 	// Derived paths
 	ScriptDir    string
 	EnvFile      string
@@ -343,6 +348,10 @@ func Load(scriptDir string) (*Config, error) {
 	// Plan-confirm (ENG-221)
 	cfg.PlanConfirm = getbool(fileEnv, "PLAN_CONFIRM", false)
 	cfg.PlanConfirmLabel = getenv(fileEnv, "PLAN_CONFIRM_LABEL", DefaultPlanConfirmLabel)
+
+	// Dashboard (ENG-274)
+	cfg.DashboardAddr = getenv(fileEnv, "DASHBOARD_ADDR", "")
+	cfg.DashboardToken = getenv(fileEnv, "DASHBOARD_TOKEN", "")
 
 	return cfg, nil
 }

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,0 +1,96 @@
+// Package dashboard serves a read-only HTTP dashboard showing a point-in-time
+// snapshot of the pipeline. All requests require a Bearer token.
+package dashboard
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"io/fs"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+//go:embed static
+var staticFiles embed.FS
+
+// SnapshotFunc returns the current pipeline snapshot as JSON-serializable data.
+type SnapshotFunc func() any
+
+// Server is the dashboard HTTP server.
+type Server struct {
+	srv   *http.Server
+	token string
+}
+
+// New creates a dashboard server bound to addr, gated by the given token.
+// snapshotFn is called on each GET /api/snapshot to produce the response payload.
+func New(addr, token string, snapshotFn SnapshotFunc) *Server {
+	mux := http.NewServeMux()
+
+	s := &Server{
+		srv: &http.Server{
+			Addr:    addr,
+			Handler: mux,
+		},
+		token: token,
+	}
+
+	mux.Handle("/api/snapshot", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(snapshotFn())
+	})))
+
+	// Serve embedded static files at /.
+	staticSub, _ := fs.Sub(staticFiles, "static")
+	fileServer := http.FileServer(http.FS(staticSub))
+	mux.Handle("/", s.requireAuth(fileServer))
+
+	return s
+}
+
+// ListenAndServe starts listening. It blocks until the server is shut down.
+func (s *Server) ListenAndServe() error {
+	ln, err := net.Listen("tcp", s.srv.Addr)
+	if err != nil {
+		return err
+	}
+	slog.Info("dashboard listening", "addr", ln.Addr().String())
+	return s.srv.Serve(ln)
+}
+
+// Shutdown gracefully shuts down the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.srv.Shutdown(ctx)
+}
+
+// Handler returns the server's HTTP handler (for testing with httptest).
+func (s *Server) Handler() http.Handler {
+	return s.srv.Handler
+}
+
+// requireAuth returns middleware that checks for a valid Bearer token in the
+// Authorization header, or a ?token= query parameter (convenience for browser
+// page loads).
+func (s *Server) requireAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := ""
+		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+			token = strings.TrimPrefix(auth, "Bearer ")
+		}
+		if token == "" {
+			token = r.URL.Query().Get("token")
+		}
+		if token != s.token {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -1,0 +1,135 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testSnapshot struct {
+	Active []string `json:"active"`
+	OK     bool     `json:"ok"`
+}
+
+func newTestServer(token string) *Server {
+	return New(":0", token, func() any {
+		return testSnapshot{Active: []string{"ENG-1"}, OK: true}
+	})
+}
+
+func TestAuth_BearerToken(t *testing.T) {
+	s := newTestServer("secret-token")
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	// Valid Bearer token → 200.
+	req, _ := http.NewRequest("GET", ts.URL+"/api/snapshot", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var snap testSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		t.Fatal(err)
+	}
+	if !snap.OK || len(snap.Active) != 1 || snap.Active[0] != "ENG-1" {
+		t.Errorf("unexpected snapshot: %+v", snap)
+	}
+}
+
+func TestAuth_QueryParam(t *testing.T) {
+	s := newTestServer("qp-token")
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/snapshot?token=qp-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuth_Missing(t *testing.T) {
+	s := newTestServer("secret")
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/snapshot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuth_WrongToken(t *testing.T) {
+	s := newTestServer("correct")
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/snapshot", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuth_StaticPage(t *testing.T) {
+	s := newTestServer("page-token")
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	// Page load without token → 401.
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Errorf("expected 401 for page without token, got %d", resp.StatusCode)
+	}
+
+	// Page load with query param token → 200.
+	resp, err = http.Get(ts.URL + "/?token=page-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200 for page with token, got %d", resp.StatusCode)
+	}
+}
+
+func TestSnapshot_MethodNotAllowed(t *testing.T) {
+	s := newTestServer("tok")
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/snapshot", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Noctra Dashboard</title>
+<style>
+  :root { --bg: #0d1117; --card: #161b22; --border: #30363d; --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff; --green: #3fb950; --red: #f85149; --yellow: #d29922; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); padding: 1.5rem; max-width: 64rem; margin: 0 auto; }
+  h1 { font-size: 1.5rem; margin-bottom: 1rem; }
+  h2 { font-size: 1.1rem; color: var(--muted); margin-bottom: 0.5rem; font-weight: 500; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: 1rem; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 0.5rem; padding: 1rem; }
+  .badge { display: inline-block; font-size: 0.75rem; padding: 0.15rem 0.5rem; border-radius: 1rem; font-weight: 600; }
+  .badge-green { background: rgba(63,185,80,0.15); color: var(--green); }
+  .badge-red { background: rgba(248,81,73,0.15); color: var(--red); }
+  .badge-yellow { background: rgba(210,153,34,0.15); color: var(--yellow); }
+  ul { list-style: none; }
+  li { padding: 0.25rem 0; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.875rem; }
+  .empty { color: var(--muted); font-style: italic; font-size: 0.875rem; }
+  .retries { color: var(--muted); font-size: 0.75rem; margin-left: 0.25rem; }
+  .stat-row { display: flex; justify-content: space-between; padding: 0.25rem 0; font-size: 0.875rem; }
+  .stat-label { color: var(--muted); }
+  #error { display: none; background: rgba(248,81,73,0.15); color: var(--red); border: 1px solid var(--red); border-radius: 0.5rem; padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 0.875rem; }
+</style>
+</head>
+<body>
+<h1>Noctra Dashboard</h1>
+<div id="error"></div>
+<div class="grid">
+  <div class="card">
+    <h2>Active Runs</h2>
+    <ul id="active"></ul>
+  </div>
+  <div class="card">
+    <h2>Queue (failed attempts)</h2>
+    <ul id="queued"></ul>
+  </div>
+  <div class="card">
+    <h2>Skipped</h2>
+    <ul id="skipped"></ul>
+  </div>
+  <div class="card">
+    <h2>Budget</h2>
+    <div id="budget"></div>
+  </div>
+</div>
+<script>
+(function() {
+  var params = new URLSearchParams(window.location.search);
+  var token = params.get("token") || "";
+
+  function formatTokens(n) {
+    if (n >= 1000000) return (n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1) + "M";
+    if (n >= 1000) return (n / 1000).toFixed(n % 1000 === 0 ? 0 : 1) + "K";
+    return String(n);
+  }
+
+  function esc(s) {
+    var d = document.createElement("span");
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function renderList(el, items, emptyMsg) {
+    if (!items || items.length === 0) {
+      el.innerHTML = '<li class="empty">' + esc(emptyMsg) + "</li>";
+      return;
+    }
+    el.innerHTML = items.map(function(id) { return "<li>" + esc(id) + "</li>"; }).join("");
+  }
+
+  function renderQueued(el, queued) {
+    var keys = Object.keys(queued || {});
+    if (keys.length === 0) {
+      el.innerHTML = '<li class="empty">No queued tickets</li>';
+      return;
+    }
+    el.innerHTML = keys.map(function(id) {
+      return "<li>" + esc(id) + '<span class="retries">(' + queued[id] + " retries)</span></li>";
+    }).join("");
+  }
+
+  function renderBudget(el, b, paused) {
+    var rows = "";
+    if (paused) {
+      rows += '<div class="stat-row"><span class="stat-label">Dispatch</span><span class="badge badge-yellow">Paused</span></div>';
+    } else {
+      rows += '<div class="stat-row"><span class="stat-label">Dispatch</span><span class="badge badge-green">Running</span></div>';
+    }
+    rows += '<div class="stat-row"><span class="stat-label">Session tokens</span><span>' + formatTokens(b.SessionTokens || 0) + "</span></div>";
+    if (b.SessionCostUSD) {
+      rows += '<div class="stat-row"><span class="stat-label">Session cost</span><span>$' + b.SessionCostUSD.toFixed(2) + "</span></div>";
+    }
+    rows += '<div class="stat-row"><span class="stat-label">Daily tokens</span><span>' + formatTokens(b.DailyTokens || 0);
+    if (b.MaxDailyTokens > 0) rows += " / " + formatTokens(b.MaxDailyTokens);
+    rows += "</span></div>";
+    if (b.MaxDailyUSD > 0) {
+      rows += '<div class="stat-row"><span class="stat-label">Daily cost</span><span>$' + (b.DailyCostUSD || 0).toFixed(2) + " / $" + b.MaxDailyUSD.toFixed(2) + "</span></div>";
+    }
+    if (b.Paused && b.PauseReason) {
+      rows += '<div class="stat-row"><span class="stat-label">Pause reason</span><span>' + esc(b.PauseReason) + "</span></div>";
+    }
+    el.innerHTML = rows;
+  }
+
+  function load() {
+    var errEl = document.getElementById("error");
+    fetch("/api/snapshot", { headers: { "Authorization": "Bearer " + token } })
+      .then(function(r) {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.json();
+      })
+      .then(function(d) {
+        errEl.style.display = "none";
+        renderList(document.getElementById("active"), d.active, "No active runs");
+        renderQueued(document.getElementById("queued"), d.queued);
+        renderList(document.getElementById("skipped"), d.skipped, "No skipped tickets");
+        renderBudget(document.getElementById("budget"), d.budget, d.paused);
+      })
+      .catch(function(e) {
+        errEl.textContent = "Failed to load snapshot: " + e.message;
+        errEl.style.display = "block";
+      });
+  }
+
+  load();
+})();
+</script>
+</body>
+</html>

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -16,6 +18,7 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/agent"
 	"github.com/ahmadAlMezaal/noctra/internal/budget"
 	"github.com/ahmadAlMezaal/noctra/internal/config"
+	"github.com/ahmadAlMezaal/noctra/internal/dashboard"
 	"github.com/ahmadAlMezaal/noctra/internal/github"
 	"github.com/ahmadAlMezaal/noctra/internal/linear"
 	"github.com/ahmadAlMezaal/noctra/internal/notify"
@@ -63,6 +66,9 @@ type Pipeline struct {
 	// and the label name resolves successfully. Empty if resolution fails
 	// (per-ticket label detection degrades to global-only mode).
 	planConfirmLabelID string
+
+	// Dashboard server — nil when cfg.DashboardAddr is empty.
+	dash *dashboard.Server
 
 	sessionStart time.Time
 
@@ -169,7 +175,29 @@ func New(cfg *config.Config) *Pipeline {
 		}
 	}
 
+	// Dashboard — constructed eagerly so banner() can inspect it, but
+	// ListenAndServe is deferred to Run (which validates the token).
+	if cfg.DashboardAddr != "" {
+		addr := normalizeDashboardAddr(cfg.DashboardAddr)
+		p.dash = dashboard.New(addr, cfg.DashboardToken, func() any {
+			return p.Snapshot()
+		})
+	}
+
 	return p
+}
+
+// normalizeDashboardAddr binds to localhost when the user supplies only a port
+// (e.g. ":8080") so the dashboard is not accidentally exposed on all interfaces.
+func normalizeDashboardAddr(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	if host == "" {
+		return net.JoinHostPort("127.0.0.1", port)
+	}
+	return addr
 }
 
 // Run blocks until ctx is canceled or a rate-limit is detected
@@ -205,6 +233,11 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		}
 	}
 
+	// Fail fast: dashboard address set but no token.
+	if p.cfg.DashboardAddr != "" && p.cfg.DashboardToken == "" {
+		return fmt.Errorf("DASHBOARD_ADDR is set but DASHBOARD_TOKEN is empty — refusing to start an unauthenticated dashboard")
+	}
+
 	p.startupCleanup(ctx)
 	p.banner()
 	if p.cfg.TriggerMode == "label" {
@@ -238,6 +271,23 @@ func (p *Pipeline) Run(ctx context.Context) error {
 			}
 		}()
 		slog.Info("telegram command listener started")
+	}
+
+	// Start the dashboard server if configured. Shares the WaitGroup so
+	// shutdown drains it alongside the poll loop and other goroutines.
+	if p.dash != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := p.dash.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Warn("dashboard server stopped", "err", err)
+			}
+		}()
+		// Shut the server down when the loop context is cancelled.
+		go func() {
+			<-loopCtx.Done()
+			_ = p.dash.Shutdown(context.Background())
+		}()
 	}
 
 	ticker := time.NewTicker(p.cfg.PollInterval)
@@ -797,6 +847,18 @@ func (p *Pipeline) banner() {
 	fmt.Printf("   Rate limit:     %s\n", rlMode)
 
 	fmt.Printf("   Notifications:  %s\n", notifyMode)
+
+	if p.dash != nil {
+		addr := normalizeDashboardAddr(p.cfg.DashboardAddr)
+		fmt.Printf("   Dashboard:      http://%s/\n", addr)
+		host, _, _ := net.SplitHostPort(addr)
+		if host == "0.0.0.0" {
+			fmt.Printf("   ⚠️  Dashboard bound to 0.0.0.0 — accessible from any network interface\n")
+		}
+	} else {
+		fmt.Printf("   Dashboard:      Disabled\n")
+	}
+
 	fmt.Println()
 	fmt.Println("Waiting for tickets... (Ctrl+C to stop)")
 	fmt.Println()

--- a/internal/pipeline/snapshot.go
+++ b/internal/pipeline/snapshot.go
@@ -6,11 +6,11 @@ import "github.com/ahmadAlMezaal/noctra/internal/budget"
 // JSON serialization. Collected under a single p.mu lock so the fields are
 // consistent with each other.
 type DashboardSnapshot struct {
-	Active  []string         `json:"active"`
-	Queued  map[string]int   `json:"queued"`
-	Skipped []string         `json:"skipped"`
-	Paused  bool             `json:"paused"`
-	Budget  budget.Stats     `json:"budget"`
+	Active  []string       `json:"active"`
+	Queued  map[string]int `json:"queued"`
+	Skipped []string       `json:"skipped"`
+	Paused  bool           `json:"paused"`
+	Budget  budget.Stats   `json:"budget"`
 }
 
 // Snapshot takes p.mu once and returns a consistent snapshot of the

--- a/internal/pipeline/snapshot.go
+++ b/internal/pipeline/snapshot.go
@@ -1,0 +1,48 @@
+package pipeline
+
+import "github.com/ahmadAlMezaal/noctra/internal/budget"
+
+// DashboardSnapshot is a point-in-time view of the pipeline state, safe for
+// JSON serialization. Collected under a single p.mu lock so the fields are
+// consistent with each other.
+type DashboardSnapshot struct {
+	Active  []string         `json:"active"`
+	Queued  map[string]int   `json:"queued"`
+	Skipped []string         `json:"skipped"`
+	Paused  bool             `json:"paused"`
+	Budget  budget.Stats     `json:"budget"`
+}
+
+// Snapshot takes p.mu once and returns a consistent snapshot of the
+// pipeline's runtime state for the dashboard.
+func (p *Pipeline) Snapshot() DashboardSnapshot {
+	p.mu.Lock()
+	active := make([]string, 0, len(p.active))
+	for id := range p.active {
+		active = append(active, id)
+	}
+	queued := make(map[string]int, len(p.failedAttempts))
+	for id, n := range p.failedAttempts {
+		if _, running := p.active[id]; running {
+			continue
+		}
+		if _, skip := p.skipped[id]; skip {
+			continue
+		}
+		queued[id] = n
+	}
+	skipped := make([]string, 0, len(p.skipped))
+	for id := range p.skipped {
+		skipped = append(skipped, id)
+	}
+	paused := p.paused
+	p.mu.Unlock()
+
+	return DashboardSnapshot{
+		Active:  active,
+		Queued:  queued,
+		Skipped: skipped,
+		Paused:  paused,
+		Budget:  p.budget.Stats(),
+	}
+}

--- a/internal/pipeline/snapshot_test.go
+++ b/internal/pipeline/snapshot_test.go
@@ -1,0 +1,103 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ahmadAlMezaal/noctra/internal/budget"
+	"github.com/ahmadAlMezaal/noctra/internal/config"
+)
+
+func TestSnapshot(t *testing.T) {
+	p := &Pipeline{
+		cfg:            &config.Config{},
+		active:         map[string]struct{}{"ENG-1": {}, "ENG-2": {}},
+		cancels:        map[string]context.CancelFunc{},
+		killed:         map[string]struct{}{},
+		failedAttempts: map[string]int{"ENG-3": 1, "ENG-1": 0},
+		skipped:        map[string]struct{}{"ENG-4": {}},
+		paused:         true,
+		budget:         budget.New(budget.Config{MaxDailyTokens: 100_000}),
+	}
+
+	snap := p.Snapshot()
+
+	// Active should contain ENG-1 and ENG-2.
+	if len(snap.Active) != 2 {
+		t.Fatalf("expected 2 active, got %d", len(snap.Active))
+	}
+	activeSet := map[string]bool{}
+	for _, id := range snap.Active {
+		activeSet[id] = true
+	}
+	if !activeSet["ENG-1"] || !activeSet["ENG-2"] {
+		t.Errorf("active set = %v, want ENG-1 and ENG-2", snap.Active)
+	}
+
+	// Queued should contain ENG-3 (has failed attempts, not active, not skipped).
+	// ENG-1 has failedAttempts=0 but is active, so excluded from queued.
+	if len(snap.Queued) != 1 {
+		t.Fatalf("expected 1 queued, got %d: %v", len(snap.Queued), snap.Queued)
+	}
+	if retries, ok := snap.Queued["ENG-3"]; !ok || retries != 1 {
+		t.Errorf("queued = %v, want {ENG-3: 1}", snap.Queued)
+	}
+
+	// Skipped should contain ENG-4.
+	if len(snap.Skipped) != 1 || snap.Skipped[0] != "ENG-4" {
+		t.Errorf("skipped = %v, want [ENG-4]", snap.Skipped)
+	}
+
+	if !snap.Paused {
+		t.Error("expected paused = true")
+	}
+
+	if snap.Budget.MaxDailyTokens != 100_000 {
+		t.Errorf("budget max daily tokens = %d, want 100000", snap.Budget.MaxDailyTokens)
+	}
+}
+
+func TestSnapshotEmpty(t *testing.T) {
+	p := &Pipeline{
+		cfg:            &config.Config{},
+		active:         map[string]struct{}{},
+		cancels:        map[string]context.CancelFunc{},
+		killed:         map[string]struct{}{},
+		failedAttempts: map[string]int{},
+		skipped:        map[string]struct{}{},
+		budget:         budget.New(budget.Config{}),
+	}
+
+	snap := p.Snapshot()
+
+	if len(snap.Active) != 0 {
+		t.Errorf("expected 0 active, got %d", len(snap.Active))
+	}
+	if len(snap.Queued) != 0 {
+		t.Errorf("expected 0 queued, got %d", len(snap.Queued))
+	}
+	if len(snap.Skipped) != 0 {
+		t.Errorf("expected 0 skipped, got %d", len(snap.Skipped))
+	}
+	if snap.Paused {
+		t.Error("expected paused = false")
+	}
+}
+
+func TestNormalizeDashboardAddr(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{":8080", "127.0.0.1:8080"},
+		{"0.0.0.0:8080", "0.0.0.0:8080"},
+		{"127.0.0.1:9090", "127.0.0.1:9090"},
+		{"localhost:3000", "localhost:3000"},
+		{"invalid", "invalid"},
+	}
+	for _, tc := range tests {
+		got := normalizeDashboardAddr(tc.in)
+		if got != tc.want {
+			t.Errorf("normalizeDashboardAddr(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -171,6 +171,9 @@ func Run(scriptDir string) error {
 
 	sweepEnabled, sweepTasks, sweepSchedule, sweepRepos, sweepMaxTasks := w.collectSweep(existingEnv)
 
+	// ── Optional: Dashboard ───────────────────────────────────────────────────
+	dashboardAddr, dashboardToken := w.collectDashboard(existingEnv)
+
 	// ── Optional: Gemini review gate ───────────────────────────────────────────
 	geminiKey := ""
 	geminiMode := existingEnv["GEMINI_MODE"]
@@ -347,6 +350,12 @@ func Run(scriptDir string) error {
 		}
 		fmt.Printf("  SWEEP_MAX_TASKS       = %d\n", sweepMaxTasks)
 	}
+	if dashboardAddr != "" {
+		fmt.Printf("  DASHBOARD_ADDR        = %s\n", dashboardAddr)
+		fmt.Printf("  DASHBOARD_TOKEN       = %s\n", mask(dashboardToken))
+	} else {
+		fmt.Printf("  DASHBOARD_ADDR        = (disabled)\n")
+	}
 	fmt.Printf("  TELEGRAM_ENABLED      = %s\n", tgEnabled)
 	if tgEnabled == "true" {
 		fmt.Printf("  TELEGRAM_BOT_TOKEN    = %s\n", mask(tgToken))
@@ -406,6 +415,8 @@ func Run(scriptDir string) error {
 		sweepSchedule:     sweepSchedule,
 		sweepRepos:        sweepRepos,
 		sweepMaxTasks:     strconv.Itoa(sweepMaxTasks),
+		dashboardAddr:     dashboardAddr,
+		dashboardToken:    dashboardToken,
 	}
 
 	// Merge into existing .env when the file already exists — this preserves
@@ -803,6 +814,32 @@ func (w *wizard) collectSweep(existing map[string]string) (enabled, tasks, sched
 	return enabled, tasks, schedule, repos, maxTasks
 }
 
+func (w *wizard) collectDashboard(existing map[string]string) (addr, token string) {
+	wasEnabled := existing["DASHBOARD_ADDR"] != ""
+	prompt := "Enable the read-only web dashboard?"
+	if wasEnabled {
+		prompt = "The web dashboard is currently enabled. Keep it?"
+	}
+	if !w.confirm(prompt) {
+		return "", ""
+	}
+
+	fmt.Println("The dashboard serves a snapshot of active runs, queue, and budget.")
+	fmt.Println("Bind to 127.0.0.1:<port> for local-only access, or 0.0.0.0:<port> to")
+	fmt.Println("expose it on the network (a warning is shown at startup).")
+	addr = w.askEx("Listen address (e.g. :8080)", askOpts{
+		existing: existing["DASHBOARD_ADDR"],
+		required: true,
+	})
+	token = w.askEx("Dashboard auth token", askOpts{
+		existing: existing["DASHBOARD_TOKEN"],
+		secret:   true,
+		required: true,
+	})
+
+	return addr, token
+}
+
 // ── Helpers (file I/O, validators, formatting) ──────────────────────────────
 
 func pingLinear(apiKey string) (string, error) {
@@ -893,6 +930,7 @@ type envValues struct {
 	autoIterate, maxIter, prPoll, trusted        string
 	sweepEnabled, sweepTasks, sweepSchedule      string
 	sweepRepos, sweepMaxTasks                    string
+	dashboardAddr, dashboardToken                string
 }
 
 // toMap returns the wizard-managed keys as a flat map suitable for
@@ -930,6 +968,8 @@ func (v envValues) toMap() map[string]string {
 		"SWEEP_REPOS":           v.sweepRepos,
 		"SWEEP_SCHEDULE":        v.sweepSchedule,
 		"SWEEP_MAX_TASKS":       v.sweepMaxTasks,
+		"DASHBOARD_ADDR":        v.dashboardAddr,
+		"DASHBOARD_TOKEN":       v.dashboardToken,
 	}
 
 	// Trigger-mode-dependent keys.
@@ -1063,6 +1103,13 @@ SWEEP_REPOS="%s"
 SWEEP_SCHEDULE="%s"
 SWEEP_INTERVAL="86400"
 SWEEP_MAX_TASKS="%s"
+
+# Read-only web dashboard (ENG-274). Off by default. Set DASHBOARD_ADDR to
+# a listen address (e.g. ":8080") to enable. DASHBOARD_TOKEN is required —
+# every request must carry it as Authorization: Bearer <token>.
+# Bind to 127.0.0.1 for local-only access; 0.0.0.0 triggers a startup warning.
+DASHBOARD_ADDR="%s"
+DASHBOARD_TOKEN="%s"
 `,
 		time.Now().Format(time.RFC3339),
 		v.linearKey, v.team, oauthLines, triggerLines, v.review,
@@ -1076,6 +1123,7 @@ SWEEP_MAX_TASKS="%s"
 		v.geminiMode, v.geminiKey,
 		v.autoIterate, v.maxIter, v.prPoll, v.trusted,
 		v.sweepEnabled, v.sweepTasks, v.sweepRepos, v.sweepSchedule, v.sweepMaxTasks,
+		v.dashboardAddr, v.dashboardToken,
 	)
 	return os.WriteFile(path, []byte(body), 0o600)
 }


### PR DESCRIPTION
## ENG-274: Dashboard P1 — snapshot API + minimal read UI + token auth

**Ticket:** https://linear.app/amazz/issue/ENG-274/dashboard-p1-snapshot-api-minimal-read-ui-token-auth

## What was implemented

Implemented a read-only web dashboard (ENG-274, P1 slice of ENG-218) gated by token auth and bound to localhost by default.

**New files:**
- `internal/dashboard/dashboard.go` — HTTP server with Bearer token auth middleware (also accepts `?token=` for browser page loads), `GET /api/snapshot` JSON endpoint, and embedded static file serving via `embed.FS`.
- `internal/dashboard/static/index.html` — Single-page vanilla JS/HTML dashboard that fetches `/api/snapshot` on load and renders active runs, queued tickets with retry counts, skipped tickets, and budget stats. Dark theme, no build step, no external deps.
- `internal/dashboard/dashboard_test.go` — `httptest`-based tests covering: valid Bearer token (200), query param token (200), missing token (401), wrong token (401), static page auth gating, and method-not-allowed (405).
- `internal/pipeline/snapshot.go` — `DashboardSnapshot` struct and `Pipeline.Snapshot()` method that takes `p.mu` once for a consistent view of active/queued/skipped/paused state, then reads `budget.Stats()` outside the lock.
- `internal/pipeline/snapshot_test.go` — Unit tests for `Snapshot()` (populated and empty states) and `normalizeDashboardAddr` (localhost default, explicit hosts, edge cases).

**Modified files:**
- `internal/config/config.go` — Added `DashboardAddr` and `DashboardToken` fields, parsed from `DASHBOARD_ADDR` and `DASHBOARD_TOKEN` env vars.
- `internal/pipeline/pipeline.go` — Added `dash *dashboard.Server` field to Pipeline; `normalizeDashboardAddr` binds to `127.0.0.1` when only a port is given; dashboard created in `New`; `Run` fails fast with a clear error when `DASHBOARD_ADDR` is set but `DASHBOARD_TOKEN` is empty; dashboard goroutine starts on the shared `WaitGroup` and shuts down on context cancel; banner prints the dashboard URL (or "Disabled") with a visible warning when bound to `0.0.0.0`.
- `.env.example` — Documented `DASHBOARD_ADDR` and `DASHBOARD_TOKEN` with usage guidance.

**Design decisions:**
- Snapshot is collected under a single `p.mu` lock for consistency; `budget.Stats()` is called separately (it has its own mutex).
- Queued tickets are derived from `failedAttempts` entries that are neither active nor skipped, matching the pipeline's retry semantics.
- The dashboard server is constructed eagerly in `New` (so the banner can inspect it) but `ListenAndServe` is deferred to `Run` (where the token validation gate lives).
- No SSE/live updates (P2), no control actions (P3), no JS build step — per ticket scope.

All existing tests pass. `go vet ./...` clean.

---

✅ Passed **Multi-model review** (Gemini `gemini-2.5-flash` via `api`)

This PR delivers a comprehensive implementation of the dashboard feature, meeting all specified requirements and acceptance criteria. The code is well-structured, includes appropriate test coverage for new components, and integrates cleanly with existing parts of the system. The attention to detail, such as binding to localhost by default and the explicit token requirement, is commendable.

Specific findings are posted as inline review comments.
---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*
<!-- noctra-authored -->