### PR TITLE
fix: apply release label via REST (Projects-classic deprecation breaks gh pr edit)

### DIFF
--- a/internal/pipeline/label_test.go
+++ b/internal/pipeline/label_test.go
@@ -1,0 +1,16 @@
+package pipeline
+
+import "testing"
+
+func TestPRLabelsAPIPath(t *testing.T) {
+	got, err := prLabelsAPIPath("https://github.com/ahmadAlMezaal/noctra/pull/241")
+	if err != nil {
+		t.Fatalf("prLabelsAPIPath: %v", err)
+	}
+	if want := "repos/ahmadAlMezaal/noctra/issues/241/labels"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if _, err := prLabelsAPIPath("https://github.com/owner/repo/issues/9"); err == nil {
+		t.Error("a non-pull URL should error")
+	}
+}

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -847,13 +848,29 @@ func ghCreatePR(ctx context.Context, repoPath, title, body, base, head string) (
 // prURL is the PR URL returned by ghCreatePR. Errors are returned to the
 // caller for logging but never block the PR.
 func ghAddLabel(ctx context.Context, repoPath, prURL, label string) error {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "edit", prURL, "--add-label", label)
+	apiPath, err := prLabelsAPIPath(prURL)
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "gh", "api", "--method", "POST", apiPath, "-f", "labels[]="+label)
 	cmd.Dir = repoPath
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+func prLabelsAPIPath(prURL string) (string, error) {
+	u, err := url.Parse(prURL)
+	if err != nil {
+		return "", fmt.Errorf("parse PR URL %q: %w", prURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" || parts[0] == "" || parts[1] == "" || parts[3] == "" {
+		return "", fmt.Errorf("unexpected PR URL: %q", prURL)
+	}
+	return fmt.Sprintf("repos/%s/%s/issues/%s/labels", parts[0], parts[1], parts[3]), nil
 }
 
 // gitHeadShort returns the abbreviated HEAD commit SHA, or "" on error.


### PR DESCRIPTION
## Problem

Seen on PR #241:
```
WARN could not apply release label id=ENG-277 label=release:minor
  err="exit status 1: GraphQL: Projects (classic) is being deprecated … (repository.pullRequest.projectCards)"
```

`ghAddLabel` ran `gh pr edit <url> --add-label <label>`. `gh pr edit` fetches the PR — including `projectCards` — and GitHub is sunsetting Projects (classic), so that field now returns a GraphQL error. The command exits non-zero and **the release label is never applied**, which silently breaks the auto-release flow (`AUTO_RELEASE_LABEL`) for Noctra's own PRs.

## Fix

Apply the label via the REST endpoint, which doesn't touch projects:
```
gh api --method POST repos/{owner}/{repo}/issues/{n}/labels -f labels[]=<label>
```
Added `prLabelsAPIPath(prURL)` to build the path from the PR URL.

## Tests
- `TestPRLabelsAPIPath` — builds the right path; rejects a non-`/pull/` URL.
- `go build`, `go vet`, `go test ./internal/pipeline/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)