### PR TITLE
fix: sweep PRs respect intended base branch (ENG-314)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -246,6 +246,9 @@ SWEEP_ENABLED=false
 SWEEP_TASKS=
 # Comma-separated repos to sweep (owner/name or git URLs, cloned on demand).
 # Empty = every repo Noctra has already cloned from tickets.
+# Append "@branch" to target a base branch other than the repo's default, e.g.
+# "acme/app@staging". Without it, Noctra uses the matching Linear project's
+# "Branch:" directive, then the repo's GitHub default branch.
 SWEEP_REPOS=
 # When to run: a cron expression (e.g. "0 0 * * *" = every day at midnight).
 # Empty = use the fixed SWEEP_INTERVAL below instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ sweep loop → scheduler.DueIn (cron SWEEP_SCHEDULE or fixed SWEEP_INTERVAL) →
 - Each task type has a per-repo **cooldown** persisted in the state file (`state.SweepState`), so the same task doesn't re-run before its cooldown expires (e.g. lint-cleanup has a 7-day cooldown).
 - Sweep branches use the `noctra/sweep-<suffix>` prefix (e.g. `noctra/sweep-lint-cleanup`), distinct from ticket-driven `noctra/<identifier>`. Auto-iterate picks them up because sweep PR bodies carry the same hidden `NoctraPRBodyMarker` as ticket PRs (they match the `noctra/*` prefix and `IsNoctraAuthoredBody`). Before the marker fix they were silently skipped — the watcher matched a footer string sweep PRs didn't share.
 - Sweep PRs get a `maintenance` label so humans can identify and bulk-close them.
+- **Base branch** a sweep PR targets (and the worktree branches from) is resolved with precedence: (1) an `@branch` suffix on the `SWEEP_REPOS` entry (`scheduler.parseSweepRepoRef`); (2) the matching Linear project's `Branch:` directive (`linear.ListProjects` → `Project.RepoDirective`, matched by `github.ExtractOwnerRepo`; applies to both `SWEEP_REPOS` entries and discovery-path repos, the latter keyed off their `origin` remote via `repo.OriginRemoteOf`); (3) the repo's GitHub default branch (`origin/HEAD`); (4) `MAIN_BRANCH`. Resolved in `scheduler.repoTargets`/`Plan` into `Job.MainBranch`, which feeds the worktree base, `branchAhead` compare, and `gh pr create` base together. Before this, sweeps discarded the resolved branch and always targeted `origin/HEAD`.
 - Sweep identifiers follow the `SWEEP-<repo-slug>-<task-suffix>` pattern for worktree directories and active-set dedup.
 - Task catalog lives in `internal/sweep/task_*.go` — each file registers a task at init time. Current tasks: `lint-cleanup` (weekly), `dead-code` (biweekly), `deps-update` (weekly), `test-coverage` (biweekly), `doc-drift` (biweekly), `modernize` (biweekly), and `bug-scan` (biweekly — scoped to high-confidence defects only). Scope sweeps with `SWEEP_TASKS`.
 
@@ -70,7 +71,7 @@ sweep loop → scheduler.DueIn (cron SWEEP_SCHEDULE or fixed SWEEP_INTERVAL) →
 | `SWEEP_INTERVAL` | `86400` (24h) | Seconds between sweep cycles (fallback when no cron). Interval mode fires immediately on startup; cron mode waits for the next matching time |
 | `SWEEP_MAX_TASKS` | `5` | Max tasks per sweep run |
 | `SWEEP_TASKS` | (all) | Comma-separated task names to enable (e.g. `lint-cleanup,dead-code`) |
-| `SWEEP_REPOS` | (all cloned) | Comma-separated `owner/name` or git URLs to sweep, resolved via `repo.ResolveDirect` (clone-on-demand). When set, **replaces** the `AllRepoPaths()` discovery; unresolvable entries warn and are skipped. Empty = every cloned repo |
+| `SWEEP_REPOS` | (all cloned) | Comma-separated `owner/name` or git URLs to sweep, resolved via `repo.ResolveDirect` (clone-on-demand). When set, **replaces** the `AllRepoPaths()` discovery; unresolvable entries warn and are skipped. Empty = every cloned repo. Each entry may pin a base branch with an `@branch` suffix (e.g. `owner/name@staging`, also on full URLs / scp `git@host:owner/name@staging`) — see the base-branch precedence under the sweep loop |
 
 ## Multi-repo
 

