### PR TITLE
feat: capture real token/cost usage from agent backends

### DIFF
--- a/internal/agent/antigravity.go
+++ b/internal/agent/antigravity.go
@@ -15,8 +15,9 @@ func (antigravityBackend) Label() string    { return "Google Antigravity" }
 func (antigravityBackend) CLI() string      { return "agy" }
 func (antigravityBackend) CoAuthor() string { return "Antigravity <noreply@google.com>" }
 
-func (b antigravityBackend) Run(ctx context.Context, opts RunOptions) error {
-	return runCLI(ctx, b.CLI(), antigravityArgs(opts), nil, opts)
+func (b antigravityBackend) Run(ctx context.Context, opts RunOptions) (Usage, error) {
+	out, err := runCLI(ctx, b.CLI(), antigravityArgs(opts), nil, opts)
+	return ParseUsage(out), err
 }
 
 // antigravityArgs builds the argv for an agy run. Unlike Claude's boolean

--- a/internal/agent/backend.go
+++ b/internal/agent/backend.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -49,10 +51,11 @@ type Backend interface {
 	// Contributors-graph entry; others render as a plain name on the commit.
 	// Returns "" if no trailer should be added.
 	CoAuthor() string
-	// Run invokes the CLI in opts.Workdir, streaming stdout+stderr to
-	// opts.LogFile. It returns ErrTimedOut (wrapped) on per-attempt timeout
-	// and the underlying error on any other non-zero exit.
-	Run(ctx context.Context, opts RunOptions) error
+	// Run invokes the CLI in opts.Workdir, writing output to opts.LogFile, and
+	// returns the run's token/cost Usage (zero-valued when the CLI reports
+	// none). It returns ErrTimedOut (wrapped) on per-attempt timeout and the
+	// underlying error on any other non-zero exit.
+	Run(ctx context.Context, opts RunOptions) (Usage, error)
 	// HasRateLimit reports whether output contains this backend's usage /
 	// rate-limit markers.
 	HasRateLimit(output string) bool
@@ -76,12 +79,9 @@ func New(name string) (Backend, error) {
 	}
 }
 
-// runCLI is the shared exec plumbing for every backend: it applies the
-// per-attempt timeout, writes the DEBUG header so the log carries enough
-// context to diagnose a run, streams stdout+stderr to the log file, and maps a
-// deadline kill to ErrTimedOut. bin/args are the backend-specific command; env
-// is the full process environment to run with (pass nil to inherit os.Environ).
-func runCLI(ctx context.Context, bin string, args, env []string, opts RunOptions) error {
+// runCLI applies the timeout, writes the DEBUG header, streams output to the
+// log, and returns it. For backends whose CLIs print usage in their text output.
+func runCLI(ctx context.Context, bin string, args, env []string, opts RunOptions) (string, error) {
 	if opts.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
@@ -90,28 +90,66 @@ func runCLI(ctx context.Context, bin string, args, env []string, opts RunOptions
 
 	logF, err := os.OpenFile(opts.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return fmt.Errorf("open log: %w", err)
+		return "", fmt.Errorf("open log: %w", err)
 	}
 	defer logF.Close()
 
 	branch, _ := currentBranch(ctx, opts.Workdir)
 	fmt.Fprintf(logF, "DEBUG: pwd = %s\nDEBUG: branch = %s\n", opts.Workdir, branch)
 
+	var buf bytes.Buffer
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = opts.Workdir
-	cmd.Stdout = logF
-	cmd.Stderr = logF
+	cmd.Stdout = io.MultiWriter(logF, &buf)
+	cmd.Stderr = io.MultiWriter(logF, &buf)
 	if env != nil {
 		cmd.Env = env
 	}
 
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("%w: %w", ErrTimedOut, err)
+			return buf.String(), fmt.Errorf("%w: %w", ErrTimedOut, err)
 		}
-		return err
+		return buf.String(), err
 	}
-	return nil
+	return buf.String(), nil
+}
+
+// runCLICapture captures stdout/stderr without streaming to the log, for
+// backends that must unwrap their output before writing it (Claude JSON mode).
+func runCLICapture(ctx context.Context, bin string, args, env []string, opts RunOptions) (stdout, stderr string, err error) {
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
+	var outBuf, errBuf bytes.Buffer
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = opts.Workdir
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	if env != nil {
+		cmd.Env = env
+	}
+
+	runErr := cmd.Run()
+	if runErr != nil && ctx.Err() == context.DeadlineExceeded {
+		runErr = fmt.Errorf("%w: %w", ErrTimedOut, runErr)
+	}
+	return outBuf.String(), errBuf.String(), runErr
+}
+
+// writeRunLog appends the DEBUG header + body, matching runCLI's log format.
+func writeRunLog(ctx context.Context, opts RunOptions, body string) {
+	logF, err := os.OpenFile(opts.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer logF.Close()
+	branch, _ := currentBranch(ctx, opts.Workdir)
+	fmt.Fprintf(logF, "DEBUG: pwd = %s\nDEBUG: branch = %s\n", opts.Workdir, branch)
+	fmt.Fprintln(logF, strings.TrimRight(body, "\n"))
 }
 
 func currentBranch(ctx context.Context, workdir string) (string, error) {

--- a/internal/agent/backend_test.go
+++ b/internal/agent/backend_test.go
@@ -91,6 +91,10 @@ func TestClaudeArgs_PassesPromptInPrintMode(t *testing.T) {
 	if i < 0 || i+1 >= len(args) || args[i+1] != "do the thing" {
 		t.Errorf("claudeArgs did not pass prompt after -p: %v", args)
 	}
+	// JSON output is required for usage/cost capture.
+	if of := slices.Index(args, "--output-format"); of < 0 || of+1 >= len(args) || args[of+1] != "json" {
+		t.Errorf("claudeArgs must request --output-format json: %v", args)
+	}
 }
 
 func TestCodexArgs_UsesExecAndPositionalPrompt(t *testing.T) {

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -15,14 +15,23 @@ func (claudeBackend) Label() string    { return "Claude Code" }
 func (claudeBackend) CLI() string      { return "claude" }
 func (claudeBackend) CoAuthor() string { return "Claude <noreply@anthropic.com>" }
 
-// Run invokes `claude --print` in opts.Workdir. When UseAgentTeams is set the
-// experimental agent-teams flag is exported into the child environment.
-func (b claudeBackend) Run(ctx context.Context, opts RunOptions) error {
+// Run invokes `claude --print --output-format json`, unwrapping the JSON result
+// into the log so the log's text consumers see the message, and returns the
+// usage/cost from the envelope. Falls back to raw output (errors, rate-limit
+// messages, text mode) when stdout isn't a JSON result object.
+func (b claudeBackend) Run(ctx context.Context, opts RunOptions) (Usage, error) {
 	var env []string
 	if opts.UseAgentTeams {
 		env = append(os.Environ(), "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1")
 	}
-	return runCLI(ctx, b.CLI(), claudeArgs(opts), env, opts)
+	stdout, stderr, err := runCLICapture(ctx, b.CLI(), claudeArgs(opts), env, opts)
+
+	if usage, result, ok := ParseClaudeJSON(stdout); ok {
+		writeRunLog(ctx, opts, result+stderr)
+		return usage, err
+	}
+	writeRunLog(ctx, opts, stdout+stderr)
+	return ParseUsage(stdout + "\n" + stderr), err
 }
 
 // claudeArgs builds the argv for a Claude Code run. Split out from Run so the
@@ -31,7 +40,7 @@ func claudeArgs(opts RunOptions) []string {
 	return []string{
 		"--dangerously-skip-permissions",
 		"--print",
-		"--output-format", "text",
+		"--output-format", "json",
 		"-p", opts.Prompt,
 	}
 }

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -22,9 +22,10 @@ func (codexBackend) CoAuthor() string { return "Codex <noreply@openai.com>" }
 
 // Run invokes `codex exec` in opts.Workdir. UseAgentTeams is Claude-only and
 // is ignored here.
-func (b codexBackend) Run(ctx context.Context, opts RunOptions) error {
+func (b codexBackend) Run(ctx context.Context, opts RunOptions) (Usage, error) {
 	// nil env → inherit os.Environ (so OPENAI_API_KEY / login state flow through).
-	return runCLI(ctx, b.CLI(), codexArgs(opts), nil, opts)
+	out, err := runCLI(ctx, b.CLI(), codexArgs(opts), nil, opts)
+	return ParseUsage(out), err
 }
 
 // codexArgs builds the argv for a Codex run. `exec` is Codex's non-interactive

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -28,8 +28,9 @@ func (copilotBackend) CoAuthor() string {
 
 // Run invokes `copilot --allow-all-tools --no-ask-user -p <prompt>` in opts.Workdir.
 // UseAgentTeams is Claude-only and is ignored here.
-func (b copilotBackend) Run(ctx context.Context, opts RunOptions) error {
-	return runCLI(ctx, b.CLI(), copilotArgs(opts), copilotEnv(ctx), opts)
+func (b copilotBackend) Run(ctx context.Context, opts RunOptions) (Usage, error) {
+	out, err := runCLI(ctx, b.CLI(), copilotArgs(opts), copilotEnv(ctx), opts)
+	return ParseUsage(out), err
 }
 
 // copilotEnv bridges a GitHub token into the Copilot CLI's environment. Copilot

--- a/internal/agent/usage.go
+++ b/internal/agent/usage.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"regexp"
 	"strconv"
 	"strings"
@@ -63,4 +64,39 @@ func ParseUsage(output string) Usage {
 func parseCommaInt(s string) int64 {
 	n, _ := strconv.ParseInt(strings.ReplaceAll(s, ",", ""), 10, 64)
 	return n
+}
+
+type claudeResult struct {
+	Type         string  `json:"type"`
+	Result       string  `json:"result"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	Usage        struct {
+		InputTokens              int64 `json:"input_tokens"`
+		OutputTokens             int64 `json:"output_tokens"`
+		CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	} `json:"usage"`
+}
+
+// ParseClaudeJSON parses Claude Code's `--output-format json` result object,
+// returning the usage and the message text. ok is false when stdout isn't a
+// JSON result object (an error, a rate-limit message, or text mode), so the
+// caller can fall back to regex parsing. total_cost_usd is a client-side
+// estimate, populated even on subscription auth.
+func ParseClaudeJSON(stdout string) (usage Usage, result string, ok bool) {
+	s := strings.TrimSpace(stdout)
+	if !strings.HasPrefix(s, "{") {
+		return Usage{}, "", false
+	}
+	var r claudeResult
+	if err := json.Unmarshal([]byte(s), &r); err != nil || r.Type != "result" {
+		return Usage{}, "", false
+	}
+	in := r.Usage.InputTokens + r.Usage.CacheCreationInputTokens + r.Usage.CacheReadInputTokens
+	return Usage{
+		InputTokens:  in,
+		OutputTokens: r.Usage.OutputTokens,
+		TotalTokens:  in + r.Usage.OutputTokens,
+		CostUSD:      r.TotalCostUSD,
+	}, r.Result, true
 }

--- a/internal/agent/usage_test.go
+++ b/internal/agent/usage_test.go
@@ -67,6 +67,44 @@ func TestParseUsage_CaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestParseClaudeJSON_ResultObject(t *testing.T) {
+	out := `{"type":"result","subtype":"success","result":"Done. BLOCKED: nothing.","total_cost_usd":0.4213,"usage":{"input_tokens":1200,"output_tokens":3400,"cache_creation_input_tokens":500,"cache_read_input_tokens":800}}`
+	u, result, ok := ParseClaudeJSON(out)
+	if !ok {
+		t.Fatal("expected ok=true for a JSON result object")
+	}
+	if result != "Done. BLOCKED: nothing." {
+		t.Errorf("result: got %q", result)
+	}
+	if u.OutputTokens != 3400 {
+		t.Errorf("OutputTokens: got %d, want 3400", u.OutputTokens)
+	}
+	if u.InputTokens != 1200+500+800 {
+		t.Errorf("InputTokens (incl cache): got %d, want 2500", u.InputTokens)
+	}
+	if u.TotalTokens != 2500+3400 {
+		t.Errorf("TotalTokens: got %d, want 5900", u.TotalTokens)
+	}
+	if u.CostUSD != 0.4213 {
+		t.Errorf("CostUSD: got %f, want 0.4213", u.CostUSD)
+	}
+}
+
+func TestParseClaudeJSON_NotJSON(t *testing.T) {
+	for _, out := range []string{"plain text output\n", "", "  ", "Error: rate limit exceeded"} {
+		if _, _, ok := ParseClaudeJSON(out); ok {
+			t.Errorf("expected ok=false for non-JSON output %q", out)
+		}
+	}
+}
+
+func TestParseClaudeJSON_WrongType(t *testing.T) {
+	// A stream event, not the final result object → fall back to regex parsing.
+	if _, _, ok := ParseClaudeJSON(`{"type":"assistant","message":{}}`); ok {
+		t.Error("expected ok=false for a non-result JSON object")
+	}
+}
+
 func TestParseCommaInt(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -316,7 +316,7 @@
       <div id="tokencost"></div>
     </section>
     <section class="panel chart" style="flex:1 1 300px">
-      <div class="phead"><span class="ptitle">Spend by agent</span><span class="kicker right">today</span></div>
+      <div class="phead"><span class="ptitle">Spend by agent</span><span class="kicker right">today · est.</span></div>
       <div id="spend"></div>
     </section>
   </div>
@@ -518,7 +518,7 @@
     var agentName = active.length ? agentInfo(active[0].agent).name : "";
     var activeSub = active.length === 0 ? "idle" : (active.length === 1 ? agentName + " live" : active.length + " agents live");
 
-    var costSub = b.MaxDailyUSD > 0 ? "of " + fmtMoney(b.MaxDailyUSD) + " cap" : "today";
+    var costSub = b.MaxDailyUSD > 0 ? "est. of " + fmtMoney(b.MaxDailyUSD) + " cap" : "est. today";
 
     var kpis = [
       { label: "PRs opened",   value: String(prs14.length), sub: "last 14 days",   accent: "var(--blue)" },

--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -351,7 +351,7 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 
 	headBefore := gitHead(ctx, wt.Path)
 
-	runErr := backend.Run(ctx, agent.RunOptions{
+	usage, runErr := backend.Run(ctx, agent.RunOptions{
 		Workdir:       wt.Path,
 		Prompt:        prompt,
 		LogFile:       logFile,
@@ -383,7 +383,6 @@ func (p *Pipeline) iteratePR(ctx context.Context, ch watch.PRChanges, identifier
 	output := agent.ReadAfter(logFile, offset)
 
 	// Record usage from the iteration (ENG-217).
-	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
 	p.recordUsage(usage, "iterate", identifier, ch.PR.URL, backend)
 	// Check budget caps immediately after recording — if exceeded, the pause

--- a/internal/pipeline/plan.go
+++ b/internal/pipeline/plan.go
@@ -249,7 +249,7 @@ func (p *Pipeline) processPlanOnly(ctx context.Context, issue source.Ticket) {
 
 	offset := agent.OffsetBefore(logFile)
 
-	runErr := backend.Run(ctx, agent.RunOptions{
+	usage, runErr := backend.Run(ctx, agent.RunOptions{
 		Workdir: wt.Path,
 		Prompt:  prompt,
 		LogFile: logFile,
@@ -271,7 +271,6 @@ func (p *Pipeline) processPlanOnly(ctx context.Context, issue source.Ticket) {
 	output := agent.ReadAfter(logFile, offset)
 
 	// Record usage from the plan pass (ENG-217).
-	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
 	p.recordUsage(usage, "plan", id, "", backend)
 	if reason := p.budget.ExceededReason(); reason != "" {

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -186,7 +186,7 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	// BLOCKED / rate-limit checks only inspect this attempt's output.
 	offset := agent.OffsetBefore(logFile)
 
-	runErr := backend.Run(ctx, agent.RunOptions{
+	usage, runErr := backend.Run(ctx, agent.RunOptions{
 		Workdir:       wt.Path,
 		Prompt:        prompt,
 		LogFile:       logFile,
@@ -229,7 +229,6 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 	output := agent.ReadAfter(logFile, offset)
 
 	// ── Record usage (ENG-217) ───────────────────────────────────────────────
-	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
 	p.recordUsage(usage, "ticket", id, "", backend)
 	if usage.TotalTokens > 0 || usage.CostUSD > 0 {
@@ -428,7 +427,7 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 
 				logger.Info("asking the agent to fix review issues")
 				fixOffset := agent.OffsetBefore(logFile)
-				fixErr := backend.Run(ctx, agent.RunOptions{
+				fixUsage, fixErr := backend.Run(ctx, agent.RunOptions{
 					Workdir:       wt.Path,
 					Prompt:        fixPrompt,
 					LogFile:       logFile,
@@ -449,7 +448,6 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 
 				fixOutput := agent.ReadAfter(logFile, fixOffset)
 
-				fixUsage := agent.ParseUsage(fixOutput)
 				p.budget.Record(fixUsage.TotalTokens, fixUsage.CostUSD)
 				p.recordUsage(fixUsage, "ticket", id, "", backend)
 				if reason := p.budget.ExceededReason(); reason != "" {

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -169,7 +169,7 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 		"log", logFile,
 		"timeout", p.cfg.AgentTimeout)
 
-	runErr := backend.Run(ctx, agent.RunOptions{
+	usage, runErr := backend.Run(ctx, agent.RunOptions{
 		Workdir: wt.Path,
 		Prompt:  prompt,
 		LogFile: logFile,
@@ -193,7 +193,6 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 
 	output := agent.ReadAfter(logFile, offset)
 
-	usage := agent.ParseUsage(output)
 	p.budget.Record(usage.TotalTokens, usage.CostUSD)
 	p.recordUsage(usage, "sweep", identifier, "", backend)
 	if usage.TotalTokens > 0 || usage.CostUSD > 0 {
@@ -343,7 +342,7 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 
 				logger.Info("asking the agent to fix review issues")
 				fixOffset := agent.OffsetBefore(logFile)
-				fixErr := backend.Run(ctx, agent.RunOptions{
+				fixUsage, fixErr := backend.Run(ctx, agent.RunOptions{
 					Workdir: wt.Path,
 					Prompt:  fixPrompt,
 					LogFile: logFile,
@@ -361,7 +360,6 @@ func (p *Pipeline) processSweepTask(ctx context.Context, job sweep.Job, identifi
 
 				fixOutput := agent.ReadAfter(logFile, fixOffset)
 
-				fixUsage := agent.ParseUsage(fixOutput)
 				p.budget.Record(fixUsage.TotalTokens, fixUsage.CostUSD)
 				p.recordUsage(fixUsage, "sweep", identifier, "", backend)
 				if reason := p.budget.ExceededReason(); reason != "" {


### PR DESCRIPTION
## Why
The dashboard showed **$0 spent / 0 tokens** even after runs. Root cause: Claude was invoked with `--output-format text`, which prints only the final message — no token/cost footer. `ParseUsage` regex-scanned that text, found nothing, and recorded `(0 tokens, $0)` for every Claude run. (The occasional token spike on the chart was a **Codex** run, whose `tokens used:` footer the regex *does* catch — but Codex prints no dollar amount, so cost stayed $0 there too.)

## What
Make `Backend.Run` return a structured `Usage`, so each backend extracts its own usage instead of the pipeline regex-scanning the log tail:

- **Claude** now runs `--output-format json` and parses the result envelope: `usage` (input/output + cache tokens) and `total_cost_usd`. The JSON is **unwrapped** — only the message text is written to the log — so the existing text consumers (`ExtractSummary`, `BlockedLine`, `ExtractFindingReplies`, release-bump, rate-limit detection) and the dashboard log tail are unchanged. Falls back to raw output + regex on errors, rate-limit messages, or non-JSON. `json` mode is inherently non-streaming, so no live tail is lost that text mode had.
- **Codex / Copilot / Antigravity** keep streaming and regex-parse their own output (Codex's `tokens used` footer still works). Their coverage is **bounded by what each CLI prints** — see Limitations.

## Honest limitations
- `total_cost_usd` is a **client-side estimate** (per Anthropic's own docs, "not authoritative billing"), and on a **subscription there's no per-call dollar cost**. So the dashboard now labels cost **"est."** (spend-by-agent + cost-today) rather than implying real spend. The truthful primary metric on a subscription is **tokens**.
- Codex/Copilot/Antigravity only report what their CLIs expose today (Codex: tokens; the others: likely neither). The new mechanism is per-backend, so wiring their structured/JSON modes is a clean follow-up once each is verified the way Claude's schema was.

## Testing
- `go build`, `go vet`, `go test ./...`, `gofmt` — clean.
- New tests: `ParseClaudeJSON` (result object → tokens incl. cache + cost + message; non-JSON and wrong-type → fall back), and a guard that `claudeArgs` requests `--output-format json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)