### PR TITLE
ENG-280: Dashboard P0 — persist run history + token usage (wire run_history + usage_events)

### DIFF
--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -201,6 +201,7 @@ func (p *Pipeline) resolveIterateBackend(ctx context.Context, prURL, identifier 
 // the existing remote branch, builds a fix prompt from the new feedback,
 // runs Claude, and pushes the follow-up commit.
 func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier string) {
+	startedAt := time.Now()
 	logger := slog.With("id", identifier, "pr", ch.PR.URL)
 	logger.Info("re-engaging on PR", "events", len(ch.Events), "ci_failed", ch.CIFailure != nil)
 
@@ -230,6 +231,11 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		if err != nil {
 			logger.Error("could not parse PR repo from URL", "err", err)
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
+			p.recordRun(state.RunHistory{
+				Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+				AgentBackend: backend.Name(), RunType: "iterate",
+				StartedAt: startedAt, FinishedAt: time.Now(), Status: "failed",
+			})
 			return
 		}
 	}
@@ -237,6 +243,11 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	if err != nil {
 		logger.Error("repo resolve (direct) failed", "err", err, "ref", ref)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+			AgentBackend: backend.Name(), RunType: "iterate",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "failed",
+		})
 		return
 	}
 
@@ -244,6 +255,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	if err != nil {
 		logger.Error("resume worktree failed", "err", err)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, "")
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+			Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+			RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+			Status: "failed",
+		})
 		return
 	}
 	logger.Info("resume worktree", "path", wt.Path)
@@ -360,6 +377,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	// Record usage from the iteration (ENG-217).
 	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+	p.recordUsage(usage, "iterate", identifier, ch.PR.URL, backend)
 	// Check budget caps immediately after recording — if exceeded, the pause
 	// takes effect on the next poll tick (in-flight work drains naturally).
 	if reason := p.budget.ExceededReason(); reason != "" {
@@ -380,6 +398,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	if runErr != nil {
 		logger.Error("agent run failed", "err", runErr)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+			Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+			RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+			Status: "failed",
+		})
 		return
 	}
 
@@ -392,6 +416,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		}
 		// Advance cursor + count attempt so we don't loop on the same feedback.
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+			Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+			RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+			Status: "blocked",
+		})
 		return
 	}
 
@@ -404,12 +434,24 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	if err := runIn(ctx, wt.Path, "git", "add", "-A"); err != nil {
 		logger.Error("git add failed", "err", err)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+			Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+			RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+			Status: "failed",
+		})
 		return
 	}
 	staged, err := hasStagedChanges(ctx, wt.Path)
 	if err != nil {
 		logger.Error("git diff --cached failed", "err", err)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+			Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+			RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+			Status: "failed",
+		})
 		return
 	}
 	if staged {
@@ -420,6 +462,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 		if err := runIn(ctx, wt.Path, "git", "commit", "-m", commitMsg); err != nil {
 			logger.Error("git commit failed", "err", err)
 			p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+			p.recordRun(state.RunHistory{
+				Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+				Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+				RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+				Status: "failed",
+			})
 			return
 		}
 	}
@@ -427,6 +475,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	if err != nil {
 		logger.Error("git rev-list failed", "err", err)
 		p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+			Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+			RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+			Status: "failed",
+		})
 		return
 	}
 	// Key "addressed" on HEAD moving, not branch-ahead: the agent may self-push.
@@ -437,6 +491,12 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			if err := runIn(ctx, wt.Path, "git", "push", "origin", wt.Branch); err != nil {
 				logger.Error("git push failed", "err", err)
 				p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
+				p.recordRun(state.RunHistory{
+					Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+					Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+					RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+					Status: "failed",
+				})
 				return
 			}
 		}
@@ -488,6 +548,16 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 			notify.EscapeMarkdown(identifier), ch.PR.Number))
 	}
 
+	iterateStatus := "no_change"
+	if moved || ahead {
+		iterateStatus = "pr_opened"
+	}
+	p.recordRun(state.RunHistory{
+		Identifier: identifier, TicketID: identifier, PRURL: ch.PR.URL,
+		Repo: filepath.Base(resolved.Path), AgentBackend: backend.Name(),
+		RunType: "iterate", StartedAt: startedAt, FinishedAt: time.Now(),
+		Status: iterateStatus, Iterations: 1,
+	})
 	p.recordIteration(ctx, ch, identifier, ch.PR.Number, issueID)
 }
 

