### PR TITLE
feat: surface the agent's error reason in failure notifications (ENG-316)

### DIFF
--- a/internal/agent/log.go
+++ b/internal/agent/log.go
@@ -44,6 +44,35 @@ func ReadAfter(logFile string, offset int64) string {
 	return string(b)
 }
 
+var secretRe = regexp.MustCompile(`(?i)(sk-ant-[a-z0-9-]+|sk-[a-z0-9]{20,}|gh[opsur]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]+|bearer\s+[A-Za-z0-9._~+/-]+=*)`)
+
+// FailureDetail returns a short, credential-redacted reason for a failed run: the last
+// meaningful line of the output tail (skipping the attempt header + DEBUG lines), else the process error.
+func FailureDetail(output string, runErr error) string {
+	detail := lastMeaningfulLine(output)
+	if detail == "" && runErr != nil {
+		detail = runErr.Error()
+	}
+	detail = strings.TrimSpace(secretRe.ReplaceAllString(detail, "[redacted]"))
+	const max = 300
+	if r := []rune(detail); len(r) > max {
+		detail = string(r[:max]) + "…"
+	}
+	return detail
+}
+
+func lastMeaningfulLine(output string) string {
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		s := strings.TrimSpace(lines[i])
+		if s == "" || strings.HasPrefix(s, "DEBUG:") || strings.HasPrefix(s, "--- Attempt") {
+			continue
+		}
+		return s
+	}
+	return ""
+}
+
 // blockedRe matches the "BLOCKED: <reason>" line every backend's prompt asks for — backend-agnostic, unlike rate-limit detection (see HasRateLimit).
 var blockedRe = regexp.MustCompile(`(?im)^BLOCKED:\s*(.*)$`)
 

--- a/internal/agent/log_test.go
+++ b/internal/agent/log_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -191,5 +192,38 @@ func TestReleaseLabel(t *testing.T) {
 				t.Errorf("ReleaseLabel(%q, %q) = %q, want %q", tt.bump, tt.defaultBump, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFailureDetail(t *testing.T) {
+	authErr := "--- Attempt 2026-07-01T01:10:31+01:00 ---\n" +
+		"DEBUG: pwd = /home/x/.noctra-worktrees/ENG-313\n" +
+		"DEBUG: branch = noctra/eng-313\n" +
+		`Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}` + "\n"
+
+	if got := FailureDetail(authErr, errors.New("exit status 1")); !strings.HasPrefix(got, "Failed to authenticate. API Error: 401") {
+		t.Errorf("expected the 401 line, got %q", got)
+	}
+
+	// Only header/DEBUG lines → fall back to the process error.
+	onlyNoise := "--- Attempt 2026-07-01T01:10:31+01:00 ---\nDEBUG: pwd = /x\nDEBUG: branch = y\n"
+	if got := FailureDetail(onlyNoise, errors.New("exit status 1")); got != "exit status 1" {
+		t.Errorf("expected fallback to runErr, got %q", got)
+	}
+
+	// Empty output and nil error → empty.
+	if got := FailureDetail("", nil); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+
+	// Credential-shaped tokens are redacted.
+	if got := FailureDetail("auth failed with key sk-ant-abc123def456ghi789 rejected", nil); strings.Contains(got, "sk-ant-abc123") {
+		t.Errorf("expected redaction, got %q", got)
+	}
+
+	// Long lines are capped.
+	long := strings.Repeat("x", 500)
+	if got := FailureDetail(long, nil); len([]rune(got)) > 301 {
+		t.Errorf("expected cap ~300, got len %d", len([]rune(got)))
 	}
 }

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -248,13 +248,14 @@ func (p *Pipeline) process(ctx context.Context, issue source.Ticket) {
 
 	if runErr != nil {
 		attempts := p.bumpFailed(id)
+		detail := agent.FailureDetail(output, runErr)
 		logger.Warn("agent exited with error",
-			"err", runErr, "attempt", attempts, "max", p.cfg.MaxRetries)
+			"err", runErr, "detail", detail, "attempt", attempts, "max", p.cfg.MaxRetries)
 		p.ticketBackToTrigger(ctx, issue, fmt.Sprintf(
-			"❌ **Noctra: Agent failed** (attempt %d/%d)\n\nThe agent exited with an error. Will retry on next poll cycle (up to %d attempts).\n\nTicket moved back to **%s**.",
-			attempts, p.cfg.MaxRetries, p.cfg.MaxRetries, p.cfg.TriggerState))
-		p.notifier.Send(ctx, fmt.Sprintf("❌ *%s* — %s\nFailed (attempt %d/%d)",
-			id, notify.EscapeMarkdown(issue.Title), attempts, p.cfg.MaxRetries))
+			"❌ **Noctra: Agent failed** (attempt %d/%d)\n\nThe agent exited with an error:\n\n```\n%s\n```\n\nWill retry on next poll cycle (up to %d attempts).\n\nTicket moved back to **%s**.",
+			attempts, p.cfg.MaxRetries, detail, p.cfg.MaxRetries, p.cfg.TriggerState))
+		p.notifier.Send(ctx, fmt.Sprintf("❌ *%s* — %s\nFailed (attempt %d/%d)\n%s",
+			id, notify.EscapeMarkdown(issue.Title), attempts, p.cfg.MaxRetries, notify.EscapeMarkdown(detail)))
 		p.recordRun(state.RunHistory{
 			Identifier: id, TicketID: id, Repo: filepath.Base(resolved.Path),
 			AgentBackend: backend.Name(), RunType: "ticket",


### PR DESCRIPTION
Closes [ENG-316](https://linear.app/amazz/issue/ENG-316).

## Why

When a dispatched agent exits with a generic non-zero error, the failure notice only said:

> ❌ ENG-313 — Component reuse…
> Failed (attempt 1/3)

The actual reason — tonight it was `401 Invalid authentication credentials` from an expired `claude` login — went **only** to the per-ticket log + journald. Diagnosing meant SSHing into the Pi and tailing `~/.noctra/logs/ENG-313.log`. Every *other* failure path (BLOCKED, no-change, timeout, repo-resolution) already surfaces its reason; this one was the gap.

## What

New `agent.FailureDetail(output, runErr)`:
- takes the **last meaningful line** of the run's output tail (skips the `--- Attempt …` header and `DEBUG:` lines) — i.e. the agent's own final error,
- falls back to the process error (`exit status 1`) when the output is only noise,
- **redacts** credential-shaped tokens (`sk-…`, `sk-ant-…`, `gh[opsur]_…`, `github_pat_…`, `Bearer …`) before it leaves the process,
- caps to ~300 runes.

The ticket agent-failure path (`internal/pipeline/process.go`) now includes it in **both** the Telegram message and the Linear comment (fenced), so a failure reads:

```
❌ ENG-313 — Component reuse: consolidate mobile primitives…
Failed (attempt 1/3)
Failed to authenticate. API Error: 401 … "Invalid authentication credentials"
```

## Tests

`internal/agent/log_test.go` → `TestFailureDetail`: the 401 case, fallback-to-runErr when output is header/DEBUG-only, empty in/nil, credential redaction, and length cap.

`go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...` all clean.

## Scope note
Applied to the ticket dispatch path (what surfaced this). The sweep path currently doesn't notify on failure at all — left as-is; happy to extend in a follow-up if you want failed sweeps to ping too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)