### PR TITLE
ENG-275: Dashboard P2 — live SSE updates + log tail follow

### DIFF
--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,19 +1,22 @@
 // Package dashboard serves a read-only HTTP dashboard showing a point-in-time
-// snapshot of the pipeline. All requests require a Bearer token.
+// snapshot of the pipeline. All requests require a valid dashboard token.
 package dashboard
 
 import (
 	"context"
 	"embed"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/ahmadAlMezaal/noctra/internal/agent"
 	"github.com/ahmadAlMezaal/noctra/internal/state"
 	"github.com/ahmadAlMezaal/noctra/internal/sweep"
 )
@@ -32,12 +35,16 @@ type Providers struct {
 	SweepTasks      []sweep.Task
 	MaxPRIterations int
 	RepoPaths       func() []string // repo.Resolver.AllRepoPaths
+	LogDir          string
+	Hub             *Hub
 }
 
 // Server is the dashboard HTTP server.
 type Server struct {
-	srv   *http.Server
-	token string
+	srv        *http.Server
+	token      string
+	snapshotFn SnapshotFunc
+	prov       Providers
 }
 
 // New creates a dashboard server bound to addr, gated by the given token.
@@ -51,7 +58,12 @@ func New(addr, token string, snapshotFn SnapshotFunc, prov Providers) *Server {
 			Addr:    addr,
 			Handler: mux,
 		},
-		token: token,
+		token:      token,
+		snapshotFn: snapshotFn,
+		prov:       prov,
+	}
+	if s.prov.Hub == nil {
+		s.prov.Hub = NewHub(defaultMaxSubscribers)
 	}
 
 	mux.Handle("/api/snapshot", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -61,6 +73,22 @@ func New(addr, token string, snapshotFn SnapshotFunc, prov Providers) *Server {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(snapshotFn())
+	})))
+
+	mux.Handle("/api/events", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleEvents(w, r)
+	})))
+
+	mux.Handle("/api/logs/", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleLogs(w, r)
 	})))
 
 	mux.Handle("/api/history", s.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -142,7 +170,136 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 	})
 }
 
+// Hub returns the server's live event hub.
+func (s *Server) Hub() *Hub {
+	return s.prov.Hub
+}
+
 // ── API handlers ────────────────────────────────────────────────────────────