--- a/internal/pipeline/plan.go
+++ b/internal/pipeline/plan.go
@@ -271,6 +271,7 @@ func (p *Pipeline) processPlanOnly(ctx context.Context, issue source.Ticket) {
 	// Record usage from the plan pass (ENG-217).
 	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+	p.recordUsage(usage, "plan", id, "", backend)
 	if reason := p.budget.ExceededReason(); reason != "" {
 		p.flagBudgetExceeded(reason)
 	}

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ahmadAlMezaal/noctra/internal/agent"
 	"github.com/ahmadAlMezaal/noctra/internal/github"
@@ -51,6 +52,7 @@ func (p *Pipeline) resolveBackend(issue source.Ticket) agent.Backend {
 // moves the ticket back to the trigger state where the source supports that.
 func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	id := issue.Identifier
+	startedAt := time.Now()
 	logger := slog.With("id", id)
 	logger.Info("starting", "title", issue.Title)
 
@@ -209,6 +211,11 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 			p.cfg.AgentTimeout, p.cfg.TriggerState))
 		p.notifier.Send(ctx, fmt.Sprintf("⏰ *%s* — %s\nTimed out after %s. Moving back to %s.",
 			id, notify.EscapeMarkdown(issue.Title), p.cfg.AgentTimeout, notify.EscapeMarkdown(p.cfg.TriggerState)))
+		p.recordRun(state.RunHistory{
+			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
+			AgentBackend: backend.Name(), RunType: "ticket",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "failed",
+		})
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}
@@ -218,6 +225,7 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	// ── Record usage (ENG-217) ───────────────────────────────────────────────
 	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+	p.recordUsage(usage, "ticket", id, "", backend)
 	if usage.TotalTokens > 0 || usage.CostUSD > 0 {
 		logger.Info("usage recorded",
 			"tokens", usage.TotalTokens, "cost_usd", usage.CostUSD)
@@ -255,6 +263,11 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		p.notifier.Send(ctx, fmt.Sprintf(
 			"🛑 *Usage limit detected*\nNoctra %s after %d dispatches.\n✅ %d PRs created | ❌ %d failed",
 			action, t, s, f))
+		p.recordRun(state.RunHistory{
+			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
+			AgentBackend: backend.Name(), RunType: "ticket",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "failed",
+		})
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}
@@ -269,6 +282,11 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 			attempts, p.cfg.MaxRetries, p.cfg.MaxRetries, p.cfg.TriggerState))
 		p.notifier.Send(ctx, fmt.Sprintf("❌ *%s* — %s\nFailed (attempt %d/%d)",
 			id, notify.EscapeMarkdown(issue.Title), attempts, p.cfg.MaxRetries))
+		p.recordRun(state.RunHistory{
+			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
+			AgentBackend: backend.Name(), RunType: "ticket",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "failed",
+		})
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}
@@ -279,6 +297,11 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		p.resolveNoChanges(ctx, issue, fmt.Sprintf(
 			"✅ **Noctra: nothing to do**\n\n> %s\n\nNo changes were needed, so this ticket was closed automatically.", nc))
 		p.notifier.Send(ctx, fmt.Sprintf("✅ *%s* — nothing to do\n%s", id, notify.EscapeMarkdown(nc)))
+		p.recordRun(state.RunHistory{
+			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
+			AgentBackend: backend.Name(), RunType: "ticket",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "no_change",
+		})
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}
@@ -294,6 +317,11 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 			"🚧 **Noctra needs your input** (attempt %d/%d)\n\nThe agent got blocked on this ticket:\n\n> %s\n\nClarify in the ticket comments, then move it back to **%s** to retry. After %d attempts it won't be re-dispatched until Noctra restarts.",
 			attempts, p.cfg.MaxRetries, blocked, p.cfg.TriggerState, p.cfg.MaxRetries))
 		p.notifier.Send(ctx, fmt.Sprintf("⚠️ *%s* — Blocked\n%s", id, notify.EscapeMarkdown(blocked)))
