### PR TITLE
feat: archive no-op tickets instead of marking Done / re-queuing

### DIFF
--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -573,6 +573,39 @@ func TestRemoveLabel_RemovesTarget(t *testing.T) {
 	}
 }
 
+func TestArchiveIssue(t *testing.T) {
+	client := fakeServer(t, struct {
+		authHeader string
+		query      string
+		variables  map[string]any
+	}{
+		authHeader: "k",
+		query:      "issueArchive",
+		variables:  map[string]any{"id": "issue_1"},
+	}, map[string]any{
+		"data": map[string]any{"issueArchive": map[string]any{"success": true}},
+	})
+	if err := client.ArchiveIssue(context.Background(), "issue_1"); err != nil {
+		t.Fatalf("ArchiveIssue: %v", err)
+	}
+}
+
+func TestArchiveIssue_SuccessFalse(t *testing.T) {
+	client := fakeServer(t, struct {
+		authHeader string
+		query      string
+		variables  map[string]any
+	}{
+		authHeader: "k",
+		query:      "issueArchive",
+	}, map[string]any{
+		"data": map[string]any{"issueArchive": map[string]any{"success": false}},
+	})
+	if err := client.ArchiveIssue(context.Background(), "issue_1"); err == nil {
+		t.Fatal("expected error when issueArchive reports success=false")
+	}
+}
+
 func TestResolveStateIDs_SkipsTriggerWhenEmpty(t *testing.T) {
 	client := fakeServer(t, struct {
 		authHeader string

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -249,6 +249,26 @@ func (c *Client) SetState(ctx context.Context, issueID, stateID string) error {
 	return nil
 }
 
+// ArchiveIssue archives an issue (reversible — restorable from the Linear UI).
+func (c *Client) ArchiveIssue(ctx context.Context, issueID string) error {
+	mutation := `mutation($id: String!) {
+	  issueArchive(id: $id) { success }
+	}`
+
+	var resp struct {
+		IssueArchive struct {
+			Success bool `json:"success"`
+		} `json:"issueArchive"`
+	}
+	if err := c.Do(ctx, mutation, map[string]any{"id": issueID}, &resp); err != nil {
+		return err
+	}
+	if !resp.IssueArchive.Success {
+		return fmt.Errorf("issueArchive reported success=false for %s", issueID)
+	}
+	return nil
+}
+
 // Comment posts a markdown comment on an issue.
 func (c *Client) Comment(ctx context.Context, issueID, body string) error {
 	mutation := `mutation($issueId: String!, $body: String!) {

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -300,7 +300,7 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	if nc := agent.NoChangesLine(output); nc != "" {
 		logger.Info("no changes needed", "reason", nc)
 		p.resolveNoChanges(ctx, issue, fmt.Sprintf(
-			"✅ **Noctra: nothing to do**\n\n> %s\n\nNo changes were needed, so this ticket was closed automatically.", nc))
+			"✅ **Noctra: nothing to do**\n\n> %s\n\nNo changes were needed, so this ticket was archived automatically. Restore it from the archive if work is still required.", nc))
 		p.notifier.Send(ctx, fmt.Sprintf("✅ *%s* — nothing to do\n%s", id, notify.EscapeMarkdown(nc)))
 		p.recordRun(state.RunHistory{
 			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
@@ -349,15 +349,12 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 		return
 	}
 	if !dirty && !committed {
-		// Count the attempt — otherwise this re-queues to the trigger state every
-		// poll and burns the whole dispatch budget on one unprogressable ticket
-		// (e.g. a vague description, already-done work, or a ticket pointed at the
-		// wrong repo). After MaxRetries it's skipped until restart.
-		attempts := p.bumpFailed(id)
-		logger.Warn("no changes made", "attempt", attempts, "max", p.cfg.MaxRetries)
-		p.ticketBackToTrigger(ctx, issue, fmt.Sprintf(
-			"💭 **Noctra: No code changes made** (attempt %d/%d)\n\nThe agent completed without modifying any files — usually the ticket is too vague, already done, or its Linear project points at the wrong repo.\n\nAdd more detail (or check the project's `Repo:` directive), then move it back to **%s** to retry. After %d attempts it won't be re-dispatched until Noctra restarts.",
-			attempts, p.cfg.MaxRetries, p.cfg.TriggerState, p.cfg.MaxRetries))
+		// Empty diff with no NO_CHANGES line: resolve as a no-op (archive) instead
+		// of re-queuing every poll until MaxRetries.
+		logger.Info("no changes made; archiving", "issue", id)
+		p.resolveNoChanges(ctx, issue,
+			"💭 **Noctra: No code changes made**\n\nThe agent completed without modifying any files — usually the ticket is already done, too vague, or its Linear project points at the wrong repo. It was archived automatically.\n\nIf work is still required, add detail (or fix the project's `Repo:` directive) and restore it from the archive.")
+		p.notifier.Send(ctx, fmt.Sprintf("✅ *%s* — no changes made, archived", id))
 		p.recordRun(state.RunHistory{
 			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
 			AgentBackend: backend.Name(), RunType: "ticket",
@@ -688,13 +685,22 @@ func (p *Pipeline) ticketComment(ctx context.Context, ticket source.Ticket, body
 	return p.ticketSource(ticket).Comment(ctx, ticket, body)
 }
 
-// resolveNoChanges comments, then moves a no-op ticket to Done (or skips it for
-// the session) so it leaves the trigger state and isn't re-dispatched.
+// resolveNoChanges comments, then archives a no-op ticket (falling back to a
+// Done transition, then to skip-for-session) so it leaves the trigger state and
+// isn't re-dispatched.
 func (p *Pipeline) resolveNoChanges(ctx context.Context, ticket source.Ticket, body string) {
 	if err := p.ticketComment(ctx, ticket, body); err != nil {
 		slog.Warn("no-changes comment failed", "issue_id", ticket.ID, "err", err)
 	}
-	if dm, ok := p.ticketSource(ticket).(source.DoneMarker); ok {
+	src := p.ticketSource(ticket)
+	if ar, ok := src.(source.Archiver); ok {
+		if err := ar.Archive(ctx, ticket); err == nil {
+			return
+		} else {
+			slog.Warn("archive failed; falling back to mark-done", "issue_id", ticket.ID, "err", err)
+		}
+	}
+	if dm, ok := src.(source.DoneMarker); ok {
 		if err := dm.MarkDone(ctx, ticket); err == nil {
 			return
 		} else {

--- a/internal/source/linear.go
+++ b/internal/source/linear.go
@@ -166,6 +166,21 @@ func (s *LinearSource) MarkDone(ctx context.Context, ticket Ticket) error {
 	return firstErr
 }
 
+// Archive archives a ticket. In label mode the trigger label is dropped first
+// so a later restore doesn't immediately re-dispatch it.
+func (s *LinearSource) Archive(ctx context.Context, ticket Ticket) error {
+	var firstErr error
+	if s.cfg.TriggerMode == "label" && s.triggerLabelID != "" {
+		if err := s.client.RemoveLabel(ctx, ticket.ID, s.triggerLabelID); err != nil {
+			firstErr = err
+		}
+	}
+	if err := s.client.ArchiveIssue(ctx, ticket.ID); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
 func (s *LinearSource) Comment(ctx context.Context, ticket Ticket, body string) error {
 	return s.client.Comment(ctx, ticket.ID, body)
 }

--- a/internal/source/types.go
+++ b/internal/source/types.go
@@ -23,10 +23,15 @@ type TicketSource interface {
 	Comment(context.Context, Ticket, string) error
 }
 
-// DoneMarker is an optional capability for sources that can move a ticket to a
-// terminal "done" state (used on NO_CHANGES).
+// DoneMarker moves a ticket to a terminal "done" state — the no-op resolution
+// fallback when a source can't archive.
 type DoneMarker interface {
 	MarkDone(context.Context, Ticket) error
+}
+
+// Archiver archives a ticket outright (preferred over DoneMarker on a no-op).
+type Archiver interface {
+	Archive(context.Context, Ticket) error
 }
 
 // ReadyInfo is the source-agnostic status update after Noctra opens a PR.


### PR DESCRIPTION
## What

Changes how Noctra resolves a ticket the coding agent makes **no changes** for.

### 1. Explicit `NO_CHANGES:` → archive instead of Done
When the agent reports the ticket is already satisfied (`NO_CHANGES: <reason>`), `resolveNoChanges` now **archives** the ticket rather than moving it to the Done state — so finished-but-untouched tickets don't pile up on the board (and don't count against Linear's active-issue cap).

### 2. Implicit empty diff → archive instead of looping to `MaxRetries`
Previously, when the agent finished **without** a `NO_CHANGES:` line but left no diff (no dirty worktree, no commits ahead), the ticket was bounced back to the trigger state and re-dispatched **every poll until `MaxRetries`**, burning the dispatch budget on an unprogressable ticket. It's now treated as a no-op resolution and archived once, with a comment explaining how to restore it if work is still needed.

## How
- `linear.Client.ArchiveIssue` — new `issueArchive` GraphQL mutation (reversible; restorable from the Linear UI).
- `source.Archiver` capability, implemented by `LinearSource.Archive` (drops the trigger label first in label mode so a later restore doesn't immediately re-dispatch).
- `resolveNoChanges` prefers `Archiver`, falling back to `DoneMarker`, then skip-for-session. GitHub Issues / Jira sources (no `Archive`/`MarkDone`) are unaffected — they still skip.

## Notes
- Archiving is **reversible** — restore from the archive if a ticket actually needed work.
- Both no-change paths record run status `no_change` as before.

## Tests
- `TestArchiveIssue` / `TestArchiveIssue_SuccessFalse` for the new mutation.
- `go test ./...`, `go build ./...`, `go vet ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)