### PR TITLE
feat: update-available hint in `noctra version` + `noctra config list`

### DIFF
--- a/cmd/noctra/main.go
+++ b/cmd/noctra/main.go
@@ -202,12 +202,9 @@ func printBanner() {
 	fmt.Printf("  %s🌙 v%s%s — Autonomous Linear → PR agent\n\n", ansiDim, version, ansiReset)
 }
 
-// printUpdateNotice does a best-effort check for a newer release and prints a
-// single non-fatal hint when one exists. It is silent on any failure (offline,
-// gh missing/unauthed, timeout) and on dev/snapshot builds — mirroring
-// pipeline.checkForUpdate — so `noctra version` stays fast and works offline.
-// The short timeout bounds the wait; the version line is already printed before
-// this runs, so the network check never delays the answer the user asked for.
+// printUpdateNotice prints a non-fatal hint when a newer release exists. Best-
+// effort: silent on any failure and on dev/snapshot builds, with a short
+// timeout so `noctra version` stays fast and works offline.
 func printUpdateNotice() {
 	if version == "" || strings.Contains(version, "dev") || strings.Contains(version, "snapshot") {
 		return

--- a/cmd/noctra/main.go
+++ b/cmd/noctra/main.go
@@ -4,7 +4,7 @@
 //
 //	noctra            start the poll loop (default)
 //	noctra setup      interactive .env wizard
-//	noctra config     read or edit .env settings (path, edit, get, set)
+//	noctra config     read or edit .env settings (path, list, edit, get, set)
 //	noctra cleanup    clean up stale branches and worktrees
 //	noctra cleanup --force
 //	noctra doctor     preflight dependency and config checks
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/ahmadAlMezaal/noctra/internal/cleanup"
 	"github.com/ahmadAlMezaal/noctra/internal/config"
@@ -178,6 +179,7 @@ func realMain() error {
 	case "version", "--version", "-v":
 		printBanner()
 		fmt.Println("noctra", version)
+		printUpdateNotice()
 		return nil
 	case "help", "--help", "-h":
 		printBanner()
@@ -198,6 +200,25 @@ func printBanner() {
 	}
 	fmt.Print(ansiAmber, bannerArt, ansiReset)
 	fmt.Printf("  %s🌙 v%s%s — Autonomous Linear → PR agent\n\n", ansiDim, version, ansiReset)
+}
+
+// printUpdateNotice does a best-effort check for a newer release and prints a
+// single non-fatal hint when one exists. It is silent on any failure (offline,
+// gh missing/unauthed, timeout) and on dev/snapshot builds — mirroring
+// pipeline.checkForUpdate — so `noctra version` stays fast and works offline.
+// The short timeout bounds the wait; the version line is already printed before
+// this runs, so the network check never delays the answer the user asked for.
+func printUpdateNotice() {
+	if version == "" || strings.Contains(version, "dev") || strings.Contains(version, "snapshot") {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	latest, err := selfupdate.Latest(ctx)
+	if err != nil || !selfupdate.IsNewer(latest, version) {
+		return
+	}
+	fmt.Printf("\n🆙 A newer version is available: %s (run `noctra update` to upgrade)\n", latest)
 }
 
 // parseUninstallArgs interprets the flags for the destructive `uninstall`

--- a/internal/configcmd/configcmd.go
+++ b/internal/configcmd/configcmd.go
@@ -4,6 +4,7 @@
 // Subcommands:
 //
 //	noctra config path          print the resolved .env path
+//	noctra config list          print all KEY=VALUE pairs (secrets masked)
 //	noctra config edit          open .env in $EDITOR
 //	noctra config get KEY       print one value (exit 1 if unset)
 //	noctra config set KEY=VALUE upsert one key (atomic, comment-preserving)
@@ -14,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -33,6 +35,14 @@ func Run(scriptDir string, args []string) error {
 	switch args[0] {
 	case "path":
 		return runPath(envFile)
+	case "list", "ls":
+		reveal := false
+		for _, a := range args[1:] {
+			if a == "--reveal" || a == "--show-secrets" {
+				reveal = true
+			}
+		}
+		return runList(envFile, reveal)
 	case "edit":
 		return runEdit(envFile)
 	case "get":
@@ -56,6 +66,7 @@ func printUsage() {
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  path            Print the resolved .env file path")
+	fmt.Println("  list            Print all KEY=VALUE pairs (secrets masked; --reveal to show)")
 	fmt.Println("  edit            Open .env in $EDITOR (falls back to vi/nano)")
 	fmt.Println("  get KEY         Print the value of KEY from .env")
 	fmt.Println("  set KEY=VALUE   Set KEY to VALUE (atomic, preserves comments)")
@@ -66,6 +77,64 @@ func printUsage() {
 func runPath(envFile string) error {
 	fmt.Println(envFile)
 	return nil
+}
+
+// runList prints every KEY=VALUE pair from .env, sorted by key. Secret-looking
+// values (tokens, keys, passwords, webhook URLs) are masked by default so the
+// output is safe to paste or screenshot; --reveal prints them verbatim. An
+// empty/missing .env is reported rather than printing nothing.
+func runList(envFile string, reveal bool) error {
+	env, err := config.LoadEnvFile(envFile)
+	if err != nil {
+		return err
+	}
+	if len(env) == 0 {
+		fmt.Printf("No settings found in %s\n", envFile)
+		return nil
+	}
+
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	masked := false
+	for _, k := range keys {
+		val := env[k]
+		if !reveal && isSecretKey(k) && val != "" {
+			val = maskSecret(val)
+			masked = true
+		}
+		fmt.Printf("%s=%s\n", k, val)
+	}
+	if masked {
+		fmt.Fprintln(os.Stderr, "\n(secrets masked — pass --reveal to show full values)")
+	}
+	return nil
+}
+
+// secretKeyParts flags keys whose values are sensitive and should be masked.
+var secretKeyParts = []string{"TOKEN", "SECRET", "KEY", "PASSWORD", "PASS", "WEBHOOK"}
+
+// isSecretKey reports whether a setting's value should be masked by default.
+func isSecretKey(key string) bool {
+	up := strings.ToUpper(key)
+	for _, part := range secretKeyParts {
+		if strings.Contains(up, part) {
+			return true
+		}
+	}
+	return false
+}
+
+// maskSecret hides a sensitive value, keeping the last 4 characters as a hint
+// when the value is long enough to spare them without exposing the whole secret.
+func maskSecret(val string) string {
+	if len(val) <= 8 {
+		return "••••••"
+	}
+	return "••••••" + val[len(val)-4:]
 }
 
 // runEdit opens the resolved .env in the user's $EDITOR. Falls back to vi,

--- a/internal/configcmd/configcmd_test.go
+++ b/internal/configcmd/configcmd_test.go
@@ -205,3 +205,51 @@ func TestRun_SetMissingArg(t *testing.T) {
 		t.Error("set without a key should error")
 	}
 }
+
+func TestIsSecretKey(t *testing.T) {
+	secret := []string{"LINEAR_API_KEY", "LINEAR_OAUTH_CLIENT_SECRET", "GH_TOKEN", "TELEGRAM_BOT_TOKEN", "SLACK_WEBHOOK_URL", "DB_PASSWORD"}
+	for _, k := range secret {
+		if !isSecretKey(k) {
+			t.Errorf("isSecretKey(%q) = false, want true", k)
+		}
+	}
+	plain := []string{"AGENT_BACKEND", "TRIGGER_MODE", "REPO_PATH", "SWEEP_ENABLED", "MAIN_BRANCH"}
+	for _, k := range plain {
+		if isSecretKey(k) {
+			t.Errorf("isSecretKey(%q) = true, want false", k)
+		}
+	}
+}
+
+func TestMaskSecret(t *testing.T) {
+	// Short secrets are fully masked — no trailing characters leak.
+	if got := maskSecret("short"); got != "••••••" {
+		t.Errorf("maskSecret short = %q, want fully masked", got)
+	}
+	// Long secrets keep a 4-char hint.
+	got := maskSecret("lin_api_abcd1234")
+	if got != "••••••1234" {
+		t.Errorf("maskSecret long = %q, want last-4 hint", got)
+	}
+}
+
+func TestRunList(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	writeTestFile(t, envFile, `LINEAR_API_KEY="lin_api_abcd1234"
+AGENT_BACKEND="claude"
+`)
+	// Both masked and revealed paths should succeed without error.
+	if err := runList(envFile, false); err != nil {
+		t.Errorf("runList (masked) should succeed: %v", err)
+	}
+	if err := runList(envFile, true); err != nil {
+		t.Errorf("runList (reveal) should succeed: %v", err)
+	}
+}
+
+func TestRunList_MissingFile(t *testing.T) {
+	if err := runList(filepath.Join(t.TempDir(), "nope.env"), false); err != nil {
+		t.Errorf("runList on a missing file should not error: %v", err)
+	}
+}


### PR DESCRIPTION
Two small CLI quality-of-life additions.

## 1. `noctra version` now flags available updates

Prints the current version **first**, then does a best-effort check for a newer release and appends a non-fatal hint:

```
noctra 0.28.5

🆙 A newer version is available: v0.28.6 (run `noctra update` to upgrade)
```

- Silent on any failure (offline, `gh` missing/unauthed, 5s timeout) and on dev/snapshot builds → stays fast and offline-friendly.
- Reuses the existing `selfupdate.Latest` / `IsNewer` (same logic the `run` startup goroutine uses).

## 2. `noctra config list`

Lists every `KEY=VALUE` pair (sorted) so you don't have to `cat ~/.noctra/.env`:

```
noctra config list            # secrets masked by default
noctra config list --reveal   # full values
```

Secret-looking keys (`TOKEN`/`SECRET`/`KEY`/`PASSWORD`/`PASS`/`WEBHOOK`) are masked as `••••••1234` (4-char hint when long enough, fully masked if ≤8 chars) so output is safe to paste/screenshot. A stderr footer notes when anything was masked.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` — all 22 packages pass. New unit tests cover `isSecretKey`, `maskSecret`, and `runList`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)