+		p.recordRun(state.RunHistory{
+			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
+			AgentBackend: backend.Name(), RunType: "ticket",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "blocked",
+		})
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}
@@ -325,6 +353,11 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		p.ticketBackToTrigger(ctx, issue, fmt.Sprintf(
 			"💭 **Noctra: No code changes made** (attempt %d/%d)\n\nThe agent completed without modifying any files — usually the ticket is too vague, already done, or its Linear project points at the wrong repo.\n\nAdd more detail (or check the project's `Repo:` directive), then move it back to **%s** to retry. After %d attempts it won't be re-dispatched until Noctra restarts.",
 			attempts, p.cfg.MaxRetries, p.cfg.TriggerState, p.cfg.MaxRetries))
+		p.recordRun(state.RunHistory{
+			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
+			AgentBackend: backend.Name(), RunType: "ticket",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "no_change",
+		})
 		repo.CleanupWorktree(ctx, resolved.Path, p.cfg.WorktreeBase, id)
 		return
 	}
@@ -416,6 +449,7 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 				// Record usage from the fix pass.
 				fixUsage := agent.ParseUsage(fixOutput)
 				p.budget.Record(fixUsage.TotalTokens, fixUsage.CostUSD)
+				p.recordUsage(fixUsage, "ticket", id, "", backend)
 				if reason := p.budget.ExceededReason(); reason != "" {
 					p.flagBudgetExceeded(reason)
 					p.notifier.Send(ctx, fmt.Sprintf(
@@ -595,6 +629,12 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	}
 
 	p.bumpSuccess()
+	p.recordRun(state.RunHistory{
+		Identifier: id, TicketID: id, PRURL: prURL,
+		Repo:         filepath.Base(resolved.Path),
+		AgentBackend: backend.Name(), RunType: "ticket",
+		StartedAt: startedAt, FinishedAt: time.Now(), Status: "pr_opened",
+	})
 	p.notifier.Send(ctx, fmt.Sprintf("✅ *%s* — %s\nPR ready (via %s): %s",
 		id, notify.EscapeMarkdown(issue.Title), notify.EscapeMarkdown(backend.Label()), prURL))
 
@@ -852,4 +892,36 @@ func appendCoAuthorTrailer(msg, coAuthor string) string {
 		return msg
 	}
 	return strings.TrimRight(msg, " \t\n\r") + "\n\nCo-authored-by: " + coAuthor
+}
+
+// recordUsage persists a usage_events row beside the in-memory budget counter.
+// Best-effort: a failed insert is logged and never blocks the run.
+func (p *Pipeline) recordUsage(usage agent.Usage, source, ticketID, prURL string, backend agent.Backend) {
+	if p.store == nil {
+		return
+	}
+	if err := p.store.RecordUsage(state.UsageEvent{
+		OccurredAt:   time.Now(),
+		Source:       source,
+		TicketID:     ticketID,
+		PRURL:        prURL,
+		AgentBackend: backend.Name(),
+		InputTokens:  usage.InputTokens,
+		OutputTokens: usage.OutputTokens,
+		TotalTokens:  usage.TotalTokens,
+		CostUSD:      usage.CostUSD,
+	}); err != nil {
+		slog.Warn("record usage event failed", "source", source, "ticket_id", ticketID, "err", err)
+	}
+}
+
+// recordRun persists a run_history row at a lifecycle's terminal point.
+// Best-effort: a failed insert is logged and never blocks the run.
+func (p *Pipeline) recordRun(rec state.RunHistory) {
+	if p.store == nil {
+		return
+	}
+	if err := p.store.InsertRunHistory(rec); err != nil {
+		slog.Warn("record run history failed", "id", rec.Identifier, "status", rec.Status, "err", err)
+	}
 }

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -131,6 +131,7 @@ func (p *Pipeline) sweepOnce(ctx context.Context, wg *sync.WaitGroup) {
 // processSweepTask is one sweep task's full lifecycle: create worktree →
 // run agent with task-specific prompt → check output → commit/push → PR.
 func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifier string) {
+	startedAt := time.Now()
 	logger := slog.With("sweep_task", job.Task.Name, "repo", job.RepoSlug, "id", identifier)
 	logger.Info("starting sweep task", "description", job.Task.Description)
 
@@ -193,6 +194,7 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	// Record usage.
 	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
+	p.recordUsage(usage, "sweep", identifier, "", backend)
 	if usage.TotalTokens > 0 || usage.CostUSD > 0 {
 		logger.Info("usage recorded", "tokens", usage.TotalTokens, "cost_usd", usage.CostUSD)
 	}
@@ -217,6 +219,11 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 		if err := p.sweeper.RecordRun(job.RepoSlug, job.Task.Name); err != nil {
 			logger.Warn("could not record sweep run in state", "err", err)
 		}
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, Repo: job.RepoSlug,
+			AgentBackend: backend.Name(), RunType: "sweep",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "failed",
+		})
 		return
 	}
 
