### PR TITLE
feat: add 'noctra dashboard' command to tunnel to a remote dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -267,6 +267,11 @@ SWEEP_MAX_TASKS=5
 # Bearer token required on every request (header or ?token= query param).
 # DASHBOARD_TOKEN=
 
+# SSH target for `noctra dashboard` (run on your laptop) to tunnel to the Pi
+# and open the UI in your browser. Set this in your *local* config, with the
+# same DASHBOARD_ADDR port + DASHBOARD_TOKEN as the host running Noctra.
+# DASHBOARD_SSH=user@raspberrypi
+
 # Where Noctra persists PR cursors, sweep cooldowns, OAuth, and history.
 # Defaults to $HOME/.noctra/state.db.
 # STATE_DB=

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ setup: build ## Build and run the interactive setup wizard
 cleanup: build ## Build and run cleanup
 	./$(BINARY) cleanup
 
+dashboard: build ## SSH-tunnel to a remote dashboard and open it (set DASHBOARD_SSH in .env)
+	./$(BINARY) dashboard
+
 # ── Cross-compile (run on the Mac, scp the output to the Pi) ────────────────
 
 build-pi: ## Cross-compile for Raspberry Pi (arm64)

--- a/cmd/noctra/dashboard_cmd.go
+++ b/cmd/noctra/dashboard_cmd.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ahmadAlMezaal/noctra/internal/config"
+)
+
+const dashboardUsage = `Usage: noctra dashboard [flags]
+
+Open an SSH tunnel to a remote Noctra's dashboard and launch it in your browser.
+Reads DASHBOARD_SSH (e.g. user@raspberrypi), DASHBOARD_ADDR (for the port), and
+DASHBOARD_TOKEN from config; flags override. Ctrl+C closes the tunnel.
+
+Flags:
+  --host <user@host>   SSH target running Noctra (default: DASHBOARD_SSH)
+  --port <port>        dashboard port (default: from DASHBOARD_ADDR, else 8080)
+  --token <token>      dashboard token (default: DASHBOARD_TOKEN)
+  --no-browser         tunnel only; don't open a browser
+  --help, -h           show this help
+`
+
+func runDashboard(scriptDir string, args []string) error {
+	var hostFlag, portFlag, tokenFlag string
+	noBrowser := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--host":
+			i, hostFlag = nextArg(args, i)
+		case "--port":
+			i, portFlag = nextArg(args, i)
+		case "--token":
+			i, tokenFlag = nextArg(args, i)
+		case "--no-browser":
+			noBrowser = true
+		case "--help", "-h":
+			fmt.Print(dashboardUsage)
+			return nil
+		default:
+			return fmt.Errorf("unknown flag %q\n\n%s", args[i], dashboardUsage)
+		}
+	}
+
+	cfg, _ := config.Load(scriptDir)
+
+	host := firstNonEmpty(hostFlag, dashboardField(cfg, func(c *config.Config) string { return c.DashboardSSH }))
+	if host == "" {
+		return fmt.Errorf("no SSH host: set DASHBOARD_SSH (e.g. user@raspberrypi) or pass --host")
+	}
+	port := firstNonEmpty(portFlag, dashboardPort(dashboardField(cfg, func(c *config.Config) string { return c.DashboardAddr })), "8080")
+	token := firstNonEmpty(tokenFlag, dashboardField(cfg, func(c *config.Config) string { return c.DashboardToken }))
+
+	dashURL := fmt.Sprintf("http://localhost:%s/", port)
+	if token != "" {
+		dashURL += "?token=" + token
+	}
+
+	fmt.Printf("🌙 Tunnelling %s → localhost:%s\n", host, port)
+	fmt.Printf("   Dashboard: %s\n", dashURL)
+	fmt.Println("   Ctrl+C to close.")
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	forward := fmt.Sprintf("%s:localhost:%s", port, port)
+	cmd := exec.CommandContext(ctx, "ssh", "-N", "-o", "ExitOnForwardFailure=yes", "-L", forward, host)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start ssh tunnel: %w", err)
+	}
+
+	if !noBrowser {
+		go func() {
+			time.Sleep(1500 * time.Millisecond)
+			openBrowser(dashURL)
+		}()
+	}
+
+	err := cmd.Wait()
+	if ctx.Err() != nil {
+		return nil
+	}
+	return err
+}
+
+func nextArg(args []string, i int) (int, string) {
+	if i+1 < len(args) {
+		return i + 1, args[i+1]
+	}
+	return i, ""
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func dashboardField(cfg *config.Config, get func(*config.Config) string) string {
+	if cfg == nil {
+		return ""
+	}
+	return get(cfg)
+}
+
+func dashboardPort(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	if _, p, err := net.SplitHostPort(addr); err == nil {
+		return p
+	}
+	return strings.TrimPrefix(addr, ":")
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
+}

--- a/cmd/noctra/main.go
+++ b/cmd/noctra/main.go
@@ -87,6 +87,8 @@ func realMain() error {
 		return runPoll(scriptDir)
 	case "setup":
 		return runSetup(scriptDir)
+	case "dashboard":
+		return runDashboard(scriptDir, os.Args[2:])
 	case "config":
 		return configcmd.Run(scriptDir, os.Args[2:])
 	case "cleanup":
@@ -242,6 +244,7 @@ func printUsage() {
 	fmt.Println("Commands:")
 	fmt.Println("  run       Start the poll loop (default)")
 	fmt.Println("  setup     Interactive configuration wizard")
+	fmt.Println("  dashboard SSH-tunnel to a remote dashboard and open it in your browser")
 	fmt.Println("  config    Read or edit .env settings (path, edit, get, set)")
 	fmt.Println("  cleanup   Clean up stale branches and worktrees")
 	fmt.Println("  doctor    Preflight dependency and config checks")
@@ -383,7 +386,7 @@ func runService(verb string) error {
 // subcommands is the list completion offers. Kept in one place so the help
 // text, the completion script, and tests stay in sync.
 var subcommands = []string{
-	"run", "setup", "config", "update", "install-service", "uninstall", "logs", "start", "stop", "restart",
+	"run", "setup", "dashboard", "config", "update", "install-service", "uninstall", "logs", "start", "stop", "restart",
 	"status", "doctor", "cleanup", "completion", "version", "help",
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,6 +222,7 @@ type Config struct {
 	// serves a read-only snapshot UI on that address.
 	DashboardAddr  string // listen address (e.g. ":8080"); empty = dashboard disabled
 	DashboardToken string // required Bearer token for all dashboard requests
+	DashboardSSH   string // SSH target (user@host) for `noctra dashboard` to tunnel to
 
 	// Derived paths
 	ScriptDir    string
@@ -352,6 +353,7 @@ func Load(scriptDir string) (*Config, error) {
 	// Dashboard (ENG-274)
 	cfg.DashboardAddr = getenv(fileEnv, "DASHBOARD_ADDR", "")
 	cfg.DashboardToken = getenv(fileEnv, "DASHBOARD_TOKEN", "")
+	cfg.DashboardSSH = getenv(fileEnv, "DASHBOARD_SSH", "")
 
 	return cfg, nil
 }


### PR DESCRIPTION
## Context

The dashboard runs inside `noctra run` on the Pi, bound to localhost. Reaching it from a laptop meant remembering `ssh -L 8080:localhost:8080 user@host` and pasting a tokenized URL every time. This adds a client-side convenience command.

## Change

`noctra dashboard` (new subcommand, runs on your laptop):
1. Reads `DASHBOARD_SSH` (e.g. `user@raspberrypi`), the port from `DASHBOARD_ADDR`, and `DASHBOARD_TOKEN` from local config — `--host` / `--port` / `--token` override.
2. Opens the tunnel: `ssh -N -o ExitOnForwardFailure=yes -L <port>:localhost:<port> <host>`.
3. Opens the browser to `http://localhost:<port>/?token=<token>` (`open`/`xdg-open`/`rundll32`); `--no-browser` skips it.
4. Holds the tunnel in the foreground; Ctrl+C closes it cleanly.

Not in `noctra run` — that's the agent loop on the Pi; the tunnel is a separate client-side concern.

- `internal/config`: new `DASHBOARD_SSH`.
- `cmd/noctra`: dispatch + `dashboard_cmd.go`; added to the subcommand/completion list and help.
- `Makefile`: `make dashboard` convenience wrapper.
- `.env.example`: documents `DASHBOARD_SSH`.

So setup is once (`DASHBOARD_SSH`, `DASHBOARD_ADDR`, `DASHBOARD_TOKEN` in local config), then just `noctra dashboard`.

## Tests
- Existing `cmd/noctra` completion test passes (it asserts every subcommand appears — `dashboard` added). `config` tests pass. `go build`/`go vet` clean.
- Smoke-checked: `--help` prints usage; missing host → clear error.

## Follow-up (not in this PR)
Optionally fetch the token over SSH (`ssh host noctra config get DASHBOARD_TOKEN`) so it lives only on the Pi, instead of mirroring it locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)