### PR TITLE
ENG-277: Dashboard P4 — depth: run history, sweep + PR-iterate panels, cost sparkline, deep links

### DIFF
--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -10,7 +10,12 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+	"github.com/ahmadAlMezaal/noctra/internal/sweep"
 )
 
 //go:embed static
@@ -18,6 +23,16 @@ var staticFiles embed.FS
 
 // SnapshotFunc returns the current pipeline snapshot as JSON-serializable data.
 type SnapshotFunc func() any
+
+// Providers supplies the data sources the dashboard reads from. All fields
+// are optional — a nil Store or empty function gracefully degrades the
+// corresponding panel to an empty response.
+type Providers struct {
+	Store           *state.Store
+	SweepTasks      []sweep.Task
+	MaxPRIterations int
+	RepoPaths       func() []string // repo.Resolver.AllRepoPaths
+}
 
 // Server is the dashboard HTTP server.
 type Server struct {
@@ -27,7 +42,8 @@ type Server struct {
 
 // New creates a dashboard server bound to addr, gated by the given token.
 // snapshotFn is called on each GET /api/snapshot to produce the response payload.
-func New(addr, token string, snapshotFn SnapshotFunc) *Server {
+// prov supplies optional data sources for history, cost, PR, and sweep panels.
+func New(addr, token string, snapshotFn SnapshotFunc, prov Providers) *Server {
 	mux := http.NewServeMux()
 
 	s := &Server{
@@ -45,6 +61,38 @@ func New(addr, token string, snapshotFn SnapshotFunc) *Server {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(snapshotFn())
+	})))
+
+	mux.Handle("/api/history", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleHistory(w, r, prov.Store)
+	})))
+
+	mux.Handle("/api/prs", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handlePRs(w, r, prov.Store, prov.MaxPRIterations)
+	})))
+
+	mux.Handle("/api/sweeps", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleSweeps(w, r, prov.Store, prov.SweepTasks)
+	})))
+
+	mux.Handle("/api/cost", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleCost(w, r, prov.Store)
 	})))
 
 	staticSub, _ := fs.Sub(staticFiles, "static")