@@ -226,6 +233,11 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 		if err := p.sweeper.RecordRun(job.RepoSlug, job.Task.Name); err != nil {
 			logger.Warn("could not record sweep run in state", "err", err)
 		}
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, Repo: job.RepoSlug,
+			AgentBackend: backend.Name(), RunType: "sweep",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "blocked",
+		})
 		return
 	}
 
@@ -245,6 +257,11 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 		if err := p.sweeper.RecordRun(job.RepoSlug, job.Task.Name); err != nil {
 			logger.Warn("could not record sweep run in state", "err", err)
 		}
+		p.recordRun(state.RunHistory{
+			Identifier: identifier, Repo: job.RepoSlug,
+			AgentBackend: backend.Name(), RunType: "sweep",
+			StartedAt: startedAt, FinishedAt: time.Now(), Status: "no_change",
+		})
 		return
 	}
 
@@ -350,6 +367,7 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 				// Record usage from the fix pass.
 				fixUsage := agent.ParseUsage(fixOutput)
 				p.budget.Record(fixUsage.TotalTokens, fixUsage.CostUSD)
+				p.recordUsage(fixUsage, "sweep", identifier, "", backend)
 				if reason := p.budget.ExceededReason(); reason != "" {
 					p.flagBudgetExceeded(reason)
 					p.notifier.Send(ctx, fmt.Sprintf(
@@ -442,6 +460,11 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 
 	logger.Info("✅ sweep PR created", "url", prURL)
 	p.bumpSuccess()
+	p.recordRun(state.RunHistory{
+		Identifier: identifier, PRURL: prURL, Repo: job.RepoSlug,
+		AgentBackend: backend.Name(), RunType: "sweep",
+		StartedAt: startedAt, FinishedAt: time.Now(), Status: "pr_opened",
+	})
 	p.notifier.Send(ctx, fmt.Sprintf("✅ *Sweep: %s* on %s\nPR: %s",
 		notify.EscapeMarkdown(job.Task.Name),
 		notify.EscapeMarkdown(job.RepoSlug),

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -95,6 +95,36 @@ type PlanState struct {
 	PlannedAt time.Time `json:"planned_at"`
 }
 
+// RunHistory records the outcome of a single Noctra run (ticket, sweep, or
+// iterate). Written at each lifecycle's terminal point so the dashboard's
+// "what happened overnight" panel survives restarts.
+type RunHistory struct {
+	Identifier   string
+	TicketID     string
+	PRURL        string
+	Repo         string
+	AgentBackend string
+	RunType      string // "ticket" | "sweep" | "iterate"
+	StartedAt    time.Time
+	FinishedAt   time.Time
+	Status       string // "pr_opened" | "blocked" | "failed" | "no_change"
+	Iterations   int
+}
+
+// UsageEvent records token consumption from a single agent invocation.
+// Written beside every budget.Record call so cost data survives restarts.
+type UsageEvent struct {
+	OccurredAt   time.Time
+	Source       string // "ticket" | "iterate" | "sweep" | "plan"
+	TicketID     string
+	PRURL        string
+	AgentBackend string
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	CostUSD      float64
+}
+
 // OAuthState persists the rotating Linear actor=app OAuth credentials (ENG-236)
 // so a restart does not lose a refresh-token rotation.
 type OAuthState struct {
@@ -600,6 +630,96 @@ func (s *Store) AllPlans() map[string]PlanState {
 		return nil
 	}
 	return out
+}
+
+// InsertRunHistory persists a run-history record. Best-effort: a failed
+// insert is logged and never blocks the run.
+func (s *Store) InsertRunHistory(rec RunHistory) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.db.Exec(`INSERT INTO run_history (
+			identifier, ticket_id, pr_url, repo, agent_backend,
+			run_type, started_at, finished_at, status, iterations
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		rec.Identifier,
+		rec.TicketID,
+		rec.PRURL,
+		rec.Repo,
+		rec.AgentBackend,
+		rec.RunType,
+		formatTime(rec.StartedAt),
+		formatTime(rec.FinishedAt),
+		rec.Status,
+		rec.Iterations,
+	)
+	if err != nil {
+		return fmt.Errorf("insert run history: %w", err)
+	}
+	return nil
+}
+
+// ListRunHistory returns the most recent n run-history records, newest first.
+func (s *Store) ListRunHistory(limit int) ([]RunHistory, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rows, err := s.db.Query(`SELECT identifier, ticket_id, pr_url, repo, agent_backend,
+		run_type, started_at, finished_at, status, iterations
+		FROM run_history ORDER BY started_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list run history: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("close run_history rows failed", "err", err)
+		}
+	}()
+	var out []RunHistory
+	for rows.Next() {
+		var r RunHistory
+		var startedAt, finishedAt sql.NullString
+		if err := rows.Scan(
+			&r.Identifier, &r.TicketID, &r.PRURL, &r.Repo, &r.AgentBackend,
+			&r.RunType, &startedAt, &finishedAt, &r.Status, &r.Iterations,
+		); err != nil {
+			return nil, fmt.Errorf("scan run history: %w", err)
+		}
+		if t, convErr := parseNullTime(startedAt); convErr == nil {
+			r.StartedAt = t
+		}
+		if t, convErr := parseNullTime(finishedAt); convErr == nil {
+			r.FinishedAt = t
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate run history: %w", err)
+	}
+	return out, nil
+}
+
+// RecordUsage persists a usage-event row. Best-effort: a failed insert is
+// logged and never blocks the run.
+func (s *Store) RecordUsage(ev UsageEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.db.Exec(`INSERT INTO usage_events (
+			occurred_at, source, ticket_id, pr_url, agent_backend,
+			input_tokens, output_tokens, total_tokens, cost_usd
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		formatTime(ev.OccurredAt),
+		ev.Source,
+		ev.TicketID,
+		ev.PRURL,
+		ev.AgentBackend,
+		ev.InputTokens,
+		ev.OutputTokens,
+		ev.TotalTokens,
+		ev.CostUSD,
+	)
+	if err != nil {
+		return fmt.Errorf("record usage event: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) migrateLegacyJSON(path string) error {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -535,6 +535,240 @@ func TestLessons(t *testing.T) {
 	}
 }
 
+// ── Run history + usage event tests (ENG-280) ──────────────────────────────
+
+func TestInsertAndListRunHistory(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	recs := []RunHistory{
+		{
+			Identifier: "ENG-1", TicketID: "ENG-1",
+			PRURL: "https://github.com/o/r/pull/1", Repo: "my-repo",
+			AgentBackend: "claude", RunType: "ticket",
+			StartedAt: now.Add(-3 * time.Minute), FinishedAt: now.Add(-2 * time.Minute),
+			Status: "pr_opened",
+		},
+		{
+			Identifier: "ENG-2", TicketID: "ENG-2", Repo: "my-repo",
+			AgentBackend: "codex", RunType: "ticket",
+			StartedAt: now.Add(-1 * time.Minute), FinishedAt: now,
+			Status: "failed",
+		},
+		{
+			Identifier: "SWEEP-my-repo-lint", Repo: "my-repo",
+			AgentBackend: "claude", RunType: "sweep",
+			StartedAt: now, FinishedAt: now.Add(time.Minute),
+			Status: "no_change",
+		},
+	}
+
+	for _, r := range recs {
+		if err := s.InsertRunHistory(r); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	// All — newest first.
+	got, err := s.ListRunHistory(10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len: got %d, want 3", len(got))
+	}
+	if got[0].Identifier != "SWEEP-my-repo-lint" {
+		t.Errorf("newest first: got %s", got[0].Identifier)
+	}
+	if got[1].Identifier != "ENG-2" {
+		t.Errorf("second: got %s", got[1].Identifier)
+	}
+	if got[2].Identifier != "ENG-1" {
+		t.Errorf("third: got %s", got[2].Identifier)
+	}
+
+	// Fields on the first record.
+	if got[0].RunType != "sweep" {
+		t.Errorf("run_type: got %q", got[0].RunType)
+	}
+	if got[0].Status != "no_change" {
+		t.Errorf("status: got %q", got[0].Status)
+	}
+	if got[2].PRURL != "https://github.com/o/r/pull/1" {
+		t.Errorf("pr_url: got %q", got[2].PRURL)
+	}
+	if got[2].Status != "pr_opened" {
+		t.Errorf("status: got %q", got[2].Status)
+	}
+
+	// Bounded read.
+	got2, err := s.ListRunHistory(2)
+	if err != nil {
+		t.Fatalf("list(2): %v", err)
+	}
+	if len(got2) != 2 {
+		t.Fatalf("len: got %d, want 2", len(got2))
+	}
+	if got2[0].Identifier != "SWEEP-my-repo-lint" {
+		t.Errorf("bounded: got %s", got2[0].Identifier)
+	}
+}
+
+func TestListRunHistory_Empty(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	got, err := s.ListRunHistory(10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %d", len(got))
+	}
+}
+
+func TestRunHistory_TimestampRoundTrip(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := RunHistory{
+		Identifier: "ENG-99", TicketID: "ENG-99", Repo: "test-repo",
+		AgentBackend: "claude", RunType: "ticket",
+		StartedAt: now, FinishedAt: now.Add(5 * time.Minute),
+		Status: "pr_opened",
+	}
+	if err := s.InsertRunHistory(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.ListRunHistory(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len: got %d, want 1", len(got))
+	}
+	if got[0].StartedAt.Sub(now).Abs() > time.Second {
+		t.Errorf("started_at drift: got %v, want ~%v", got[0].StartedAt, now)
+	}
+	if got[0].FinishedAt.Sub(now.Add(5*time.Minute)).Abs() > time.Second {
+		t.Errorf("finished_at drift: got %v, want ~%v", got[0].FinishedAt, now.Add(5*time.Minute))
+	}
+}
+
+func TestRecordUsage(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := s.RecordUsage(UsageEvent{
+		OccurredAt: now, Source: "ticket", TicketID: "ENG-42",
+		PRURL: "https://github.com/o/r/pull/7", AgentBackend: "claude",
+		InputTokens: 1000, OutputTokens: 500, TotalTokens: 1500, CostUSD: 0.03,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.RecordUsage(UsageEvent{
+		OccurredAt: now.Add(time.Minute), Source: "iterate", TicketID: "ENG-42",
+		PRURL: "https://github.com/o/r/pull/7", AgentBackend: "claude",
+		InputTokens: 2000, OutputTokens: 1000, TotalTokens: 3000, CostUSD: 0.06,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify rows directly (no public read API for usage_events yet — P4).
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM usage_events`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count: got %d, want 2", count)
+	}
+
+	var source, ticketID string
+	var inputTokens, totalTokens int64
+	var costUSD float64
+	err = s.db.QueryRow(`SELECT source, ticket_id, input_tokens, total_tokens, cost_usd
+		FROM usage_events ORDER BY id LIMIT 1`).Scan(
+		&source, &ticketID, &inputTokens, &totalTokens, &costUSD,
+	)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if source != "ticket" {
+		t.Errorf("source: got %q", source)
+	}
+	if ticketID != "ENG-42" {
+		t.Errorf("ticket_id: got %q", ticketID)
+	}
+	if inputTokens != 1000 {
+		t.Errorf("input_tokens: got %d", inputTokens)
+	}
+	if totalTokens != 1500 {
+		t.Errorf("total_tokens: got %d", totalTokens)
+	}
+	if costUSD != 0.03 {
+		t.Errorf("cost_usd: got %f", costUSD)
+	}
+}
+
+func TestInsertRunHistory_SurvivesReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := s.InsertRunHistory(RunHistory{
+		Identifier: "ENG-7", TicketID: "ENG-7", Repo: "repo",
+		AgentBackend: "claude", RunType: "ticket",
+		StartedAt: now, FinishedAt: now.Add(time.Minute),
+		Status: "pr_opened", Iterations: 0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s2)
+
+	got, err := s2.ListRunHistory(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d", len(got))
+	}
+	if got[0].Identifier != "ENG-7" || got[0].Status != "pr_opened" {
+		t.Errorf("record did not survive reopen: %+v", got[0])
+	}
+}
+
 func closeStore(t *testing.T, s *Store) {
 	t.Helper()
 	if err := s.Close(); err != nil {


### PR DESCRIPTION
## ENG-280: Dashboard P0 — persist run history + token usage (wire run_history + usage_events)

**Ticket:** https://linear.app/amazz/issue/ENG-280/dashboard-p0-persist-run-history-token-usage-wire-run-history-usage

## What was implemented

Wired the pre-existing `run_history` and `usage_events` SQLite tables so they actually receive data, giving the dashboard durable history + cost data that survives restarts.

**`internal/state/state.go`** — Added `RunHistory` and `UsageEvent` structs matching the existing table schemas. Added three new store methods:
- `InsertRunHistory(rec)` — persists a run-history record (RFC3339 timestamps, mutex-guarded).
- `ListRunHistory(limit)` — returns the most recent N runs, newest first (ordered by `started_at DESC`).
- `RecordUsage(ev)` — persists a usage-event row.

**`internal/pipeline/process.go`** — Added `recordUsage` and `recordRun` helper methods on `Pipeline` (best-effort: log on failure, never block the run). Wired `recordUsage` beside both `p.budget.Record` calls (main agent run + review fix-pass). Wired `recordRun` at every terminal point of the ticket lifecycle: timeout → `failed`, rate-limit → `failed`, non-zero exit → `failed`, NO_CHANGES → `no_change`, BLOCKED → `blocked`, no dirty/committed → `no_change`, PR created → `pr_opened`.

**`internal/pipeline/iterate.go`** — Wired `recordUsage` beside the iterate `p.budget.Record` call. Wired `recordRun` at every terminal point: repo resolution failures → `failed`, worktree resume failure → `failed`, agent run failure → `failed`, blocked → `blocked`, git operation failures → `failed`, final success → `pr_opened` (if HEAD moved/pushed) or `no_change` (no diff).

**`internal/pipeline/sweep.go`** — Wired `recordUsage` beside both sweep `p.budget.Record` calls (main run + review fix-pass). Wired `recordRun` at terminal points: agent error → `failed`, blocked → `blocked`, no changes → `no_change`, PR created → `pr_opened`.

**`internal/pipeline/plan.go`** — Wired `recordUsage` beside the plan-only `p.budget.Record` call (source = `"plan"`). No `run_history` for plan passes since they're read-only exploration, not implementation runs.

**`internal/state/state_test.go`** — Added five new tests: `TestInsertAndListRunHistory` (insert 3 records, verify newest-first ordering + bounded read), `TestListRunHistory_Empty`, `TestRunHistory_TimestampRoundTrip` (RFC3339 round-trip fidelity), `TestRecordUsage` (insert + verify via direct SQL query), `TestInsertRunHistory_SurvivesReopen` (persist across close/reopen).

All existing tests pass; `go vet ./...` clean. No HTTP endpoints or UI changes (that's P4/ENG-277).

---

✅ Passed **Multi-model review** (Gemini `gemini-2.5-flash` via `api`)

The diff comprehensively implements the persistence of run history and token usage, meeting all specified requirements and acceptance criteria. The new store methods are well-tested, and the integration points in the pipeline are correctly handled with appropriate error logging.
---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*
<!-- noctra-authored -->