--- a/internal/linear/operations.go
+++ b/internal/linear/operations.go
@@ -348,6 +348,43 @@ func (c *Client) SearchIssues(ctx context.Context, term string, limit int) ([]Is
 	return resp.Issues.Nodes, nil
 }
 
+// ListProjects returns every visible project with its description/content.
+func (c *Client) ListProjects(ctx context.Context) ([]Project, error) {
+	query := `query($after: String) {
+	  projects(first: 250, after: $after) {
+	    nodes { name description content }
+	    pageInfo { hasNextPage endCursor }
+	  }
+	}`
+
+	var out []Project
+	after := ""
+	for {
+		var resp struct {
+			Projects struct {
+				Nodes    []Project `json:"nodes"`
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+			} `json:"projects"`
+		}
+		vars := map[string]any{}
+		if after != "" {
+			vars["after"] = after
+		}
+		if err := c.Do(ctx, query, vars, &resp); err != nil {
+			return nil, err
+		}
+		out = append(out, resp.Projects.Nodes...)
+		if !resp.Projects.PageInfo.HasNextPage || resp.Projects.PageInfo.EndCursor == "" {
+			break
+		}
+		after = resp.Projects.PageInfo.EndCursor
+	}
+	return out, nil
+}
+
 // FetchLabeledIssues returns every issue carrying the named label across all visible teams (label-mode counterpart of FetchTriggerIssues).
 func (c *Client) FetchLabeledIssues(ctx context.Context, labelName string) ([]Issue, error) {
 	query := `query($label: String!) {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -147,7 +147,11 @@ func New(cfg *config.Config) *Pipeline {
 					schedule = parsed
 				}
 			}
-			p.sweeper = sweep.NewScheduler(store, p.resolver, tasks, cfg.SweepInterval, cfg.SweepMaxTasks, schedule, cfg.SweepRepos)
+			sched := sweep.NewScheduler(store, p.resolver, tasks, cfg.SweepInterval, cfg.SweepMaxTasks, schedule, cfg.SweepRepos)
+			if p.linear != nil {
+				sched.SetDirectiveBranchResolver(p.branchFromLinearDirective)
+			}
+			p.sweeper = sched
 		}
 	}
 

--- a/internal/pipeline/sweep.go
+++ b/internal/pipeline/sweep.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -70,6 +71,28 @@ func (p *Pipeline) runSweepLoop(ctx context.Context, wg *sync.WaitGroup) {
 		p.sweepOnce(ctx, wg)
 		p.sweeper.MarkSwept()
 	}
+}
+
+func (p *Pipeline) branchFromLinearDirective(ctx context.Context, ref string) string {
+	want, err := github.ExtractOwnerRepo(ref)
+	if err != nil {
+		return ""
+	}
+	projects, err := p.linear.ListProjects(ctx)
+	if err != nil {
+		slog.Warn("sweep: could not list Linear projects for branch directive", "err", err)
+		return ""
+	}
+	for i := range projects {
+		r, b := projects[i].RepoDirective()
+		if r == "" || b == "" {
+			continue
+		}
+		if got, err := github.ExtractOwnerRepo(r); err == nil && strings.EqualFold(got, want) {
+			return b
+		}
+	}
+	return ""
 }
 
 // sweepOnce runs one sweep cycle: plan eligible jobs and dispatch them.

--- a/internal/repo/resolve.go
+++ b/internal/repo/resolve.go
@@ -215,6 +215,15 @@ func (r *Resolver) AllRepoPaths() []string {
 	return out
 }
 
+// OriginRemoteOf returns a clone's `origin` URL, or "" if it can't be read.
+func OriginRemoteOf(ctx context.Context, repoPath string) string {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // AllRepoRemotes returns the `origin` URL of every AllRepoPaths repo, so the PR watcher knows which repos to scan (derived from on-disk clones, since routing is registry-free). Reads run concurrently under ctx — a hung `git` mustn't block the poll loop or outlive its timeout; fixed indices keep order stable without a lock.
 func (r *Resolver) AllRepoRemotes(ctx context.Context) []string {
 	paths := r.AllRepoPaths()
@@ -228,10 +237,7 @@ func (r *Resolver) AllRepoRemotes(ctx context.Context) []string {
 		wg.Add(1)
 		go func(idx int, path string) {
 			defer wg.Done()
-			out, err := exec.CommandContext(ctx, "git", "-C", path, "remote", "get-url", "origin").Output()
-			if err == nil {
-				urls[idx] = strings.TrimSpace(string(out))
-			}
+			urls[idx] = OriginRemoteOf(ctx, path)
 		}(i, p)
 	}
 	wg.Wait()

--- a/internal/sweep/scheduler.go
+++ b/internal/sweep/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/ahmadAlMezaal/noctra/internal/repo"
@@ -32,6 +33,13 @@ type Scheduler struct {
 	lastRef       time.Time
 	nextScheduled time.Time
 	repoRotation  int
+
+	directiveBranch func(context.Context, string) string
+}
+
+// SetDirectiveBranchResolver installs the Linear "Branch:" directive base-branch fallback.
+func (s *Scheduler) SetDirectiveBranchResolver(fn func(context.Context, string) string) {
+	s.directiveBranch = fn
 }
 
 func NewScheduler(store *state.Store, resolver RepoResolver, tasks []Task, interval time.Duration, maxTasks int, schedule *CronSchedule, sweepRepos []string) *Scheduler {
@@ -94,15 +102,34 @@ func (s *Scheduler) MarkSwept() {
 	s.lastSweep = s.now()
 }
 
-// repoPaths returns the explicit SWEEP_REPOS list (resolved/cloned on demand) when set, else every cloned repo.
-func (s *Scheduler) repoPaths(ctx context.Context) []string {
+type repoTarget struct {
+	path   string
+	branch string
+}
+
+func (s *Scheduler) repoTargets(ctx context.Context) []repoTarget {
 	if len(s.sweepRepos) == 0 {
-		return s.resolver.AllRepoPaths()
+		paths := s.resolver.AllRepoPaths()
+		targets := make([]repoTarget, 0, len(paths))
+		for _, p := range paths {
+			branch := ""
+			if s.directiveBranch != nil {
+				if remote := repo.OriginRemoteOf(ctx, p); remote != "" {
+					branch = s.directiveBranch(ctx, remote)
+				}
+			}
+			targets = append(targets, repoTarget{path: p, branch: branch})
+		}
+		return targets
 	}
-	var paths []string
+	var targets []repoTarget
 	seen := make(map[string]bool)
-	for _, ref := range s.sweepRepos {
-		res, err := s.resolver.ResolveDirect(ctx, ref, "")
+	for _, entry := range s.sweepRepos {
+		ref, branch := parseSweepRepoRef(entry)
+		if branch == "" && s.directiveBranch != nil {
+			branch = s.directiveBranch(ctx, ref)
+		}
+		res, err := s.resolver.ResolveDirect(ctx, ref, branch)
 		if err != nil {
 			slog.Warn("sweep: skipping repo it could not resolve", "repo", ref, "err", err)
 			continue
@@ -111,25 +138,44 @@ func (s *Scheduler) repoPaths(ctx context.Context) []string {
 			continue
 		}
 		seen[res.Path] = true
-		paths = append(paths, res.Path)
+		targets = append(targets, repoTarget{path: res.Path, branch: res.MainBranch})
 	}
-	return paths
+	return targets
+}
+
+func parseSweepRepoRef(entry string) (ref, branch string) {
+	entry = strings.TrimSpace(entry)
+	start := 0
+	if i := strings.Index(entry, "://"); i >= 0 {
+		if slash := strings.Index(entry[i+3:], "/"); slash >= 0 {
+			start = i + 3 + slash
+		} else {
+			start = len(entry)
+		}
+	} else if colon := strings.Index(entry, ":"); colon >= 0 && strings.Contains(entry[:colon], "@") {
+		start = colon
+	}
+	if at := strings.LastIndex(entry[start:], "@"); at >= 0 {
+		idx := start + at
+		return entry[:idx], entry[idx+1:]
+	}
+	return entry, ""
 }
 
 // Plan returns eligible (repo, task) jobs (≤ maxTasks); a task is eligible once its per-repo cooldown has expired.
 func (s *Scheduler) Plan(ctx context.Context) []Job {
-	repoPaths := s.repoPaths(ctx)
-	if len(repoPaths) == 0 {
+	targets := s.repoTargets(ctx)
+	if len(targets) == 0 {
 		slog.Debug("sweep: no repos to sweep")
 		return nil
 	}
 
 	var groups [][]Job
-	for _, rp := range repoPaths {
+	for _, t := range targets {
 		if ctx.Err() != nil {
 			break
 		}
-		slug := repo.SlugFromPath(rp)
+		slug := repo.SlugFromPath(t.path)
 		if slug == "" {
 			continue
 		}
@@ -149,10 +195,13 @@ func (s *Scheduler) Plan(ctx context.Context) []Job {
 		if len(eligible) == 0 {
 			continue
 		}
-		mainBranch := repo.DefaultBranchOf(ctx, rp)
+		mainBranch := t.branch
+		if mainBranch == "" {
+			mainBranch = repo.DefaultBranchOf(ctx, t.path)
+		}
 		repoJobs := make([]Job, len(eligible))
 		for i, task := range eligible {
-			repoJobs[i] = Job{Task: task, RepoPath: rp, RepoSlug: slug, MainBranch: mainBranch}
+			repoJobs[i] = Job{Task: task, RepoPath: t.path, RepoSlug: slug, MainBranch: mainBranch}
 		}
 		groups = append(groups, repoJobs)
 	}
@@ -165,7 +214,7 @@ func (s *Scheduler) Plan(ctx context.Context) []Job {
 
 	jobs := roundRobin(groups, s.maxTasks)
 	slog.Info("sweep plan",
-		"repos", len(repoPaths),
+		"repos", len(targets),
 		"tasks", len(s.tasks),
 		"eligible", len(jobs),
 		"max", s.maxTasks)

--- a/internal/sweep/scheduler_test.go
+++ b/internal/sweep/scheduler_test.go
@@ -20,9 +20,12 @@ type fakeResolver struct {
 
 func (f fakeResolver) AllRepoPaths() []string { return f.all }
 
-func (f fakeResolver) ResolveDirect(_ context.Context, ref, _ string) (repo.Resolved, error) {
+func (f fakeResolver) ResolveDirect(_ context.Context, ref, branch string) (repo.Resolved, error) {
 	if p, ok := f.direct[ref]; ok {
-		return repo.Resolved{Path: p, MainBranch: "main"}, nil
+		if branch == "" {
+			branch = "main"
+		}
+		return repo.Resolved{Path: p, MainBranch: branch}, nil
 	}
 	return repo.Resolved{}, fmt.Errorf("unknown repo %q", ref)
 }
@@ -397,5 +400,91 @@ func TestDueIn_CronCachesNextComputation(t *testing.T) {
 	_ = s.DueIn()
 	if !s.nextScheduled.Equal(first) {
 		t.Error("nextScheduled changed without the reference changing (not cached)")
+	}
+}
+
+func TestParseSweepRepoRef(t *testing.T) {
+	cases := []struct {
+		entry, ref, branch string
+	}{
+		{"acme/wanted", "acme/wanted", ""},
+		{"acme/wanted@staging", "acme/wanted", "staging"},
+		{" acme/wanted@staging ", "acme/wanted", "staging"},
+		{"https://github.com/acme/wanted", "https://github.com/acme/wanted", ""},
+		{"https://github.com/acme/wanted@staging", "https://github.com/acme/wanted", "staging"},
+		{"git@github.com:acme/wanted.git", "git@github.com:acme/wanted.git", ""},
+		{"git@github.com:acme/wanted.git@staging", "git@github.com:acme/wanted.git", "staging"},
+		{"ssh://git@github.com/acme/wanted", "ssh://git@github.com/acme/wanted", ""},
+		{"ssh://git@github.com/acme/wanted@staging", "ssh://git@github.com/acme/wanted", "staging"},
+		{"acme/wanted@release/1.2", "acme/wanted", "release/1.2"},
+	}
+	for _, c := range cases {
+		ref, branch := parseSweepRepoRef(c.entry)
+		if ref != c.ref || branch != c.branch {
+			t.Errorf("parseSweepRepoRef(%q) = (%q, %q), want (%q, %q)", c.entry, ref, branch, c.ref, c.branch)
+		}
+	}
+}
+
+func TestPlan_BranchPrecedence(t *testing.T) {
+	wanted := initTestRepo(t, t.TempDir(), "wanted-repo")
+	mkScheduler := func(sweepRepos []string, directive func(context.Context, string) string) *Scheduler {
+		store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+		res := fakeResolver{direct: map[string]string{"acme/wanted": wanted}}
+		s := NewScheduler(store, res, []Task{testTask("t1", time.Hour)}, time.Hour, 5, nil, sweepRepos)
+		if directive != nil {
+			s.SetDirectiveBranchResolver(directive)
+		}
+		return s
+	}
+	planBranch := func(s *Scheduler) string {
+		jobs := s.Plan(context.Background())
+		if len(jobs) != 1 {
+			t.Fatalf("expected 1 job, got %d", len(jobs))
+		}
+		return jobs[0].MainBranch
+	}
+
+	if got := planBranch(mkScheduler([]string{"acme/wanted@override"}, func(context.Context, string) string { return "directive" })); got != "override" {
+		t.Errorf("@branch override: got %q, want %q", got, "override")
+	}
+	if got := planBranch(mkScheduler([]string{"acme/wanted"}, func(context.Context, string) string { return "staging" })); got != "staging" {
+		t.Errorf("directive fallback: got %q, want %q", got, "staging")
+	}
+	if got := planBranch(mkScheduler([]string{"acme/wanted"}, nil)); got != "main" {
+		t.Errorf("default fallback: got %q, want %q", got, "main")
+	}
+}
+
+func TestPlan_DiscoveryDirectiveBranch(t *testing.T) {
+	reposBase := t.TempDir()
+	dir := initTestRepo(t, reposBase, "wanted-repo")
+	addOrigin(t, dir, "https://github.com/acme/wanted")
+
+	store, _ := state.Open(filepath.Join(t.TempDir(), "state.json"))
+	resolver := &repo.Resolver{ReposBase: reposBase}
+	s := NewScheduler(store, resolver, []Task{testTask("t1", time.Hour)}, time.Hour, 5, nil, nil)
+	s.SetDirectiveBranchResolver(func(_ context.Context, ref string) string {
+		if ref == "https://github.com/acme/wanted" {
+			return "staging"
+		}
+		return ""
+	})
+
+	jobs := s.Plan(context.Background())
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].MainBranch != "staging" {
+		t.Errorf("discovery directive branch: got %q, want %q", jobs[0].MainBranch, "staging")
+	}
+}
+
+func addOrigin(t *testing.T, dir, url string) {
+	t.Helper()
+	cmd := exec.Command("git", "remote", "add", "origin", url)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %s: %v", out, err)
 	}
 }


### PR DESCRIPTION
Fixes [ENG-314](https://linear.app/amazz/issue/ENG-314).

## Problem

Sweep maintenance PRs always targeted the repo's **GitHub default branch** (`origin/HEAD`), ignoring any intended base branch. `scheduler.repoPaths()` resolved each repo via `ResolveDirect(ctx, ref, "")` but **discarded** the returned `MainBranch` (kept only the path), and `Plan()` then set `Job.MainBranch = repo.DefaultBranchOf()` (origin/HEAD).

Real failure: a repo whose default branch is `prod` (flow `feature → staging → prod`, Linear project declares `Branch: staging`) received three sweep PRs straight onto `prod`.

## Fix

Base branch is resolved with precedence and propagated into `Job.MainBranch` — which already feeds all three consumers (worktree base in `CreateWorktreeWithBranch`, the `branchAhead` compare, and the `gh pr create` base), so fixing population fixes all of them:

1. **`@branch` suffix** on a `SWEEP_REPOS` entry — `owner/name@staging`, full URLs, and scp-style `git@host:owner/name@staging` (parsed by `parseSweepRepoRef`, which skips user@host authorities so SSH refs without an override aren't misread).
2. **Linear project `Branch:` directive** — new `linear.ListProjects` + existing `Project.RepoDirective`, matched via `github.ExtractOwnerRepo`. Applies to **both** explicit `SWEEP_REPOS` entries **and** the all-cloned-repos discovery path (the latter keyed off each clone's `origin` remote via the new `repo.OriginRemoteOf`).
3. **Repo's GitHub default branch** (`origin/HEAD`) — prior behavior.
4. **`MAIN_BRANCH`** config default.

## Scope decisions

- Fix 2's directive fallback covers the **discovery path** too (not just `SWEEP_REPOS`), so it fixes setups that rely on cloned-repo discovery + a Linear `Branch:` directive.
- The directive lookup is best-effort and only active when a Linear client is configured; any error falls through to `origin/HEAD`. It calls `ListProjects` per swept repo per plan (daily cadence, a handful of repos) — could be memoized per-plan later if needed.

## Tests

`internal/sweep/scheduler_test.go`:
- `TestParseSweepRepoRef` — `owner/name`, `@branch`, full/scp/ssh URLs (with and without override), `release/1.2` branch names, whitespace.
- `TestPlan_BranchPrecedence` — `@branch` > directive > origin/HEAD fallback.
- `TestPlan_DiscoveryDirectiveBranch` — discovery-path repo resolves its branch from the directive via its `origin` remote.

## Docs

- `.env.example` — documents the `SWEEP_REPOS` `@branch` syntax + fallback order.
- `CLAUDE.md` — `SWEEP_REPOS` row + a base-branch precedence bullet in the sweep section.

(README has no sweep-config section and no skill documents `SWEEP_REPOS`, so nothing to update there.)

`go build ./...`, `go vet ./...`, `gofmt -l`, and `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)