@@ -92,4 +140,234 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// ── API handlers ────────────────────────────────────────────────────────────
+
+type historyEntry struct {
+	Identifier string  `json:"identifier"`
+	TicketID   string  `json:"ticket_id,omitempty"`
+	PRURL      string  `json:"pr_url,omitempty"`
+	Repo       string  `json:"repo"`
+	RunType    string  `json:"run_type"`
+	Status     string  `json:"status"`
+	DurationS  float64 `json:"duration_s"`
+	StartedAt  string  `json:"started_at"`
+	FinishedAt string  `json:"finished_at,omitempty"`
+	LinearURL  string  `json:"linear_url,omitempty"`
+}
+
+func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request, store *state.Store) {
+	if store == nil {
+		writeJSON(w, []historyEntry{})
+		return
+	}
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 500 {
+			limit = n
+		}
+	}
+	runs, err := store.ListRunHistory(limit)
+	if err != nil {
+		slog.Warn("dashboard history query failed", "err", err)
+		writeJSON(w, []historyEntry{})
+		return
+	}
+	entries := make([]historyEntry, 0, len(runs))
+	for _, r := range runs {
+		dur := 0.0
+		if !r.FinishedAt.IsZero() && !r.StartedAt.IsZero() {
+			dur = r.FinishedAt.Sub(r.StartedAt).Seconds()
+		}
+		e := historyEntry{
+			Identifier: r.Identifier,
+			TicketID:   r.TicketID,
+			PRURL:      r.PRURL,
+			Repo:       r.Repo,
+			RunType:    r.RunType,
+			Status:     r.Status,
+			DurationS:  dur,
+			StartedAt:  r.StartedAt.UTC().Format(time.RFC3339),
+		}
+		if !r.FinishedAt.IsZero() {
+			e.FinishedAt = r.FinishedAt.UTC().Format(time.RFC3339)
+		}
+		if r.TicketID != "" {
+			e.LinearURL = linearURL(r.TicketID)
+		}
+		entries = append(entries, e)
+	}
+	writeJSON(w, entries)
+}
+
+type prEntry struct {
+	PRURL         string `json:"pr_url"`
+	TicketID      string `json:"ticket_id,omitempty"`
+	Iterations    int    `json:"iterations"`
+	MaxIterations int    `json:"max_iterations"`
+	Capped        bool   `json:"capped"`
+	LastCISHA     string `json:"last_ci_sha,omitempty"`
+	LastReasoning string `json:"last_reasoning,omitempty"`
+	LinearURL     string `json:"linear_url,omitempty"`
+}
+
+func (s *Server) handlePRs(w http.ResponseWriter, _ *http.Request, store *state.Store, maxIter int) {
+	if store == nil {
+		writeJSON(w, []prEntry{})
+		return
+	}
+	all := store.All()
+	entries := make([]prEntry, 0, len(all))
+	for url, pr := range all {
+		e := prEntry{
+			PRURL:         url,
+			TicketID:      pr.TicketID,
+			Iterations:    pr.Iterations,
+			MaxIterations: maxIter,
+			Capped:        maxIter > 0 && pr.Iterations >= maxIter,
+			LastCISHA:     pr.LastCISHA,
+			LastReasoning: pr.LastReasoning,
+		}
+		if pr.TicketID != "" {
+			e.LinearURL = linearURL(pr.TicketID)
+		}
+		entries = append(entries, e)
+	}
+	writeJSON(w, entries)
+}
+
+type sweepEntry struct {
+	Repo            string  `json:"repo"`
+	Task            string  `json:"task"`
+	Description     string  `json:"description"`
+	CooldownH       float64 `json:"cooldown_h"`
+	LastRunAt       string  `json:"last_run_at,omitempty"`
+	CooldownLeftH   float64 `json:"cooldown_left_h"`
+	Eligible        bool    `json:"eligible"`
+}
+
+func (s *Server) handleSweeps(w http.ResponseWriter, _ *http.Request, store *state.Store, tasks []sweep.Task) {
+	if store == nil || len(tasks) == 0 {
+		writeJSON(w, []sweepEntry{})
+		return
+	}
+	sweepStates := store.AllSweepStates()
+	now := time.Now()
+	var entries []sweepEntry
+	for key, ss := range sweepStates {
+		parts := strings.SplitN(key, "/", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		repoSlug, taskName := parts[0], parts[1]
+		var task *sweep.Task
+		for i := range tasks {
+			if tasks[i].Name == taskName {
+				task = &tasks[i]
+				break
+			}
+		}
+		desc := ""
+		cooldown := time.Duration(0)
+		if task != nil {
+			desc = task.Description
+			cooldown = task.Cooldown
+		}
+		cooldownLeft := time.Duration(0)
+		eligible := true
+		if !ss.LastRunAt.IsZero() && cooldown > 0 {
+			nextEligible := ss.LastRunAt.Add(cooldown)
+			if now.Before(nextEligible) {
+				cooldownLeft = nextEligible.Sub(now)
+				eligible = false
+			}
+		}
+		e := sweepEntry{
+			Repo:          repoSlug,
+			Task:          taskName,
+			Description:   desc,
+			CooldownH:     cooldown.Hours(),
+			CooldownLeftH: cooldownLeft.Hours(),
+			Eligible:      eligible,
+		}
+		if !ss.LastRunAt.IsZero() {
+			e.LastRunAt = ss.LastRunAt.UTC().Format(time.RFC3339)
+		}
+		entries = append(entries, e)
+	}
+	// Also include tasks for repos that haven't run yet (no state).
+	// We only show tasks with recorded state — tasks that have never run
+	// on any repo have no sweep_states row, so they won't appear here.
+	// That's fine: the panel shows "what happened" rather than "what could
+	// happen on every possible repo".
+	writeJSON(w, entries)
+}
+
+type costBucket struct {
+	Date       string  `json:"date"`
+	CostUSD    float64 `json:"cost_usd"`
+	TotalTokens int64  `json:"total_tokens"`
+}
+
+type costResponse struct {
+	Buckets []costBucket `json:"buckets"`
+}
+
+func (s *Server) handleCost(w http.ResponseWriter, r *http.Request, store *state.Store) {
+	if store == nil {
+		writeJSON(w, costResponse{})
+		return
+	}
+	days := 30
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 365 {
+			days = n
+		}
+	}
+	since := time.Now().UTC().AddDate(0, 0, -days).Truncate(24 * time.Hour)
+	events, err := store.ListUsageEvents(since)
+	if err != nil {
+		slog.Warn("dashboard cost query failed", "err", err)
+		writeJSON(w, costResponse{})
+		return
+	}
+
+	bucketMap := map[string]*costBucket{}
+	for _, ev := range events {
+		day := ev.OccurredAt.UTC().Format("2006-01-02")
+		b, ok := bucketMap[day]
+		if !ok {
+			b = &costBucket{Date: day}
+			bucketMap[day] = b
+		}
+		b.CostUSD += ev.CostUSD
+		b.TotalTokens += ev.TotalTokens
+	}
+
+	buckets := make([]costBucket, 0, len(bucketMap))
+	for d := since; !d.After(time.Now().UTC()); d = d.AddDate(0, 0, 1) {
+		day := d.Format("2006-01-02")
+		if b, ok := bucketMap[day]; ok {
+			buckets = append(buckets, *b)
+		} else {
+			buckets = append(buckets, costBucket{Date: day})
+		}
+	}
+	writeJSON(w, costResponse{Buckets: buckets})
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func linearURL(ticketID string) string {
+	parts := strings.SplitN(ticketID, "-", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return "https://linear.app/issue/" + ticketID
 }

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -238,13 +238,13 @@ func (s *Server) handlePRs(w http.ResponseWriter, _ *http.Request, store *state.
 }
 
 type sweepEntry struct {
-	Repo            string  `json:"repo"`
-	Task            string  `json:"task"`
-	Description     string  `json:"description"`
-	CooldownH       float64 `json:"cooldown_h"`
-	LastRunAt       string  `json:"last_run_at,omitempty"`
-	CooldownLeftH   float64 `json:"cooldown_left_h"`
-	Eligible        bool    `json:"eligible"`
+	Repo          string  `json:"repo"`
+	Task          string  `json:"task"`
+	Description   string  `json:"description"`
+	CooldownH     float64 `json:"cooldown_h"`
+	LastRunAt     string  `json:"last_run_at,omitempty"`
+	CooldownLeftH float64 `json:"cooldown_left_h"`
+	Eligible      bool    `json:"eligible"`
 }
 
 func (s *Server) handleSweeps(w http.ResponseWriter, _ *http.Request, store *state.Store, tasks []sweep.Task) {
@@ -296,18 +296,13 @@ func (s *Server) handleSweeps(w http.ResponseWriter, _ *http.Request, store *sta
 		}
 		entries = append(entries, e)
 	}
-	// Also include tasks for repos that haven't run yet (no state).
-	// We only show tasks with recorded state — tasks that have never run
-	// on any repo have no sweep_states row, so they won't appear here.
-	// That's fine: the panel shows "what happened" rather than "what could
-	// happen on every possible repo".
 	writeJSON(w, entries)
 }
 
 type costBucket struct {
-	Date       string  `json:"date"`
-	CostUSD    float64 `json:"cost_usd"`
-	TotalTokens int64  `json:"total_tokens"`
+	Date        string  `json:"date"`
+	CostUSD     float64 `json:"cost_usd"`
+	TotalTokens int64   `json:"total_tokens"`
 }
 
 type costResponse struct {

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -4,7 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/state"
+	"github.com/ahmadAlMezaal/noctra/internal/sweep"
 )
 
 type testSnapshot struct {
@@ -15,7 +20,7 @@ type testSnapshot struct {
 func newTestServer(token string) *Server {
 	return New(":0", token, func() any {
 		return testSnapshot{Active: []string{"ENG-1"}, OK: true}
-	})
+	}, Providers{})
 }
 
 func TestAuth_BearerToken(t *testing.T) {
@@ -128,5 +133,252 @@ func TestSnapshot_MethodNotAllowed(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+// ── History endpoint tests (ENG-277) ────────────────────────────────────────
+
+func newTestServerWithStore(t *testing.T, token string) (*Server, *state.Store) {
+	t.Helper()
+	store, err := state.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(":0", token, func() any { return nil }, Providers{
+		Store:           store,
+		MaxPRIterations: 3,
+		SweepTasks: []sweep.Task{
+			{Name: "lint-cleanup", Description: "Fix lint warnings", Cooldown: 7 * 24 * time.Hour},
+		},
+	})
+	return srv, store
+}
+
+func authedGet(t *testing.T, ts *httptest.Server, path, token string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("GET", ts.URL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestHistory_ReturnsRuns(t *testing.T) {
+	srv, store := newTestServerWithStore(t, "tok")
+	defer store.Close()
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := store.InsertRunHistory(state.RunHistory{
+		Identifier: "ENG-1", TicketID: "ENG-1", Repo: "my-repo",
+		RunType: "ticket", Status: "pr_opened",
+		PRURL:    "https://github.com/o/r/pull/1",
+		StartedAt: now.Add(-5 * time.Minute), FinishedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := authedGet(t, ts, "/api/history?limit=10", "tok")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var entries []historyEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Identifier != "ENG-1" {
+		t.Errorf("identifier: got %q", entries[0].Identifier)
+	}
+	if entries[0].PRURL != "https://github.com/o/r/pull/1" {
+		t.Errorf("pr_url: got %q", entries[0].PRURL)
+	}
+	if entries[0].DurationS < 299 || entries[0].DurationS > 301 {
+		t.Errorf("duration_s: got %f, want ~300", entries[0].DurationS)
+	}
+	if entries[0].LinearURL == "" {
+		t.Error("expected linear_url to be set")
+	}
+}
+
+func TestHistory_NilStore(t *testing.T) {
+	srv := New(":0", "tok", func() any { return nil }, Providers{})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp := authedGet(t, ts, "/api/history", "tok")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var entries []historyEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected empty, got %d", len(entries))
+	}
+}
+
+func TestPRs_ReturnsTrackedPRs(t *testing.T) {
+	srv, store := newTestServerWithStore(t, "tok")
+	defer store.Close()
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	prURL := "https://github.com/o/r/pull/5"
+	if err := store.Update(prURL, func(r *state.PRState) {
+		r.TicketID = "ENG-5"
+		r.Iterations = 2
+		r.LastCISHA = "abc1234"
+		r.LastReasoning = "Fixed the bug"
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := authedGet(t, ts, "/api/prs", "tok")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var entries []prEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].PRURL != prURL {
+		t.Errorf("pr_url: got %q", entries[0].PRURL)
+	}
+	if entries[0].Iterations != 2 {
+		t.Errorf("iterations: got %d", entries[0].Iterations)
+	}
+	if entries[0].MaxIterations != 3 {
+		t.Errorf("max_iterations: got %d", entries[0].MaxIterations)
+	}
+	if entries[0].Capped {
+		t.Error("expected not capped")
+	}
+	if entries[0].LastReasoning != "Fixed the bug" {
+		t.Errorf("last_reasoning: got %q", entries[0].LastReasoning)
+	}
+}
+
+func TestSweeps_ReturnsSweepState(t *testing.T) {
+	srv, store := newTestServerWithStore(t, "tok")
+	defer store.Close()
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := store.UpdateSweep("my-repo/lint-cleanup", func(ss *state.SweepState) {
+		ss.LastRunAt = now
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := authedGet(t, ts, "/api/sweeps", "tok")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var entries []sweepEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Repo != "my-repo" {
+		t.Errorf("repo: got %q", entries[0].Repo)
+	}
+	if entries[0].Task != "lint-cleanup" {
+		t.Errorf("task: got %q", entries[0].Task)
+	}
+	if entries[0].Eligible {
+		t.Error("expected not eligible (just ran)")
+	}
+}
+
+func TestCost_ReturnsBuckets(t *testing.T) {
+	srv, store := newTestServerWithStore(t, "tok")
+	defer store.Close()
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	now := time.Now().UTC()
+	if err := store.RecordUsage(state.UsageEvent{
+		OccurredAt: now, Source: "ticket", CostUSD: 0.50, TotalTokens: 10000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := authedGet(t, ts, "/api/cost?days=7", "tok")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var cr costResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatal(err)
+	}
+	if len(cr.Buckets) == 0 {
+		t.Fatal("expected non-empty buckets")
+	}
+	// At least one bucket should have cost > 0
+	found := false
+	for _, b := range cr.Buckets {
+		if b.CostUSD > 0 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one bucket with cost > 0")
+	}
+}
+
+func TestHistory_MethodNotAllowed(t *testing.T) {
+	srv, store := newTestServerWithStore(t, "tok")
+	defer store.Close()
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/history", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestLinearURL(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"ENG-42", "https://linear.app/issue/ENG-42"},
+		{"PROJ-1", "https://linear.app/issue/PROJ-1"},
+		{"nohyphen", ""},
+	}
+	for _, tc := range tests {
+		got := linearURL(tc.in)
+		if got != tc.want {
+			t.Errorf("linearURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -167,7 +167,7 @@ func authedGet(t *testing.T, ts *httptest.Server, path, token string) *http.Resp
 
 func TestHistory_ReturnsRuns(t *testing.T) {
 	srv, store := newTestServerWithStore(t, "tok")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -175,7 +175,7 @@ func TestHistory_ReturnsRuns(t *testing.T) {
 	if err := store.InsertRunHistory(state.RunHistory{
 		Identifier: "ENG-1", TicketID: "ENG-1", Repo: "my-repo",
 		RunType: "ticket", Status: "pr_opened",
-		PRURL:    "https://github.com/o/r/pull/1",
+		PRURL:     "https://github.com/o/r/pull/1",
 		StartedAt: now.Add(-5 * time.Minute), FinishedAt: now,
 	}); err != nil {
 		t.Fatal(err)
@@ -229,7 +229,7 @@ func TestHistory_NilStore(t *testing.T) {
 
 func TestPRs_ReturnsTrackedPRs(t *testing.T) {
 	srv, store := newTestServerWithStore(t, "tok")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -275,7 +275,7 @@ func TestPRs_ReturnsTrackedPRs(t *testing.T) {
 
 func TestSweeps_ReturnsSweepState(t *testing.T) {
 	srv, store := newTestServerWithStore(t, "tok")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -312,7 +312,7 @@ func TestSweeps_ReturnsSweepState(t *testing.T) {
 
 func TestCost_ReturnsBuckets(t *testing.T) {
 	srv, store := newTestServerWithStore(t, "tok")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -351,7 +351,7 @@ func TestCost_ReturnsBuckets(t *testing.T) {
 
 func TestHistory_MethodNotAllowed(t *testing.T) {
 	srv, store := newTestServerWithStore(t, "tok")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -7,15 +7,19 @@
 <style>
   :root { --bg: #0d1117; --card: #161b22; --border: #30363d; --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff; --green: #3fb950; --red: #f85149; --yellow: #d29922; }
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); padding: 1.5rem; max-width: 64rem; margin: 0 auto; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); padding: 1.5rem; max-width: 80rem; margin: 0 auto; }
   h1 { font-size: 1.5rem; margin-bottom: 1rem; }
   h2 { font-size: 1.1rem; color: var(--muted); margin-bottom: 0.5rem; font-weight: 500; }
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: 1rem; }
+  h3 { font-size: 0.95rem; color: var(--accent); margin: 0.75rem 0 0.25rem; font-weight: 500; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: 1rem; margin-bottom: 1rem; }
+  .wide { grid-column: 1 / -1; }
   .card { background: var(--card); border: 1px solid var(--border); border-radius: 0.5rem; padding: 1rem; }
   .badge { display: inline-block; font-size: 0.75rem; padding: 0.15rem 0.5rem; border-radius: 1rem; font-weight: 600; }
   .badge-green { background: rgba(63,185,80,0.15); color: var(--green); }
   .badge-red { background: rgba(248,81,73,0.15); color: var(--red); }
   .badge-yellow { background: rgba(210,153,34,0.15); color: var(--yellow); }
+  .badge-blue { background: rgba(88,166,255,0.15); color: var(--accent); }
+  .badge-muted { background: rgba(139,148,158,0.15); color: var(--muted); }
   ul { list-style: none; }
   li { padding: 0.25rem 0; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.875rem; }
   .empty { color: var(--muted); font-style: italic; font-size: 0.875rem; }
@@ -23,11 +27,26 @@
   .stat-row { display: flex; justify-content: space-between; padding: 0.25rem 0; font-size: 0.875rem; }
   .stat-label { color: var(--muted); }
   #error { display: none; background: rgba(248,81,73,0.15); color: var(--red); border: 1px solid var(--red); border-radius: 0.5rem; padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 0.875rem; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.8125rem; }
+  th { text-align: left; color: var(--muted); font-weight: 500; padding: 0.4rem 0.5rem; border-bottom: 1px solid var(--border); }
+  td { padding: 0.4rem 0.5rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .mono { font-family: "SFMono-Regular", Consolas, monospace; }
+  .truncate { max-width: 18rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .sparkline-wrap { display: flex; align-items: flex-end; gap: 0.5rem; margin-top: 0.5rem; }
+  .tab-bar { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; }
+  .tab { padding: 0.25rem 0.75rem; border-radius: 0.25rem; font-size: 0.8125rem; cursor: pointer; background: transparent; color: var(--muted); border: 1px solid var(--border); }
+  .tab.active { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+  .repo-group { margin-bottom: 0.5rem; }
 </style>
 </head>
 <body>
 <h1>Noctra Dashboard</h1>
 <div id="error"></div>
+
+<!-- Row 1: Live snapshot cards -->
 <div class="grid">
   <div class="card">
     <h2>Active Runs</h2>
@@ -46,10 +65,41 @@
     <div id="budget"></div>
   </div>
 </div>
+
+<!-- Row 2: Cost sparkline -->
+<div class="grid">
+  <div class="card wide">
+    <h2>Cost (last 30 days)</h2>
+    <div id="cost-panel"></div>
+  </div>
+</div>
+
+<!-- Row 3: Run history -->
+<div class="grid">
+  <div class="card wide">
+    <h2>Run History</h2>
+    <div class="tab-bar" id="history-tabs"></div>
+    <div id="history-panel"></div>
+  </div>
+</div>
+
+<!-- Row 4: PR iterate + Sweep -->
+<div class="grid">
+  <div class="card">
+    <h2>PR Auto-Iterate</h2>
+    <div id="pr-panel"></div>
+  </div>
+  <div class="card">
+    <h2>Sweep Tasks</h2>
+    <div id="sweep-panel"></div>
+  </div>
+</div>
+
 <script>
 (function() {
   var params = new URLSearchParams(window.location.search);
   var token = params.get("token") || "";
+  var headers = { "Authorization": "Bearer " + token };
 
   function formatTokens(n) {
     if (n >= 1000000) return (n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1) + "M";
@@ -62,6 +112,47 @@
     d.textContent = s;
     return d.innerHTML;
   }
+
+  function formatDuration(secs) {
+    if (secs <= 0) return "-";
+    if (secs < 60) return Math.round(secs) + "s";
+    var m = Math.floor(secs / 60);
+    var s = Math.round(secs % 60);
+    if (m < 60) return m + "m " + s + "s";
+    var h = Math.floor(m / 60);
+    m = m % 60;
+    return h + "h " + m + "m";
+  }
+
+  function statusBadge(status) {
+    var cls = "badge-muted";
+    if (status === "pr_opened") cls = "badge-green";
+    else if (status === "failed") cls = "badge-red";
+    else if (status === "blocked") cls = "badge-yellow";
+    else if (status === "no_change") cls = "badge-muted";
+    return '<span class="badge ' + cls + '">' + esc(status) + "</span>";
+  }
+
+  function typeBadge(runType) {
+    var cls = "badge-blue";
+    if (runType === "sweep") cls = "badge-muted";
+    else if (runType === "iterate") cls = "badge-yellow";
+    return '<span class="badge ' + cls + '">' + esc(runType) + "</span>";
+  }
+
+  function link(url, text) {
+    if (!url) return esc(text || "-");
+    return '<a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(text || url) + "</a>";
+  }
+
+  function shortTime(iso) {
+    if (!iso) return "-";
+    var d = new Date(iso);
+    return d.toLocaleDateString(undefined, {month:"short",day:"numeric"}) + " " +
+           d.toLocaleTimeString(undefined, {hour:"2-digit",minute:"2-digit"});
+  }
+
+  // ── Snapshot (live state) ───────────────────────────────────────────────
 
   function renderList(el, items, emptyMsg) {
     if (!items || items.length === 0) {
@@ -102,27 +193,194 @@
     if (b.Paused && b.PauseReason) {
       rows += '<div class="stat-row"><span class="stat-label">Pause reason</span><span>' + esc(b.PauseReason) + "</span></div>";
     }
+    if (b.PausedUntil && b.PausedUntil !== "0001-01-01T00:00:00Z") {
+      var until = new Date(b.PausedUntil);
+      if (until > new Date()) {
+        rows += '<div class="stat-row"><span class="stat-label">Resumes</span><span>' + shortTime(b.PausedUntil) + "</span></div>";
+      }
+    }
     el.innerHTML = rows;
+  }
+
+  // ── Cost sparkline ──────────────────────────────────────────────────────
+
+  function renderSparkline(values, width, height) {
+    if (!values || values.length === 0) return "";
+    var max = Math.max.apply(null, values);
+    if (max === 0) max = 1;
+    var step = width / Math.max(values.length - 1, 1);
+    var points = values.map(function(v, i) {
+      var x = (i * step).toFixed(1);
+      var y = (height - (v / max) * (height - 4) - 2).toFixed(1);
+      return x + "," + y;
+    });
+    return '<svg width="' + width + '" height="' + height + '" viewBox="0 0 ' + width + " " + height + '">' +
+      '<polyline fill="none" stroke="' + "var(--accent)" + '" stroke-width="1.5" points="' + points.join(" ") + '"/>' +
+      "</svg>";
+  }
+
+  function renderCost(el, data) {
+    if (!data || !data.buckets || data.buckets.length === 0) {
+      el.innerHTML = '<span class="empty">No usage data</span>';
+      return;
+    }
+    var buckets = data.buckets;
+    var totalCost = 0, totalTokens = 0, todayCost = 0, todayTokens = 0;
+    var today = new Date().toISOString().slice(0, 10);
+    var costs = [];
+    for (var i = 0; i < buckets.length; i++) {
+      totalCost += buckets[i].cost_usd;
+      totalTokens += buckets[i].total_tokens;
+      costs.push(buckets[i].cost_usd);
+      if (buckets[i].date === today) {
+        todayCost = buckets[i].cost_usd;
+        todayTokens = buckets[i].total_tokens;
+      }
+    }
+    var html = '<div class="stat-row"><span class="stat-label">Today</span><span>$' + todayCost.toFixed(2) + " / " + formatTokens(todayTokens) + " tokens</span></div>";
+    html += '<div class="stat-row"><span class="stat-label">30-day total</span><span>$' + totalCost.toFixed(2) + " / " + formatTokens(totalTokens) + " tokens</span></div>";
+    html += '<div class="sparkline-wrap">' + renderSparkline(costs, 500, 40) + "</div>";
+    el.innerHTML = html;
+  }
+
+  // ── Run history (grouped by repo with tab switching) ────────────────────
+
+  var historyData = [];
+
+  function renderHistory(el, tabsEl, data) {
+    historyData = data || [];
+    if (historyData.length === 0) {
+      tabsEl.innerHTML = "";
+      el.innerHTML = '<span class="empty">No run history</span>';
+      return;
+    }
+    // Group by repo
+    var repos = {};
+    var repoOrder = [];
+    for (var i = 0; i < historyData.length; i++) {
+      var r = historyData[i].repo || "(unknown)";
+      if (!repos[r]) { repos[r] = []; repoOrder.push(r); }
+      repos[r].push(historyData[i]);
+    }
+
+    // Tabs
+    var tabHtml = '<span class="tab active" data-repo="__all__">All</span>';
+    for (var j = 0; j < repoOrder.length; j++) {
+      tabHtml += '<span class="tab" data-repo="' + esc(repoOrder[j]) + '">' + esc(repoOrder[j]) + "</span>";
+    }
+    tabsEl.innerHTML = tabHtml;
+
+    // Tab click
+    tabsEl.querySelectorAll(".tab").forEach(function(tab) {
+      tab.addEventListener("click", function() {
+        tabsEl.querySelectorAll(".tab").forEach(function(t) { t.classList.remove("active"); });
+        tab.classList.add("active");
+        var repo = tab.getAttribute("data-repo");
+        renderHistoryTable(el, repo === "__all__" ? historyData : repos[repo] || []);
+      });
+    });
+
+    renderHistoryTable(el, historyData);
+  }
+
+  function renderHistoryTable(el, runs) {
+    if (runs.length === 0) {
+      el.innerHTML = '<span class="empty">No runs</span>';
+      return;
+    }
+    var html = "<table><thead><tr><th>Identifier</th><th>Repo</th><th>Type</th><th>Status</th><th>Duration</th><th>PR</th><th>Started</th></tr></thead><tbody>";
+    for (var i = 0; i < runs.length; i++) {
+      var r = runs[i];
+      var idCell = r.linear_url ? link(r.linear_url, r.identifier) : esc(r.identifier);
+      var prCell = r.pr_url ? link(r.pr_url, "PR") : "-";
+      html += "<tr><td class='mono'>" + idCell + "</td><td>" + esc(r.repo || "-") + "</td><td>" + typeBadge(r.run_type) + "</td><td>" + statusBadge(r.status) + "</td><td class='mono'>" + formatDuration(r.duration_s) + "</td><td>" + prCell + "</td><td>" + shortTime(r.started_at) + "</td></tr>";
+    }
+    html += "</tbody></table>";
+    el.innerHTML = html;
+  }
+
+  // ── PR auto-iterate panel ───────────────────────────────────────────────
+
+  function renderPRs(el, data) {
+    if (!data || data.length === 0) {
+      el.innerHTML = '<span class="empty">No tracked PRs</span>';
+      return;
+    }
+    var html = "<table><thead><tr><th>PR</th><th>Ticket</th><th>Iterations</th><th>CI SHA</th><th>Reasoning</th></tr></thead><tbody>";
+    for (var i = 0; i < data.length; i++) {
+      var p = data[i];
+      var prLink = p.pr_url ? link(p.pr_url, p.pr_url.replace(/.*\/pull\//, "#")) : "-";
+      var ticketLink = p.linear_url ? link(p.linear_url, p.ticket_id) : esc(p.ticket_id || "-");
+      var iterText = p.iterations + " / " + p.max_iterations;
+      var iterBadge = p.capped ? '<span class="badge badge-red">capped</span>' : '<span class="badge badge-green">' + esc(iterText) + "</span>";
+      var sha = p.last_ci_sha ? esc(p.last_ci_sha.substring(0, 7)) : "-";
+      var reason = p.last_reasoning ? '<span class="truncate" title="' + esc(p.last_reasoning) + '">' + esc(p.last_reasoning.substring(0, 80)) + "</span>" : "-";
+      html += "<tr><td>" + prLink + "</td><td class='mono'>" + ticketLink + "</td><td>" + iterBadge + "</td><td class='mono'>" + sha + "</td><td>" + reason + "</td></tr>";
+    }
+    html += "</tbody></table>";
+    el.innerHTML = html;
+  }
+
+  // ── Sweep panel ─────────────────────────────────────────────────────────
+
+  function renderSweeps(el, data) {
+    if (!data || data.length === 0) {
+      el.innerHTML = '<span class="empty">No sweep data</span>';
+      return;
+    }
+    var html = "<table><thead><tr><th>Repo</th><th>Task</th><th>Status</th><th>Last run</th></tr></thead><tbody>";
+    for (var i = 0; i < data.length; i++) {
+      var s = data[i];
+      var statusBdg;
+      if (s.eligible) {
+        statusBdg = '<span class="badge badge-green">eligible</span>';
+      } else {
+        var left = s.cooldown_left_h;
+        var leftStr = left < 1 ? Math.round(left * 60) + "m" : Math.round(left) + "h";
+        statusBdg = '<span class="badge badge-yellow">' + leftStr + " left</span>";
+      }
+      html += "<tr><td>" + esc(s.repo) + "</td><td>" + esc(s.task) + "</td><td>" + statusBdg + "</td><td>" + shortTime(s.last_run_at) + "</td></tr>";
+    }
+    html += "</tbody></table>";
+    el.innerHTML = html;
+  }
+
+  // ── Load data ───────────────────────────────────────────────────────────
+
+  function fetchJSON(url) {
+    return fetch(url, { headers: headers }).then(function(r) {
+      if (!r.ok) throw new Error("HTTP " + r.status);
+      return r.json();
+    });
   }
 
   function load() {
     var errEl = document.getElementById("error");
-    fetch("/api/snapshot", { headers: { "Authorization": "Bearer " + token } })
-      .then(function(r) {
-        if (!r.ok) throw new Error("HTTP " + r.status);
-        return r.json();
-      })
-      .then(function(d) {
-        errEl.style.display = "none";
-        renderList(document.getElementById("active"), d.active, "No active runs");
-        renderQueued(document.getElementById("queued"), d.queued);
-        renderList(document.getElementById("skipped"), d.skipped, "No skipped tickets");
-        renderBudget(document.getElementById("budget"), d.budget, d.paused);
-      })
-      .catch(function(e) {
-        errEl.textContent = "Failed to load snapshot: " + e.message;
-        errEl.style.display = "block";
-      });
+
+    // Fetch all endpoints in parallel
+    Promise.all([
+      fetchJSON("/api/snapshot"),
+      fetchJSON("/api/history?limit=100"),
+      fetchJSON("/api/prs"),
+      fetchJSON("/api/sweeps"),
+      fetchJSON("/api/cost?days=30")
+    ]).then(function(results) {
+      errEl.style.display = "none";
+      var snap = results[0], history = results[1], prs = results[2], sweeps = results[3], cost = results[4];
+
+      renderList(document.getElementById("active"), snap.active, "No active runs");
+      renderQueued(document.getElementById("queued"), snap.queued);
+      renderList(document.getElementById("skipped"), snap.skipped, "No skipped tickets");
+      renderBudget(document.getElementById("budget"), snap.budget, snap.paused);
+
+      renderCost(document.getElementById("cost-panel"), cost);
+      renderHistory(document.getElementById("history-panel"), document.getElementById("history-tabs"), history);
+      renderPRs(document.getElementById("pr-panel"), prs);
+      renderSweeps(document.getElementById("sweep-panel"), sweeps);
+    }).catch(function(e) {
+      errEl.textContent = "Failed to load dashboard: " + e.message;
+      errEl.style.display = "block";
+    });
   }
 
   load();

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -100,9 +100,9 @@ func New(cfg *config.Config) *Pipeline {
 	}
 
 	// Open the state store up front if any feature needs it: auto-iterate,
-	// sweep, plan-confirm, or actor=app OAuth refresh persistence.
+	// sweep, plan-confirm, actor=app OAuth refresh persistence, or dashboard.
 	var store *state.Store
-	if cfg.AutoIteratePRs || cfg.SweepEnabled || cfg.PlanConfirm || cfg.PlanConfirmLabel != "" || cfg.ActorAppConfigured() {
+	if cfg.AutoIteratePRs || cfg.SweepEnabled || cfg.PlanConfirm || cfg.PlanConfirmLabel != "" || cfg.ActorAppConfigured() || cfg.DashboardAddr != "" {
 		s, err := state.OpenMigrating(cfg.StateDB, cfg.StateFile)
 		if err != nil {
 			slog.Warn("state store open failed", "path", cfg.StateDB, "legacy_path", cfg.StateFile, "err", err)
@@ -179,9 +179,17 @@ func New(cfg *config.Config) *Pipeline {
 	// ListenAndServe is deferred to Run (which validates the token).
 	if cfg.DashboardAddr != "" {
 		addr := normalizeDashboardAddr(cfg.DashboardAddr)
+		prov := dashboard.Providers{
+			Store:           store,
+			MaxPRIterations: cfg.MaxPRIterations,
+			RepoPaths:       p.resolver.AllRepoPaths,
+		}
+		if p.sweeper != nil {
+			prov.SweepTasks = sweep.FilterTasks(cfg.SweepTasks)
+		}
 		p.dash = dashboard.New(addr, cfg.DashboardToken, func() any {
 			return p.Snapshot()
-		})
+		}, prov)
 	}
 
 	return p

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -697,6 +697,92 @@ func (s *Store) ListRunHistory(limit int) ([]RunHistory, error) {
 	return out, nil
 }
 
+// ListUsageEvents returns usage events that occurred at or after since,
+// ordered by occurred_at ascending. When since is zero, all events are
+// returned.
+func (s *Store) ListUsageEvents(since time.Time) ([]UsageEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var rows *sql.Rows
+	var err error
+	if since.IsZero() {
+		rows, err = s.db.Query(`SELECT occurred_at, source, ticket_id, pr_url, agent_backend,
+			input_tokens, output_tokens, total_tokens, cost_usd
+			FROM usage_events ORDER BY occurred_at ASC`)
+	} else {
+		rows, err = s.db.Query(`SELECT occurred_at, source, ticket_id, pr_url, agent_backend,
+			input_tokens, output_tokens, total_tokens, cost_usd
+			FROM usage_events WHERE occurred_at >= ? ORDER BY occurred_at ASC`,
+			formatTime(since).String)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list usage events: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("close usage_events rows failed", "err", err)
+		}
+	}()
+
+	var out []UsageEvent
+	for rows.Next() {
+		var ev UsageEvent
+		var occurredAt sql.NullString
+		if err := rows.Scan(
+			&occurredAt, &ev.Source, &ev.TicketID, &ev.PRURL, &ev.AgentBackend,
+			&ev.InputTokens, &ev.OutputTokens, &ev.TotalTokens, &ev.CostUSD,
+		); err != nil {
+			return nil, fmt.Errorf("scan usage event: %w", err)
+		}
+		if t, convErr := parseNullTime(occurredAt); convErr == nil {
+			ev.OccurredAt = t
+		}
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate usage events: %w", err)
+	}
+	return out, nil
+}
+
+// AllSweepStates returns every sweep state record keyed by
+// "<repo-slug>/<task-name>".
+func (s *Store) AllSweepStates() map[string]SweepState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rows, err := s.db.Query(`SELECT key, last_run_at FROM sweep_states`)
+	if err != nil {
+		slog.Warn("state all sweep states failed", "err", err)
+		return nil
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Warn("close sweep_states rows failed", "err", err)
+		}
+	}()
+	out := map[string]SweepState{}
+	for rows.Next() {
+		var key string
+		var lastRun sql.NullString
+		if err := rows.Scan(&key, &lastRun); err != nil {
+			slog.Warn("scan sweep state failed", "err", err)
+			return nil
+		}
+		lastRunAt, convErr := parseNullTime(lastRun)
+		if convErr != nil {
+			slog.Warn("parse sweep last_run_at failed", "key", key, "err", convErr)
+			continue
+		}
+		out[key] = SweepState{LastRunAt: lastRunAt}
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("iterate sweep states failed", "err", err)
+		return nil
+	}
+	return out
+}
+
 // RecordUsage persists a usage-event row. Best-effort: a failed insert is
 // logged and never blocks the run.
 func (s *Store) RecordUsage(ev UsageEvent) error {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -697,9 +697,7 @@ func (s *Store) ListRunHistory(limit int) ([]RunHistory, error) {
 	return out, nil
 }
 
-// ListUsageEvents returns usage events that occurred at or after since,
-// ordered by occurred_at ascending. When since is zero, all events are
-// returned.
+// ListUsageEvents returns usage events at or after since (all if zero).
 func (s *Store) ListUsageEvents(since time.Time) ([]UsageEvent, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -758,6 +758,113 @@ func TestInsertRunHistory_SurvivesReopen(t *testing.T) {
 	}
 }
 
+// ── ListUsageEvents tests (ENG-277) ─────────────────────────────────────────
+
+func TestListUsageEvents(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	events := []UsageEvent{
+		{OccurredAt: now.Add(-2 * time.Hour), Source: "ticket", TicketID: "ENG-1", CostUSD: 0.10, TotalTokens: 5000},
+		{OccurredAt: now.Add(-1 * time.Hour), Source: "iterate", TicketID: "ENG-1", CostUSD: 0.05, TotalTokens: 2500},
+		{OccurredAt: now, Source: "sweep", TicketID: "", CostUSD: 0.03, TotalTokens: 1500},
+	}
+	for _, ev := range events {
+		if err := s.RecordUsage(ev); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := s.ListUsageEvents(time.Time{})
+	if err != nil {
+		t.Fatalf("ListUsageEvents(zero): %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("all: got %d, want 3", len(got))
+	}
+	if got[0].Source != "ticket" || got[2].Source != "sweep" {
+		t.Errorf("order: got %s..%s, want ticket..sweep", got[0].Source, got[2].Source)
+	}
+
+	got2, err := s.ListUsageEvents(now.Add(-90 * time.Minute))
+	if err != nil {
+		t.Fatalf("ListUsageEvents(since): %v", err)
+	}
+	if len(got2) != 2 {
+		t.Fatalf("since: got %d, want 2", len(got2))
+	}
+	if got2[0].Source != "iterate" {
+		t.Errorf("since first: got %q, want iterate", got2[0].Source)
+	}
+}
+
+func TestListUsageEvents_Empty(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	got, err := s.ListUsageEvents(time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %d", len(got))
+	}
+}
+
+// ── AllSweepStates tests (ENG-277) ──────────────────────────────────────────
+
+func TestAllSweepStates(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := s.UpdateSweep("repo-a/lint-cleanup", func(ss *SweepState) {
+		ss.LastRunAt = now
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateSweep("repo-b/dead-code", func(ss *SweepState) {
+		ss.LastRunAt = now.Add(-24 * time.Hour)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := s.AllSweepStates()
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+	if !got["repo-a/lint-cleanup"].LastRunAt.Equal(now) {
+		t.Errorf("repo-a/lint-cleanup: got %v, want %v", got["repo-a/lint-cleanup"].LastRunAt, now)
+	}
+	if !got["repo-b/dead-code"].LastRunAt.Equal(now.Add(-24 * time.Hour)) {
+		t.Errorf("repo-b/dead-code: got %v", got["repo-b/dead-code"].LastRunAt)
+	}
+}
+
+func TestAllSweepStates_Empty(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(t, s)
+
+	got := s.AllSweepStates()
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %d", len(got))
+	}
+}
+
 func closeStore(t *testing.T, s *Store) {
 	t.Helper()
 	if err := s.Close(); err != nil {


### PR DESCRIPTION
## ENG-277: Dashboard P4 — depth: run history, sweep + PR-iterate panels, cost sparkline, deep links

**Ticket:** https://linear.app/amazz/issue/ENG-277/dashboard-p4-depth-run-history-sweep-pr-iterate-panels-cost-sparkline

## What was implemented

Implemented ENG-277: Dashboard P4 — depth: run history, sweep + PR-iterate panels, cost sparkline, deep links.

**Backend changes:**

- `internal/state/state.go`: Added two new Store readers:
  - `ListUsageEvents(since time.Time)` — returns usage events at or after `since`, ordered chronologically. Enables the cost sparkline panel.
  - `AllSweepStates()` — returns all sweep state records keyed by `repo-slug/task-name`. Enables the sweep panel.

- `internal/dashboard/dashboard.go`: Extended `New()` to accept a `Providers` struct alongside the existing `SnapshotFunc`. Added four new API endpoints:
  - `GET /api/history?limit=N` — returns recent runs from `run_history` (newest first, bounded by `limit`, default 50, max 500). Each entry includes identifier, repo, run_type, status, duration, PR URL, and a deep link to Linear.
  - `GET /api/prs` — returns all tracked PR states with iteration count, max iterations, capped status, last CI SHA, and last reasoning. Includes deep links to both the GitHub PR and Linear ticket.
  - `GET /api/sweeps` — returns per-repo/per-task sweep state with cooldown status (eligible vs cooling down with time remaining), sourced from `AllSweepStates()` cross-referenced with the task catalog.
  - `GET /api/cost?days=N` — aggregates `usage_events` into daily buckets (cost + tokens per day) over the last N days (default 30).

- `internal/pipeline/pipeline.go`: Wired the new `Providers` struct into dashboard construction, passing the Store, sweep tasks, MaxPRIterations, and repo paths. Also extended the Store-opening condition to include `cfg.DashboardAddr != ""` so the dashboard can read history/usage even when auto-iterate/sweep aren't enabled.

**Frontend changes:**

- `internal/dashboard/static/index.html`: Expanded the single-page dashboard with:
  - **Cost sparkline panel**: hand-drawn SVG polyline showing daily spend over 30 days, with today/30-day totals and token counts. Also shows the pause countdown from budget stats.
  - **Run history timeline**: table with identifier, repo, type badge, status badge, duration, PR link, and started timestamp. Grouped by repo via clickable tabs (All / per-repo).
  - **PR auto-iterate panel**: table showing each tracked PR with iteration count/cap, capped badge, last CI SHA, and last reasoning (truncated with tooltip).
  - **Sweep panel**: table showing repo/task/status (eligible or cooldown remaining)/last run time.
  - **Deep links**: ticket identifiers link to Linear (`https://linear.app/issue/<ID>`), PR columns link to GitHub PR URLs.

**Tests added:**

- `internal/state/state_test.go`: 4 new tests covering `ListUsageEvents` (with/without `since` filter, empty case) and `AllSweepStates` (populated/empty).
- `internal/dashboard/dashboard_test.go`: 7 new tests covering all four API endpoints (history with data, history with nil store, PRs, sweeps, cost buckets, method-not-allowed, and the `linearURL` helper).

All 22 packages pass. `go vet` clean.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*
<!-- noctra-authored -->