+
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	events, unsubscribe, ok := s.prov.Hub.Subscribe(r.Context())
+	if !ok {
+		http.Error(w, "too many subscribers", http.StatusTooManyRequests)
+		return
+	}
+	defer unsubscribe()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	if !s.writeSnapshotEvent(w) {
+		return
+	}
+	flusher.Flush()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case _, ok := <-events:
+			if !ok {
+				return
+			}
+			if !s.writeSnapshotEvent(w) {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func (s *Server) writeSnapshotEvent(w http.ResponseWriter) bool {
+	b, err := json.Marshal(s.snapshotFn())
+	if err != nil {
+		slog.Warn("dashboard snapshot encode failed", "err", err)
+		return false
+	}
+	if _, err := fmt.Fprintf(w, "event: snapshot\ndata: %s\n\n", b); err != nil {
+		return false
+	}
+	return true
+}
+
+func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/logs/")
+	if id == "" || id != filepath.Base(id) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	logFile := filepath.Join(s.prov.LogDir, id+".log")
+	if r.URL.Query().Get("follow") != "1" && r.URL.Query().Get("follow") != "true" {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = fmt.Fprint(w, boundedTail(logFile, 64*1024))
+		return
+	}
+	s.followLog(w, r, logFile)
+}
+
+func (s *Server) followLog(w http.ResponseWriter, r *http.Request, logFile string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher.Flush()
+
+	offset := agent.OffsetBefore(logFile)
+	initial := boundedTail(logFile, 64*1024)
+	if initial != "" {
+		writeLogEvent(w, initial)
+		flusher.Flush()
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			next := agent.OffsetBefore(logFile)
+			if next <= offset {
+				continue
+			}
+			chunk := agent.ReadAfter(logFile, offset)
+			offset = next
+			if chunk == "" {
+				continue
+			}
+			if len(chunk) > 32*1024 {
+				chunk = chunk[len(chunk)-32*1024:]
+			}
+			writeLogEvent(w, chunk)
+			flusher.Flush()
+		}
+	}
+}
+
+func boundedTail(logFile string, maxBytes int64) string {
+	size := agent.OffsetBefore(logFile)
+	if size <= 0 {
+		return ""
+	}
+	offset := size - maxBytes
+	if offset < 0 {
+		offset = 0
+	}
+	return agent.ReadAfter(logFile, offset)
+}
+
+func writeLogEvent(w http.ResponseWriter, chunk string) {
+	b, _ := json.Marshal(chunk)
+	fmt.Fprintf(w, "event: log\ndata: %s\n\n", b)
+}
 
 type historyEntry struct {
 	Identifier string  `json:"identifier"`

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -1,10 +1,14 @@
 package dashboard
 
 import (
+	"bufio"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -133,6 +137,103 @@ func TestSnapshot_MethodNotAllowed(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestEvents_InitialSnapshotFrame(t *testing.T) {
+	s := newTestServer("tok")
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/events?token=tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("content-type = %q", ct)
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	var frame strings.Builder
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		if line == "\n" || err == io.EOF {
+			break
+		}
+		frame.WriteString(line)
+	}
+	got := frame.String()
+	if !strings.Contains(got, "event: snapshot\n") {
+		t.Fatalf("missing snapshot event: %q", got)
+	}
+	if !strings.Contains(got, `"active":["ENG-1"]`) {
+		t.Fatalf("missing initial snapshot data: %q", got)
+	}
+}
+
+func TestEvents_AuthRequired(t *testing.T) {
+	s := newTestServer("tok")
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestLogsFollow_InitialTailFrameAndAuth(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ENG-9.log"), []byte("line one\nline two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := New(":0", "tok", func() any { return nil }, Providers{LogDir: dir})
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/logs/ENG-9?follow=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d", resp.StatusCode)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/logs/ENG-9?follow=1&token=tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	reader := bufio.NewReader(resp.Body)
+	var frame strings.Builder
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		if line == "\n" || err == io.EOF {
+			break
+		}
+		frame.WriteString(line)
+	}
+	got := frame.String()
+	if !strings.Contains(got, "event: log\n") || !strings.Contains(got, `line two\n`) {
+		t.Fatalf("unexpected log frame: %q", got)
 	}
 }
 

--- a/internal/dashboard/hub.go
+++ b/internal/dashboard/hub.go
@@ -1,0 +1,81 @@
+package dashboard
+
+import (
+	"context"
+	"sync"
+)
+
+const defaultMaxSubscribers = 64
+
+// Hub fans live dashboard invalidation events out to SSE subscribers.
+type Hub struct {
+	mu          sync.Mutex
+	max         int
+	subscribers map[chan struct{}]struct{}
+}
+
+// NewHub creates a bounded in-process fan-out hub.
+func NewHub(maxSubscribers int) *Hub {
+	if maxSubscribers <= 0 {
+		maxSubscribers = defaultMaxSubscribers
+	}
+	return &Hub{
+		max:         maxSubscribers,
+		subscribers: map[chan struct{}]struct{}{},
+	}
+}
+
+// Subscribe registers a subscriber until ctx is cancelled or unsubscribe is called.
+func (h *Hub) Subscribe(ctx context.Context) (<-chan struct{}, func(), bool) {
+	if h == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch, func() {}, false
+	}
+	ch := make(chan struct{}, 1)
+	done := make(chan struct{})
+	h.mu.Lock()
+	if len(h.subscribers) >= h.max {
+		h.mu.Unlock()
+		close(ch)
+		return ch, func() {}, false
+	}
+	h.subscribers[ch] = struct{}{}
+	h.mu.Unlock()
+
+	var once sync.Once
+	unsubscribe := func() {
+		once.Do(func() {
+			h.mu.Lock()
+			if _, ok := h.subscribers[ch]; ok {
+				delete(h.subscribers, ch)
+				close(ch)
+			}
+			close(done)
+			h.mu.Unlock()
+		})
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			unsubscribe()
+		case <-done:
+		}
+	}()
+	return ch, unsubscribe, true
+}
+
+// Publish notifies current subscribers without blocking slow clients.
+func (h *Hub) Publish() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for ch := range h.subscribers {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/internal/dashboard/hub_test.go
+++ b/internal/dashboard/hub_test.go
@@ -1,0 +1,66 @@
+package dashboard
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestHubPublishAndUnsubscribe(t *testing.T) {
+	h := NewHub(4)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a, unsubA, ok := h.Subscribe(ctx)
+	if !ok {
+		t.Fatal("subscribe A rejected")
+	}
+	b, unsubB, ok := h.Subscribe(ctx)
+	if !ok {
+		t.Fatal("subscribe B rejected")
+	}
+	defer unsubB()
+
+	h.Publish()
+	receive(t, a)
+	receive(t, b)
+
+	unsubA()
+	h.Publish()
+	receive(t, b)
+	select {
+	case _, ok := <-a:
+		if ok {
+			t.Fatal("unsubscribed channel received publish")
+		}
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestHubSubscriberCap(t *testing.T) {
+	h := NewHub(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, unsub, ok := h.Subscribe(ctx)
+	if !ok {
+		t.Fatal("first subscriber rejected")
+	}
+	defer unsub()
+	_, _, ok = h.Subscribe(ctx)
+	if ok {
+		t.Fatal("second subscriber accepted over cap")
+	}
+}
+
+func receive(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for publish")
+	}
+}

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -89,6 +89,9 @@
     color: var(--dim);
     border: 1px solid var(--edge);
   }
+  .topbar-tag.connected { color: var(--ok); }
+  .topbar-tag.reconnecting { color: var(--warn); }
+  .topbar-tag.disconnected { color: var(--bad); }
 
   /* ── Grid layout ───────────────────────────────────────────────────── */
   .grid {
@@ -233,6 +236,46 @@
     display: inline-block;
     vertical-align: middle;
   }
+  .run-line {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+  .log-btn {
+    border: 1px solid var(--edge);
+    background: rgba(143, 180, 255, 0.08);
+    color: var(--glow);
+    border-radius: 0.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    padding: 0.1rem 0.4rem;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .log-btn:hover { border-color: var(--glow); color: var(--moon); }
+  .log-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.625rem;
+  }
+  .log-head h2 { margin-bottom: 0; }
+  #log-card { display: none; }
+  #log-output {
+    min-height: 12rem;
+    max-height: 28rem;
+    overflow: auto;
+    white-space: pre-wrap;
+    background: #080B12;
+    border: 1px solid var(--edge);
+    border-radius: 0.375rem;
+    padding: 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.45;
+  }
 
   /* ── Sparkline ─────────────────────────────────────────────────────── */
   .sparkline-wrap {
@@ -304,6 +347,7 @@
     .grid { grid-template-columns: 1fr; }
     .topbar { gap: 0.5rem; }
     .topbar-meta { margin-left: 0; width: 100%; }
+    .run-line { align-items: flex-start; }
     table { font-size: 0.75rem; }
     th, td { padding: 0.3rem 0.25rem; }
     .truncate { max-width: 10rem; }
@@ -316,12 +360,21 @@
 <div class="topbar">
   <div class="brand"><span class="brand-moon">&#127769;</span> Noctra</div>
   <div class="topbar-meta">
+    <span class="topbar-tag reconnecting" id="connection-status">Connecting</span>
     <span class="topbar-tag" id="dispatch-status">--</span>
     <span class="topbar-tag" id="budget-tag">--</span>
   </div>
 </div>
 
 <div id="error"></div>
+
+<div class="card wide" id="log-card">
+  <div class="log-head">
+    <h2 id="log-title">Log</h2>
+    <button type="button" class="log-btn" id="close-log">Close</button>
+  </div>
+  <pre id="log-output"></pre>
+</div>
 
 <!-- Row 1: Live snapshot cards -->
 <div class="grid">
@@ -377,6 +430,15 @@
   var params = new URLSearchParams(window.location.search);
   var token = params.get("token") || "";
   var headers = { "Authorization": "Bearer " + token };
+  var events = null;
+  var logEvents = null;
+  var auxRefreshTimer = null;
+
+  function authURL(path) {
+    if (!token) return path;
+    var sep = path.indexOf("?") === -1 ? "?" : "&";
+    return path + sep + "token=" + encodeURIComponent(token);
+  }
 
   function formatTokens(n) {
     if (n >= 1000000) return (n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1) + "M";
@@ -421,6 +483,10 @@
     return '<a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(text || url) + "</a>";
   }
 
+  function logButton(id) {
+    return '<button type="button" class="log-btn" data-log-id="' + esc(id) + '">Log</button>';
+  }
+
   function shortTime(iso) {
     if (!iso) return "-";
     var d = new Date(iso);
@@ -450,14 +516,14 @@
     var html = "";
     if (g.order.length === 1 && g.order[0] === "(unknown)") {
       html = "<ul>" + items.map(function(e) {
-        return '<li class="lamp-item">' + esc(e.identifier) + "</li>";
+        return '<li class="lamp-item"><span class="run-line"><span>' + esc(e.identifier) + "</span>" + logButton(e.identifier) + "</span></li>";
       }).join("") + "</ul>";
     } else {
       for (var i = 0; i < g.order.length; i++) {
         var repo = g.order[i];
         html += '<div class="repo-header">' + esc(repo) + "</div><ul>";
         html += g.groups[repo].map(function(e) {
-          return '<li class="lamp-item">' + esc(e.identifier) + "</li>";
+          return '<li class="lamp-item"><span class="run-line"><span>' + esc(e.identifier) + "</span>" + logButton(e.identifier) + "</span></li>";
         }).join("");
         html += "</ul>";
       }
@@ -474,14 +540,14 @@
     var html = "";
     if (g.order.length === 1 && g.order[0] === "(unknown)") {
       html = "<ul>" + items.map(function(e) {
-        return "<li>" + esc(e.identifier) + '<span class="retries">(' + e.retries + " retries)</span></li>";
+        return '<li><span class="run-line"><span>' + esc(e.identifier) + '<span class="retries">(' + e.retries + " retries)</span></span>" + logButton(e.identifier) + "</span></li>";
       }).join("") + "</ul>";
     } else {
       for (var i = 0; i < g.order.length; i++) {
         var repo = g.order[i];
         html += '<div class="repo-header">' + esc(repo) + "</div><ul>";
         html += g.groups[repo].map(function(e) {
-          return "<li>" + esc(e.identifier) + '<span class="retries">(' + e.retries + " retries)</span></li>";
+          return '<li><span class="run-line"><span>' + esc(e.identifier) + '<span class="retries">(' + e.retries + " retries)</span></span>" + logButton(e.identifier) + "</span></li>";
         }).join("");
         html += "</ul>";
       }
@@ -494,7 +560,7 @@
       el.innerHTML = '<li class="empty">No skipped tickets.</li>';
       return;
     }
-    el.innerHTML = items.map(function(id) { return "<li>" + esc(id) + "</li>"; }).join("");
+    el.innerHTML = items.map(function(id) { return '<li><span class="run-line"><span>' + esc(id) + "</span>" + logButton(id) + "</span></li>"; }).join("");
   }
 
   function renderBudget(el, b, paused) {
@@ -629,12 +695,12 @@
       el.innerHTML = '<span class="empty">No runs in this view.</span>';
       return;
     }
-    var html = "<table><thead><tr><th>Identifier</th><th>Repo</th><th>Type</th><th>Status</th><th>Duration</th><th>PR</th><th>Started</th></tr></thead><tbody>";
+    var html = "<table><thead><tr><th>Identifier</th><th>Repo</th><th>Type</th><th>Status</th><th>Duration</th><th>PR</th><th>Started</th><th>Log</th></tr></thead><tbody>";
     for (var i = 0; i < runs.length; i++) {
       var r = runs[i];
       var idCell = r.linear_url ? link(r.linear_url, r.identifier) : '<span class="mono">' + esc(r.identifier) + "</span>";
       var prCell = r.pr_url ? link(r.pr_url, "PR") : '<span class="dim">-</span>';
-      html += "<tr><td class='mono'>" + idCell + "</td><td class='mono'>" + esc(r.repo || "-") + "</td><td>" + typeBadge(r.run_type) + "</td><td>" + statusBadge(r.status) + "</td><td class='mono'>" + formatDuration(r.duration_s) + "</td><td>" + prCell + "</td><td class='mono'>" + shortTime(r.started_at) + "</td></tr>";
+      html += "<tr><td class='mono'>" + idCell + "</td><td class='mono'>" + esc(r.repo || "-") + "</td><td>" + typeBadge(r.run_type) + "</td><td>" + statusBadge(r.status) + "</td><td class='mono'>" + formatDuration(r.duration_s) + "</td><td>" + prCell + "</td><td class='mono'>" + shortTime(r.started_at) + "</td><td>" + logButton(r.identifier) + "</td></tr>";
     }
     html += "</tbody></table>";
     el.innerHTML = html;
@@ -703,24 +769,39 @@
     });
   }
 
-  function load() {
+  function renderSnapshot(snap) {
+    updateTopbar(snap);
+    renderActive(document.getElementById("active"), snap.active);
+    renderQueued(document.getElementById("queued"), snap.queued);
+    renderSkipped(document.getElementById("skipped"), snap.skipped);
+    renderBudget(document.getElementById("budget"), snap.budget || {}, snap.paused);
+  }
+
+  function setConnection(state, text) {
+    var el = document.getElementById("connection-status");
+    el.className = "topbar-tag " + state;
+    el.textContent = text;
+  }
+
+  function scheduleAuxRefresh() {
+    if (auxRefreshTimer) return;
+    auxRefreshTimer = setTimeout(function() {
+      auxRefreshTimer = null;
+      loadAux();
+    }, 750);
+  }
+
+  function loadAux() {
     var errEl = document.getElementById("error");
 
     Promise.all([
-      fetchJSON("/api/snapshot"),
       fetchJSON("/api/history?limit=100"),
       fetchJSON("/api/prs"),
       fetchJSON("/api/sweeps"),
       fetchJSON("/api/cost?days=30")
     ]).then(function(results) {
       errEl.style.display = "none";
-      var snap = results[0], history = results[1], prs = results[2], sweeps = results[3], cost = results[4];
-
-      updateTopbar(snap);
-      renderActive(document.getElementById("active"), snap.active);
-      renderQueued(document.getElementById("queued"), snap.queued);
-      renderSkipped(document.getElementById("skipped"), snap.skipped);
-      renderBudget(document.getElementById("budget"), snap.budget, snap.paused);
+      var history = results[0], prs = results[1], sweeps = results[2], cost = results[3];
 
       renderCost(document.getElementById("cost-panel"), cost);
       renderHistory(document.getElementById("history-panel"), document.getElementById("history-tabs"), history);
@@ -732,7 +813,55 @@
     });
   }
 
-  load();
+  function connectEvents() {
+    if (events) events.close();
+    setConnection("reconnecting", "Connecting");
+    events = new EventSource(authURL("/api/events"));
+    events.addEventListener("open", function() {
+      setConnection("connected", "Live");
+    });
+    events.addEventListener("snapshot", function(ev) {
+      setConnection("connected", "Live");
+      renderSnapshot(JSON.parse(ev.data));
+      scheduleAuxRefresh();
+    });
+    events.addEventListener("error", function() {
+      setConnection("reconnecting", "Reconnecting");
+    });
+  }
+
+  function openLog(id) {
+    if (logEvents) logEvents.close();
+    var card = document.getElementById("log-card");
+    var out = document.getElementById("log-output");
+    document.getElementById("log-title").textContent = "Log: " + id;
+    out.textContent = "";
+    card.style.display = "block";
+    logEvents = new EventSource(authURL("/api/logs/" + encodeURIComponent(id) + "?follow=1"));
+    logEvents.addEventListener("log", function(ev) {
+      out.textContent += JSON.parse(ev.data);
+      out.scrollTop = out.scrollHeight;
+    });
+    logEvents.addEventListener("error", function() {
+      out.textContent += "\n[log stream reconnecting]\n";
+    });
+  }
+
+  document.addEventListener("click", function(ev) {
+    var btn = ev.target.closest("[data-log-id]");
+    if (btn) {
+      openLog(btn.getAttribute("data-log-id"));
+      return;
+    }
+    if (ev.target.id === "close-log") {
+      if (logEvents) logEvents.close();
+      logEvents = null;
+      document.getElementById("log-card").style.display = "none";
+    }
+  });
+
+  connectEvents();
+  loadAux();
 })();
 </script>
 </body>

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -140,6 +140,7 @@ func (p *Pipeline) prPollOnce(ctx context.Context, wg *sync.WaitGroup) {
 		p.active[identifier] = struct{}{}
 		p.cancels[identifier] = ticketCancel
 		p.mu.Unlock()
+		p.publishDashboardChange()
 
 		slog.Info("pr poll detail",
 			"pr", ch.PR.Number, "id", identifier,
@@ -254,6 +255,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	p.mu.Lock()
 	p.activeRepos[identifier] = filepath.Base(resolved.Path)
 	p.mu.Unlock()
+	p.publishDashboardChange()
 
 	wt, err := repo.ResumeWorktree(ctx, p.cfg.WorktreeBase, identifier, resolved.Path)
 	if err != nil {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -69,6 +69,7 @@ type Pipeline struct {
 
 	// Dashboard server — nil when cfg.DashboardAddr is empty.
 	dash *dashboard.Server
+	hub  *dashboard.Hub
 
 	sessionStart time.Time
 
@@ -181,10 +182,13 @@ func New(cfg *config.Config) *Pipeline {
 	// ListenAndServe is deferred to Run (which validates the token).
 	if cfg.DashboardAddr != "" {
 		addr := normalizeDashboardAddr(cfg.DashboardAddr)
+		p.hub = dashboard.NewHub(64)
 		prov := dashboard.Providers{
 			Store:           store,
 			MaxPRIterations: cfg.MaxPRIterations,
 			RepoPaths:       p.resolver.AllRepoPaths,
+			LogDir:          cfg.LogDir,
+			Hub:             p.hub,
 		}
 		if p.sweeper != nil {
 			prov.SweepTasks = sweep.FilterTasks(cfg.SweepTasks)
@@ -485,6 +489,7 @@ func (p *Pipeline) pollOnce(ctx context.Context, wg *sync.WaitGroup) {
 		p.cancels[issue.Identifier] = ticketCancel
 		p.totalDispatches++
 		p.mu.Unlock()
+		p.publishDashboardChange()
 
 		available--
 
@@ -519,13 +524,14 @@ func (p *Pipeline) fetchTickets(ctx context.Context) ([]source.Ticket, error) {
 
 func (p *Pipeline) markDone(id string) {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	delete(p.active, id)
 	if cancel, ok := p.cancels[id]; ok {
 		cancel()
 		delete(p.cancels, id)
 	}
 	delete(p.killed, id)
+	p.mu.Unlock()
+	p.publishDashboardChange()
 }
 
 // isKilled reports whether a ticket was terminated via /kill. Used to skip
@@ -566,9 +572,12 @@ func (p *Pipeline) KillRun(identifier string) error {
 // It returns true if dispatching was already paused.
 func (p *Pipeline) PauseDispatch() bool {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	alreadyPaused := p.paused
 	p.paused = true
+	p.mu.Unlock()
+	if !alreadyPaused {
+		p.publishDashboardChange()
+	}
 	return alreadyPaused
 }
 
@@ -576,9 +585,12 @@ func (p *Pipeline) PauseDispatch() bool {
 // dispatching had been paused.
 func (p *Pipeline) ResumeDispatch() bool {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	wasPaused := p.paused
 	p.paused = false
+	p.mu.Unlock()
+	if wasPaused {
+		p.publishDashboardChange()
+	}
 	return wasPaused
 }
 
@@ -590,16 +602,19 @@ func (p *Pipeline) dispatchPaused() bool {
 
 func (p *Pipeline) bumpFailed(id string) int {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.failedAttempts[id]++
 	p.failCount++
-	return p.failedAttempts[id]
+	attempts := p.failedAttempts[id]
+	p.mu.Unlock()
+	p.publishDashboardChange()
+	return attempts
 }
 
 func (p *Pipeline) bumpSuccess() {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.successCount++
+	p.mu.Unlock()
+	p.publishDashboardChange()
 }
 
 // skipPermanently marks a ticket as permanently skipped (non-transient failure
@@ -610,12 +625,23 @@ func (p *Pipeline) bumpSuccess() {
 // Idempotent: calling multiple times for the same ID only refunds once.
 func (p *Pipeline) skipPermanently(id string) {
 	p.mu.Lock()
-	defer p.mu.Unlock()
+	changed := false
 	if _, ok := p.skipped[id]; !ok {
 		p.skipped[id] = struct{}{}
+		changed = true
 		if p.totalDispatches > 0 {
 			p.totalDispatches-- // refund — config errors shouldn't count
 		}
+	}
+	p.mu.Unlock()
+	if changed {
+		p.publishDashboardChange()
+	}
+}
+
+func (p *Pipeline) publishDashboardChange() {
+	if p.hub != nil {
+		p.hub.Publish()
 	}
 }
 
@@ -626,8 +652,9 @@ func (p *Pipeline) skipPermanently(id string) {
 func (p *Pipeline) flagRateLimit() {
 	if p.cfg.RateLimitStrategy == "shutdown" {
 		p.mu.Lock()
-		defer p.mu.Unlock()
 		p.rateLimitDetected = true
+		p.mu.Unlock()
+		p.publishDashboardChange()
 		return
 	}
 	// Pause strategy: pause dispatching for the cooldown period.
@@ -635,6 +662,7 @@ func (p *Pipeline) flagRateLimit() {
 	p.budget.Pause("rate limit", resumeAt)
 	slog.Info("⏸ rate limit detected — pausing dispatches",
 		"cooldown", p.cfg.RateLimitCooldown, "resume_at", resumeAt.Format(time.RFC3339))
+	p.publishDashboardChange()
 }
 
 // flagBudgetExceeded pauses dispatching until the next UTC midnight when a
@@ -644,6 +672,7 @@ func (p *Pipeline) flagBudgetExceeded(reason string) {
 	p.budget.Pause(reason, resumeAt)
 	slog.Info("⏸ daily budget exceeded — pausing dispatches",
 		"reason", reason, "resume_at", resumeAt.Format(time.RFC3339))
+	p.publishDashboardChange()
 }
 
 // rateLimited reports whether a run should be treated as having hit a usage /

--- a/internal/pipeline/plan.go
+++ b/internal/pipeline/plan.go
@@ -112,6 +112,7 @@ func (p *Pipeline) pollPlanApprovals(ctx context.Context, wg *sync.WaitGroup, av
 		p.cancels[identifier] = ticketCancel
 		p.totalDispatches++
 		p.mu.Unlock()
+		p.publishDashboardChange()
 
 		// Remove the plan-confirm label if it's a per-ticket label.
 		if issue.HasLabel(p.cfg.PlanConfirmLabel) {

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -134,6 +134,7 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	p.mu.Lock()
 	p.activeRepos[id] = filepath.Base(resolved.Path)
 	p.mu.Unlock()
+	p.publishDashboardChange()
 
 	// ── Create worktree ──────────────────────────────────────────────────────
 	wt, err := repo.CreateWorktree(ctx, p.cfg.WorktreeBase, id, resolved.Path, resolved.MainBranch)
@@ -712,8 +713,9 @@ func (p *Pipeline) resolveNoChanges(ctx context.Context, ticket source.Ticket, b
 
 func (p *Pipeline) markSkipped(id string) {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.skipped[id] = struct{}{}
+	p.mu.Unlock()
+	p.publishDashboardChange()
 }
 
 func (p *Pipeline) ticketSource(ticket source.Ticket) source.TicketSource {
@@ -955,5 +957,7 @@ func (p *Pipeline) recordRun(rec state.RunHistory) {
 	}
 	if err := p.store.InsertRunHistory(rec); err != nil {
 		slog.Warn("record run history failed", "id", rec.Identifier, "status", rec.Status, "err", err)
+		return
 	}
+	p.publishDashboardChange()
 }

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -119,6 +119,7 @@ func (p *Pipeline) sweepOnce(ctx context.Context, wg *sync.WaitGroup) {
 		p.activeRepos[identifier] = job.RepoSlug
 		p.cancels[identifier] = taskCancel
 		p.mu.Unlock()
+		p.publishDashboardChange()
 
 		wg.Add(1)
 		go func(j sweep.Job, id string) {


### PR DESCRIPTION
## ENG-275: Dashboard P2 — live SSE updates + log tail follow

**Ticket:** https://linear.app/amazz/issue/ENG-275/dashboard-p2-live-sse-updates-log-tail-follow

## What was implemented

Implemented live dashboard SSE updates with a bounded in-process hub, `/api/events` initial snapshot streaming, and pipeline publish hooks for dispatch, finish, retry, skip, pause/resume, budget/rate-limit, sweep, and PR iteration lifecycle changes.

Added `/api/logs/{id}?follow=1` SSE log following with token query auth, bounded initial tail, rate-limited append polling, and `agent.OffsetBefore` / `agent.ReadAfter` for tail reads. Updated the frontend to use `EventSource`, show live connection status, and open per-run live log panes.

Added hub fan-out/unsubscribe/cap tests plus SSE snapshot and log auth/tail tests. Verified with `go test ./...`, `go vet ./...`, and `golangci-lint run` clean.

---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using OpenAI Codex*
<!-- noctra-authored -->