### PR TITLE
feat: add a dashboard config check to doctor

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os/exec"
 	"strings"
 	"time"
@@ -92,6 +93,7 @@ func gather(scriptDir string) []check {
 	} else {
 		checks = append(checks, checkLinearKey(cfg))
 		checks = append(checks, checkRepos(cfg))
+		checks = append(checks, checkDashboard(cfg))
 	}
 
 	// ── Config dir ───────────────────────────────────────────────────────────
@@ -281,6 +283,33 @@ func checkLinearKey(cfg *config.Config) check {
 // each Linear project's `Repo: owner/name` directive, with REPO_PATH as an
 // optional single-repo fallback — there's nothing to validate up front, so this
 // is always an informational OK.
+func checkDashboard(cfg *config.Config) check {
+	if cfg.DashboardAddr == "" {
+		return check{
+			name:   "dashboard",
+			ok:     true,
+			detail: "disabled (set DASHBOARD_ADDR to enable)",
+		}
+	}
+	if cfg.DashboardToken == "" {
+		return check{
+			name:   "dashboard",
+			ok:     false,
+			detail: "DASHBOARD_ADDR set but DASHBOARD_TOKEN is empty",
+			hint:   "set DASHBOARD_TOKEN — Noctra refuses to start an unauthenticated dashboard",
+		}
+	}
+	detail := "enabled at " + cfg.DashboardAddr
+	if host, _, err := net.SplitHostPort(cfg.DashboardAddr); err == nil && (host == "0.0.0.0" || host == "::") {
+		detail += " — exposed on all interfaces; only the token gates access"
+	}
+	return check{
+		name:   "dashboard",
+		ok:     true,
+		detail: detail,
+	}
+}
+
 func checkRepos(cfg *config.Config) check {
 	if cfg.RepoPath != "" {
 		return check{

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -82,6 +82,46 @@ func TestCheckRepos_FallbackPath(t *testing.T) {
 	}
 }
 
+func TestCheckDashboard_Disabled(t *testing.T) {
+	c := checkDashboard(&config.Config{DashboardAddr: ""})
+	if !c.ok {
+		t.Errorf("disabled dashboard should pass; detail=%q", c.detail)
+	}
+	if !strings.Contains(c.detail, "disabled") {
+		t.Errorf("expected detail to say disabled; got %q", c.detail)
+	}
+}
+
+func TestCheckDashboard_EnabledNoToken(t *testing.T) {
+	c := checkDashboard(&config.Config{DashboardAddr: ":8080", DashboardToken: ""})
+	if c.ok {
+		t.Error("enabled dashboard with no token must fail (mirrors the runtime fail-fast)")
+	}
+	if !strings.Contains(c.detail, "DASHBOARD_TOKEN") || c.hint == "" {
+		t.Errorf("expected token detail + a hint; got detail=%q hint=%q", c.detail, c.hint)
+	}
+}
+
+func TestCheckDashboard_EnabledWithToken(t *testing.T) {
+	c := checkDashboard(&config.Config{DashboardAddr: ":8080", DashboardToken: "secret"})
+	if !c.ok {
+		t.Errorf("enabled dashboard with a token should pass; detail=%q", c.detail)
+	}
+	if !strings.Contains(c.detail, ":8080") {
+		t.Errorf("expected detail to mention the address; got %q", c.detail)
+	}
+}
+
+func TestCheckDashboard_ExposedBindWarns(t *testing.T) {
+	c := checkDashboard(&config.Config{DashboardAddr: "0.0.0.0:8080", DashboardToken: "secret"})
+	if !c.ok {
+		t.Errorf("a 0.0.0.0 bind with a token still passes; detail=%q", c.detail)
+	}
+	if !strings.Contains(c.detail, "all interfaces") {
+		t.Errorf("expected an exposure warning in detail; got %q", c.detail)
+	}
+}
+
 func TestRunJSON_Shape(t *testing.T) {
 	// Use a temp dir with no config: gather() still emits checks (CLIs, gh
 	// auth, config error, config dir), so we get a non-empty, well-formed array.


### PR DESCRIPTION
## Problem

`noctra doctor` validated CLIs, gh auth, Linear, repos, and the config dir — but **not the dashboard** config added in P1 (ENG-274). The only guard on the dashboard is a runtime fail-fast in `pipeline.Run` (`DASHBOARD_ADDR` set + `DASHBOARD_TOKEN` empty → refuses to start). So a half-configured dashboard sailed through doctor — *"All 11 checks passed — ready to roll"* — and then `noctra run` wouldn't start. That's exactly the misconfiguration doctor exists to catch first.

## Change

New `checkDashboard(cfg)` in `internal/doctor`, wired into `gather` next to the Linear/repos checks:

- `DASHBOARD_ADDR` empty → ✓ `disabled (set DASHBOARD_ADDR to enable)`
- set **+ token** → ✓ `enabled at <addr>`
- set **+ no token** → ✗ `DASHBOARD_ADDR set but DASHBOARD_TOKEN is empty` + hint (mirrors the runtime fail-fast, so doctor and `run` agree)
- bound to `0.0.0.0` / `::` → ✓ with an `exposed on all interfaces` warning

Surfaces in both the human report and `doctor --json` (shares `gather`).

## Tests
- `TestCheckDashboard_Disabled` / `_EnabledNoToken` / `_EnabledWithToken` / `_ExposedBindWarns`.
- `go build`, `go vet`, `go test ./internal/doctor/...` pass. Verified locally: `✓ dashboard  disabled (set DASHBOARD_ADDR to enable)` (12 checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)