### PR TITLE
fix: stop truncated Gemini reviews from posting as Skipped + raw JSON

### DIFF
--- a/internal/review/gemini.go
+++ b/internal/review/gemini.go
@@ -186,7 +186,7 @@ func reviewSchema() map[string]any {
 }
 
 func (g *Gate) reviewAPI(ctx context.Context, prompt string, structured bool) (Result, error) {
-	gen := map[string]any{"temperature": 0.1, "maxOutputTokens": 4096}
+	gen := map[string]any{"temperature": 0.1, "maxOutputTokens": 8192}
 	if structured {
 		gen["responseMimeType"] = "application/json"
 		gen["responseSchema"] = reviewSchema()
@@ -259,14 +259,33 @@ func (g *Gate) reviewAPI(ctx context.Context, prompt string, structured bool) (R
 	return parseResult(text), nil
 }
 
+var salvageVerdictRe = regexp.MustCompile(`(?i)"verdict"\s*:\s*"\s*(PASS|FAIL)\s*"`)
+var salvageSummaryRe = regexp.MustCompile(`"summary"\s*:\s*("(?:\\.|[^"\\])*")`)
+
+func salvageStructured(text string) (verdict, summary string, ok bool) {
+	m := salvageVerdictRe.FindStringSubmatch(text)
+	if m == nil {
+		return "", "", false
+	}
+	if sm := salvageSummaryRe.FindStringSubmatch(text); sm != nil {
+		_ = json.Unmarshal([]byte(sm[1]), &summary)
+	}
+	return m[1], summary, true
+}
+
 func parseStructured(text string) (Result, bool) {
+	text = strings.TrimSpace(text)
 	var s struct {
 		Verdict  string    `json:"verdict"`
 		Summary  string    `json:"summary"`
 		Findings []Finding `json:"findings"`
 	}
-	if json.Unmarshal([]byte(strings.TrimSpace(text)), &s) != nil {
-		return Result{}, false
+	if json.Unmarshal([]byte(text), &s) != nil {
+		v, sum, ok := salvageStructured(text)
+		if !ok {
+			return Result{}, false
+		}
+		s.Verdict, s.Summary, s.Findings = v, sum, nil
 	}
 	switch strings.ToUpper(strings.TrimSpace(s.Verdict)) {
 	case "PASS":

--- a/internal/review/gemini_test.go
+++ b/internal/review/gemini_test.go
@@ -186,6 +186,26 @@ func TestParseStructuredRejectsProse(t *testing.T) {
 	}
 }
 
+func TestParseStructuredSalvagesTruncatedJSON(t *testing.T) {
+	truncated := `{"verdict": "FAIL", "summary": "Two requirements not met: \"repo grouping\" and CI deep links.", "findings": [{"path": "internal/dashboard/static/index.html", "comment": "Active Runs is not gr`
+	r, ok := parseStructured(truncated)
+	if !ok {
+		t.Fatal("truncated structured review should be salvaged, not dropped")
+	}
+	if r.Passed {
+		t.Error("salvaged verdict should be FAIL (not passed)")
+	}
+	if !strings.Contains(r.Summary, "repo grouping") {
+		t.Errorf("salvaged summary should be unescaped; got %q", r.Summary)
+	}
+}
+
+func TestParseStructuredNoVerdictStillRejected(t *testing.T) {
+	if _, ok := parseStructured(`{"summary": "incomplete`); ok {
+		t.Error("JSON with no recoverable verdict must not parse")
+	}
+}
+
 func TestResultRender(t *testing.T) {
 	r := Result{Summary: "ok overall", Findings: []Finding{{Path: "a.go", Line: 3, Severity: "high", Comment: "fix this"}}}
 	got := r.Render()


### PR DESCRIPTION
## Context

On the large P4 review (PR #241), the Gemini gate posted `⚠️ Multi-model review: Skipped` followed by a raw, truncated JSON blob — even though the review had clearly returned `verdict: FAIL`. Two distinct bugs:

1. **Truncation** — the structured request was capped at `maxOutputTokens: 4096`. A big diff with many findings overran it, so the JSON response was cut off mid-`findings` (you could see it end mid-sentence).
2. **Mislabel + raw dump** — `parseStructured` does an all-or-nothing `json.Unmarshal`. On the truncated/invalid JSON it returned `false`, the caller fell back to the prose parser, found no `VERDICT:` line → empty verdict → `Skipped: true`, and `process.go` then posted the raw JSON under a "Skipped" header. The review actually ran and failed; the label and the dump were both wrong.

## Fix

- Bump `maxOutputTokens` 4096 → **8192** (covers realistic reviews; higher cap only costs tokens actually generated).
- `parseStructured` now **salvages** the verdict + summary when the full unmarshal fails: `verdict` and `summary` come first in the schema, so they survive truncation. A salvaged review posts as a proper `PASS`/`FAIL` (findings dropped when incomplete) instead of raw JSON mislabeled "Skipped". If no verdict can be recovered, it still correctly declines (prose stays rejected).

## Tests
- `TestParseStructuredSalvagesTruncatedJSON` — truncated `FAIL` JSON → salvaged FAIL with an unescaped summary.
- `TestParseStructuredNoVerdictStillRejected` — JSON with no recoverable verdict is still dropped.
- Existing `TestParseStructuredRejectsProse` + the API/CLI suite pass. `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)