### PR TITLE
fix: don't post conversation comments on CI-only PR iterations

### DIFF
--- a/internal/pipeline/iterate.go
+++ b/internal/pipeline/iterate.go
@@ -651,7 +651,7 @@ func (p *Pipeline) postIterationReplies(ctx context.Context, ch watch.PRChanges,
 		p.replyToConversation(ctx, ch, convReply, logger)
 		return
 	}
-	if len(threadReplies) == 0 {
+	if shouldPostFallbackComment(ch, len(threadReplies)) {
 		if err := p.gh.PostComment(ctx, ch.PR.URL, convReply); err != nil {
 			logger.Warn("post iteration reply failed", "err", err)
 		}
@@ -670,6 +670,12 @@ func (p *Pipeline) replyToConversation(ctx context.Context, ch watch.PRChanges, 
 	if err := p.gh.PostComment(ctx, ch.PR.URL, body); err != nil {
 		logger.Warn("post conversation reply failed", "err", err)
 	}
+}
+
+// shouldPostFallbackComment gates the single standalone comment when no per-thread reply was posted.
+// Requires len(ch.Events) > 0 so a CI-only re-engagement — which has no one to answer — stays silent.
+func shouldPostFallbackComment(ch watch.PRChanges, threadReplyCount int) bool {
+	return threadReplyCount == 0 && len(ch.Events) > 0
 }
 
 func hasConversationComment(ch watch.PRChanges) bool {

--- a/internal/pipeline/iterate_test.go
+++ b/internal/pipeline/iterate_test.go
@@ -153,6 +153,27 @@ func TestIdentifierFromBranch_SweepRoundTrip(t *testing.T) {
 	}
 }
 
+func TestShouldPostFallbackComment(t *testing.T) {
+	cases := []struct {
+		name        string
+		ch          watch.PRChanges
+		threadCount int
+		want        bool
+	}{
+		{"CI-only, no events → no comment", watch.PRChanges{CIFailure: &watch.CIFailure{SHA: "abc"}}, 0, false},
+		{"review feedback, no thread replies → comment", watch.PRChanges{Events: []watch.Event{{Type: watch.EventComment, Path: "a.go"}}}, 0, true},
+		{"thread replies posted → no fallback", watch.PRChanges{Events: []watch.Event{{Type: watch.EventComment, Path: "a.go"}}}, 2, false},
+		{"nothing at all → no comment", watch.PRChanges{}, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldPostFallbackComment(c.ch, c.threadCount); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestDisplayName(t *testing.T) {
 	tests := []struct {
 		id   string


### PR DESCRIPTION
## Why

On [trade-mate#73](https://github.com/ahmadAlMezaal/trade-mate/pull/73) — a `deps-update` sweep PR whose `@supabase/supabase-js` bump broke CI three times (Node version → missing GRANTs → missing DELETE grant) — Noctra left three `Addressed in <sha>.` **conversation comments addressed to nobody.**

Root cause: those re-engagements were triggered purely by **CI failures** — no reviewer, no comment, no review thread. But `postIterationReplies` fell through to its standalone-comment fallback anyway:

```go
if len(threadReplies) == 0 {
    p.gh.PostComment(ctx, ch.PR.URL, convReply)  // "Addressed in <sha>. …"
}
```

That branch is meant for *review* feedback the agent didn't reply to per-thread. On a CI-only trigger there's no one to answer, so it just litters the conversation — once per CI fix.

## What

Gate the fallback comment behind `len(ch.Events) > 0` via a pure, tested `shouldPostFallbackComment` predicate. CI-only iterations now stay silent — the pushed commit and the Telegram/Linear pings already report the fix. Review/conversation feedback still gets its comment exactly as before.

## Tests

`TestShouldPostFallbackComment` covers CI-only (silent), review-with-no-thread-replies (comment), thread-replies-posted (silent), and empty. `go build`, `go vet`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)