### PR TITLE
fix: reply to conversation-comment feedback, not just review threads

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -393,6 +393,19 @@ type reviewThread struct {
 	FirstCommentDatabaseID int64  // REST API ID of the first comment (used to reply)
 }
 
+// PostComment posts a top-level conversation comment on a PR, carrying
+// NoctraReplyMarker so the watcher skips Noctra's own reply.
+func (c *Client) PostComment(ctx context.Context, prURL, body string) error {
+	body += "\n\n" + NoctraReplyMarker
+	var stderr strings.Builder
+	cmd := exec.CommandContext(ctx, "gh", "pr", "comment", prURL, "--body", body)
+	cmd.Stderr = &stderr
+	if _, err := cmd.Output(); err != nil {
+		return fmt.Errorf("gh pr comment %s: %w (%s)", prURL, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
 // ReplyAndResolveThreads replies to and resolves all unresolved review threads
 // on a PR with the given note. Best-effort: failures are logged, never returned.
 func (c *Client) ReplyAndResolveThreads(ctx context.Context, prURL, replyBody string) {

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -462,6 +462,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			reply = fmt.Sprintf("Addressed in %s.\n\n%s", sha, summary)
 		}
 		p.gh.ReplyAndResolveThreads(ctx, ch.PR.URL, reply)
+		p.replyToConversation(ctx, ch, reply, logger)
 
 		// Completion heads-up (always — mirrors the 🔄 start ping and the
 		// ✅ "PR ready" ping the main ticket flow sends on success).
@@ -475,6 +476,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		}
 		// Reply + resolve so a no-diff review isn't silent on GitHub.
 		p.gh.ReplyAndResolveThreads(ctx, ch.PR.URL, reply)
+		p.replyToConversation(ctx, ch, reply, logger)
 		if p.store != nil && summary != "" {
 			if err := p.store.Update(ch.PR.URL, func(r *state.PRState) {
 				r.LastReasoning = summary
@@ -570,6 +572,24 @@ func (p *Pipeline) ackEngagement(ctx context.Context, ch watch.PRChanges) {
 			slog.Warn("ack reaction failed", "pr", ch.PR.URL, "err", err)
 		}
 	}
+}
+
+func (p *Pipeline) replyToConversation(ctx context.Context, ch watch.PRChanges, reply string, logger *slog.Logger) {
+	if !hasConversationComment(ch) {
+		return
+	}
+	if err := p.gh.PostComment(ctx, ch.PR.URL, reply); err != nil {
+		logger.Warn("post conversation reply failed", "err", err)
+	}
+}
+
+func hasConversationComment(ch watch.PRChanges) bool {
+	for _, ev := range ch.Events {
+		if ev.Type == watch.EventComment && ev.Path == "" {
+			return true
+		}
+	}
+	return false
 }
 
 // engagementSummary is a short human description of why Noctra is

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -575,10 +575,15 @@ func (p *Pipeline) ackEngagement(ctx context.Context, ch watch.PRChanges) {
 }
 
 func (p *Pipeline) replyToConversation(ctx context.Context, ch watch.PRChanges, reply string, logger *slog.Logger) {
+	authors := conversationCommentAuthors(ch)
 	if !hasConversationComment(ch) {
 		return
 	}
-	if err := p.gh.PostComment(ctx, ch.PR.URL, reply); err != nil {
+	body := reply
+	if len(authors) > 0 {
+		body = strings.Join(authors, " ") + "\n\n" + reply
+	}
+	if err := p.gh.PostComment(ctx, ch.PR.URL, body); err != nil {
 		logger.Warn("post conversation reply failed", "err", err)
 	}
 }
@@ -590,6 +595,22 @@ func hasConversationComment(ch watch.PRChanges) bool {
 		}
 	}
 	return false
+}
+
+func conversationCommentAuthors(ch watch.PRChanges) []string {
+	seen := map[string]bool{}
+	var mentions []string
+	for _, ev := range ch.Events {
+		if ev.Type != watch.EventComment || ev.Path != "" || ev.Author.Login == "" {
+			continue
+		}
+		if seen[ev.Author.Login] {
+			continue
+		}
+		seen[ev.Author.Login] = true
+		mentions = append(mentions, "@"+ev.Author.Login)
+	}
+	return mentions
 }
 
 // engagementSummary is a short human description of why Noctra is

--- a/internal/pipeline/iterate_test.go
+++ b/internal/pipeline/iterate_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/ahmadAlMezaal/noctra/internal/watch"
 )
 
+func TestHasConversationComment(t *testing.T) {
+	cases := []struct {
+		name   string
+		events []watch.Event
+		want   bool
+	}{
+		{"conversation comment", []watch.Event{{Type: watch.EventComment}}, true},
+		{"inline review comment has a path", []watch.Event{{Type: watch.EventComment, Path: "main.go"}}, false},
+		{"review summary is not a comment", []watch.Event{{Type: watch.EventReview}}, false},
+		{"mixed picks up the conversation comment", []watch.Event{{Type: watch.EventReview}, {Type: watch.EventComment, Path: "a.go"}, {Type: watch.EventComment}}, true},
+		{"none", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasConversationComment(watch.PRChanges{Events: c.events}); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestCountEvents_MixedTypes(t *testing.T) {
 	events := []watch.Event{
 		{Type: watch.EventComment},

--- a/internal/pipeline/iterate_test.go
+++ b/internal/pipeline/iterate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ahmadAlMezaal/noctra/internal/github"
 	"github.com/ahmadAlMezaal/noctra/internal/sweep"
 	"github.com/ahmadAlMezaal/noctra/internal/watch"
 )
@@ -26,6 +27,26 @@ func TestHasConversationComment(t *testing.T) {
 				t.Errorf("got %v, want %v", got, c.want)
 			}
 		})
+	}
+}
+
+func TestConversationCommentAuthors(t *testing.T) {
+	ch := watch.PRChanges{Events: []watch.Event{
+		{Type: watch.EventComment, Author: github.Actor{Login: "alice"}},
+		{Type: watch.EventComment, Path: "main.go", Author: github.Actor{Login: "bot"}}, // inline → excluded
+		{Type: watch.EventReview, Author: github.Actor{Login: "gemini"}},                // review → excluded
+		{Type: watch.EventComment, Author: github.Actor{Login: "alice"}},                // dupe → collapsed
+		{Type: watch.EventComment, Author: github.Actor{Login: "bob"}},
+	}}
+	got := conversationCommentAuthors(ch)
+	want := []string{"@alice", "@bob"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("authors[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

When auto-iterate re-engages on a PR, the human gets a written **"Addressed in `<sha>` — <summary>"** response — but only if their feedback was an **inline review comment**. The reply path is `ReplyAndResolveThreads`, which only targets unresolved review threads:

```go
threads, err := c.fetchUnresolvedThreads(...)   // inline review-thread comments only
if len(threads) == 0 { return }                  // ← conversation comment → silent exit
```

A **top-level PR conversation comment** isn't a review thread, so the re-engagement added the 👀 ack and pushed the follow-up commits, but **posted no written reply** — even though the agent's summary was already computed and persisted to `LastReasoning`. That's the worse experience for the most natural way a human gives feedback (a plain PR comment), leaving them to guess whether the emoji + commits actually addressed the point. (Observed live on the dashboard PR #234.)

## Fix

- New `github.PostComment(ctx, prURL, body)` — posts a top-level PR conversation comment via `gh pr comment`, carrying `NoctraReplyMarker` so the watcher skips Noctra's own reply (no self-reply loop).
- `iterate.go` posts the same reply as a conversation comment **when the re-engagement included conversation comments** (`hasConversationComment` — an `EventComment` with no `Path`). Applies to both the follow-up-commit and no-diff branches, mirroring the existing thread reply.

Routing after the change:

| Trigger | Behavior |
|---------|----------|
| Inline review comment | Thread reply + resolve (unchanged) |
| Review summary | Thread reply + resolve (unchanged) |
| CI failure only | No conversation comment (unchanged) |
| **Conversation comment** | **Thread replies (if any) + a top-level conversation reply** (new) |

## Tests
- `TestHasConversationComment` — table test: conversation comment → true; inline (`Path` set) → false; review summary → false; mixed → true; none → false.
- Existing `pipeline` + `github` suites pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)