### PR TITLE
fix: post Gemini review verdict as a PR comment, not in the description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,8 @@ DEBUG: pwd = /path
 
 Keep comments minimal: explain *why* for a non-obvious decision, never narrate *what* the code already says. Prefer a self-explanatory name over a comment. Keep doc comments on exported symbols (Go convention); drop inline comments that just restate the next line.
 
+⚠️ **Do NOT add redundant comments.** This applies to humans AND any agent (Claude/Codex/Copilot) working in this repo. A comment that paraphrases the line below it, restates a clear variable/function name, or explains an obvious assignment is noise — delete it. Only write a comment when the code cannot explain *why* on its own (a non-obvious trade-off, a workaround, a subtle invariant). When in doubt, leave it out.
+
 ## Running tests
 
 ```bash

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -519,39 +519,42 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		}
 	}
 
-	reviewSection := ""
+	// The multi-model review verdict is posted as a PR comment (after creation),
+	// not embedded in the PR description, so the body stays focused on what was
+	// implemented.
+	reviewComment := ""
 	if p.review.Enabled() {
 		model := fmt.Sprintf("Gemini `%s` via `%s`", p.review.Model, p.review.Mode)
 		switch {
 		case reviewSkipped:
-			reviewSection = fmt.Sprintf("\n---\n\n⚠️ **Multi-model review:** Skipped (%s)\n\n%s", model, reviewBody)
+			reviewComment = fmt.Sprintf("⚠️ **Multi-model review:** Skipped (%s)\n\n%s", model, reviewBody)
 		case reviewSummary != "" || len(reviewFindings) > 0:
 			verdict := "✅ Passed"
 			if !reviewPassed {
 				verdict = "⚠️ Changes requested"
 			}
-			reviewSection = fmt.Sprintf("\n---\n\n%s **Multi-model review** (%s)", verdict, model)
+			reviewComment = fmt.Sprintf("%s **Multi-model review** (%s)", verdict, model)
 			if reviewSummary != "" {
-				reviewSection += "\n\n" + reviewSummary
+				reviewComment += "\n\n" + reviewSummary
 			}
 			if len(reviewFindings) > 0 {
-				reviewSection += "\n\nSpecific findings are posted as inline review comments."
+				reviewComment += "\n\nSpecific findings are posted as inline review comments."
 			}
 		case reviewPassed:
-			reviewSection = fmt.Sprintf("\n---\n\n✅ **Multi-model review:** Passed (%s)", model)
+			reviewComment = fmt.Sprintf("✅ **Multi-model review:** Passed (%s)", model)
 			if body := strings.TrimSpace(reviewBody); body != "" {
-				reviewSection += fmt.Sprintf("\n\n<details>\n<summary>Gemini review</summary>\n\n```\n%s\n```\n\n</details>", body)
+				reviewComment += fmt.Sprintf("\n\n<details>\n<summary>Gemini review</summary>\n\n```\n%s\n```\n\n</details>", body)
 			}
 		default:
-			reviewSection = fmt.Sprintf(
-				"\n\n---\n\n⚠️ **Multi-model review:** Did not pass after %d attempt(s). Please review before merging:\n\n<details>\n<summary>Gemini review comments</summary>\n\n```\n%s\n```\n\n</details>",
+			reviewComment = fmt.Sprintf(
+				"⚠️ **Multi-model review:** Did not pass after %d attempt(s). Please review before merging:\n\n<details>\n<summary>Gemini review comments</summary>\n\n```\n%s\n```\n\n</details>",
 				reviewAttempts, reviewBody)
 		}
 	}
 
 	prBody := fmt.Sprintf(
-		"## %s: %s\n\n**Ticket:** %s\n\n## What was implemented\n\n%s\n%s\n---\n\n*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using %s*\n%s",
-		id, issue.Title, issue.URL, summary, reviewSection, backend.Label(), github.NoctraPRBodyMarker)
+		"## %s: %s\n\n**Ticket:** %s\n\n## What was implemented\n\n%s\n\n---\n\n*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using %s*\n%s",
+		id, issue.Title, issue.URL, summary, backend.Label(), github.NoctraPRBodyMarker)
 
 	// ── gh pr create ─────────────────────────────────────────────────────────
 	prURL, err := ghCreatePR(ctx, resolved.Path,
@@ -582,6 +585,12 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	}
 
 	logger.Info("✅ PR created", "url", prURL)
+
+	if reviewComment != "" {
+		if err := p.gh.PostComment(ctx, prURL, reviewComment); err != nil {
+			logger.Warn("could not post review verdict comment", "err", err)
+		}
+	}
 
 	if len(reviewFindings) > 0 {
 		headSHA := gitHead(ctx, wt.Path)

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -519,9 +519,6 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		}
 	}
 
-	// The multi-model review verdict is posted as a PR comment (after creation),
-	// not embedded in the PR description, so the body stays focused on what was
-	// implemented.
 	reviewComment := ""
 	if p.review.Enabled() {
 		model := fmt.Sprintf("Gemini `%s` via `%s`", p.review.Model, p.review.Mode)

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -406,24 +406,26 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	rawLog, _ := os.ReadFile(logFile)
 	summary := agent.ExtractSummary(string(rawLog))
 
-	reviewSection := ""
+	// The multi-model review verdict is posted as a PR comment (after creation),
+	// not embedded in the PR description, so the body stays focused on what was done.
+	reviewComment := ""
 	if p.review.Enabled() {
 		if reviewSkipped {
-			reviewSection = fmt.Sprintf("\n---\n\n⚠️ **Multi-model review:** Skipped (Gemini `%s` via `%s`)\n\n%s",
+			reviewComment = fmt.Sprintf("⚠️ **Multi-model review:** Skipped (Gemini `%s` via `%s`)\n\n%s",
 				p.review.Model, p.review.Mode, reviewBody)
 		} else if reviewPassed {
-			reviewSection = fmt.Sprintf("\n---\n\n✅ **Multi-model review:** Passed (Gemini `%s` via `%s`)",
+			reviewComment = fmt.Sprintf("✅ **Multi-model review:** Passed (Gemini `%s` via `%s`)",
 				p.review.Model, p.review.Mode)
 		} else {
-			reviewSection = fmt.Sprintf(
-				"\n\n---\n\n⚠️ **Multi-model review:** Did not pass after %d attempt(s). Please review before merging:\n\n<details>\n<summary>Gemini review comments</summary>\n\n```\n%s\n```\n\n</details>",
+			reviewComment = fmt.Sprintf(
+				"⚠️ **Multi-model review:** Did not pass after %d attempt(s). Please review before merging:\n\n<details>\n<summary>Gemini review comments</summary>\n\n```\n%s\n```\n\n</details>",
 				reviewAttempts, reviewBody)
 		}
 	}
 
 	prBody := fmt.Sprintf(
-		"## 🧹 Maintenance: %s\n\n**Task:** %s\n**Repo:** %s\n\n## What was done\n\n%s%s\n\n---\n\n*Autonomous maintenance by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using %s*\n%s",
-		job.Task.Name, job.Task.Description, job.RepoSlug, summary, reviewSection, backend.Label(), github.NoctraPRBodyMarker)
+		"## 🧹 Maintenance: %s\n\n**Task:** %s\n**Repo:** %s\n\n## What was done\n\n%s\n\n---\n\n*Autonomous maintenance by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using %s*\n%s",
+		job.Task.Name, job.Task.Description, job.RepoSlug, summary, backend.Label(), github.NoctraPRBodyMarker)
 
 	prTitle := fmt.Sprintf("%s: %s", job.Task.CommitPrefix, job.Task.Description)
 
@@ -441,6 +443,13 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	}
 
 	logger.Info("✅ sweep PR created", "url", prURL)
+
+	if reviewComment != "" {
+		if err := p.gh.PostComment(ctx, prURL, reviewComment); err != nil {
+			logger.Warn("could not post review verdict comment", "err", err)
+		}
+	}
+
 	p.bumpSuccess()
 	p.notifier.Send(ctx, fmt.Sprintf("✅ *Sweep: %s* on %s\nPR: %s",
 		notify.EscapeMarkdown(job.Task.Name),

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -406,8 +406,6 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 	rawLog, _ := os.ReadFile(logFile)
 	summary := agent.ExtractSummary(string(rawLog))
 
-	// The multi-model review verdict is posted as a PR comment (after creation),
-	// not embedded in the PR description, so the body stays focused on what was done.
 	reviewComment := ""
 	if p.review.Enabled() {
 		if reviewSkipped {


### PR DESCRIPTION
## Summary

The multi-model (Gemini) review verdict was embedded directly in the PR **description**, so even a clean pass cluttered the "what was implemented" body with a verdict + summary block.

This moves the verdict to a separate PR **conversation comment** posted right after the PR is created, in both code paths:

- `internal/pipeline/process.go` — ticket-driven PRs
- `internal/pipeline/sweep.go` — maintenance sweep PRs

## Details

- The verdict block is built into a `reviewComment` string instead of being concatenated into `prBody`; the body now ends after "What was implemented" → the Noctra footer.
- It's posted via `github.PostComment`, which appends the hidden `NoctraReplyMarker`, so the auto-iterate watcher **skips Noctra's own verdict comment** rather than re-reading it as feedback and looping.
- Covers all verdict states (passed, changes-requested, skipped, did-not-pass), not just the pass case.
- Inline findings still post as inline review comments (unchanged).
- Posting failures are logged as a warning and never block the PR.

## Testing

- `go build ./...` ✅
- `go vet ./internal/pipeline/` ✅
- `go test ./internal/pipeline/ ./internal/github/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)