### PR TITLE
fix: separate daily and session counters in /status (ENG-352)

### DIFF
--- a/internal/pipeline/commands.go
+++ b/internal/pipeline/commands.go
@@ -30,12 +30,15 @@ func (p *Pipeline) registerCommands(d *telegram.Dispatcher) {
 
 func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
 	p.mu.Lock()
+	p.rollDispatchWindow(time.Now())
 	active := make([]string, 0, len(p.active))
 	for id := range p.active {
 		active = append(active, id)
 	}
 	succ := p.successCount
 	fail := p.failCount
+	dailySucc := p.dailySuccessCount
+	dailyFail := p.dailyFailCount
 	dispatches := p.totalDispatches
 	maxD := p.cfg.MaxDispatches
 	maxC := p.cfg.MaxConcurrent
@@ -62,15 +65,18 @@ func (p *Pipeline) handleStatus(_ context.Context, _ string) string {
 		}
 	}
 
-	b.WriteString("\n*Session:*\n")
+	b.WriteString("\n*Today (UTC):*\n")
+	fmt.Fprintf(&b, "✅ %d PRs created\n", dailySucc)
+	fmt.Fprintf(&b, "❌ %d failed\n", dailyFail)
+	if maxD > 0 {
+		fmt.Fprintf(&b, "📦 %d/%d ticket dispatches\n", dispatches, maxD)
+	} else {
+		fmt.Fprintf(&b, "📦 %d ticket dispatches (no cap)\n", dispatches)
+	}
+
+	fmt.Fprintf(&b, "\n*Session (%s):*\n", uptime)
 	fmt.Fprintf(&b, "✅ %d PRs created\n", succ)
 	fmt.Fprintf(&b, "❌ %d failed\n", fail)
-	if maxD > 0 {
-		fmt.Fprintf(&b, "📦 %d/%d dispatches today\n", dispatches, maxD)
-	} else {
-		fmt.Fprintf(&b, "📦 %d dispatches today (no cap)\n", dispatches)
-	}
-	fmt.Fprintf(&b, "⏱ Uptime: %s\n", uptime)
 
 	bs := p.budget.Stats()
 	if bs.SessionTokens > 0 || bs.SessionCostUSD > 0 || bs.HasCaps() {

--- a/internal/pipeline/commands_test.go
+++ b/internal/pipeline/commands_test.go
@@ -66,10 +66,13 @@ func TestHandleStatus_Active(t *testing.T) {
 			"ENG-42": {},
 			"ENG-44": {},
 		},
-		successCount:    2,
-		failCount:       1,
-		totalDispatches: 5,
-		sessionStart:    time.Now().Add(-1 * time.Hour),
+		successCount:      9,
+		failCount:         4,
+		dailySuccessCount: 2,
+		dailyFailCount:    1,
+		totalDispatches:   5,
+		dispatchWindow:    time.Now().UTC().Truncate(24 * time.Hour),
+		sessionStart:      time.Now().Add(-1 * time.Hour),
 	}
 	reply := p.handleStatus(context.Background(), "")
 	if !strings.Contains(reply, "2/3") {
@@ -81,14 +84,22 @@ func TestHandleStatus_Active(t *testing.T) {
 	if !strings.Contains(reply, "ENG-44") {
 		t.Errorf("expected ENG-44 in reply, got %q", reply)
 	}
+	// Session-cumulative counts.
+	if !strings.Contains(reply, "9 PRs created") {
+		t.Errorf("expected session success count in reply, got %q", reply)
+	}
+	if !strings.Contains(reply, "4 failed") {
+		t.Errorf("expected session fail count in reply, got %q", reply)
+	}
+	// Today (UTC) counts — distinct window from the session totals.
 	if !strings.Contains(reply, "2 PRs created") {
-		t.Errorf("expected success count in reply, got %q", reply)
+		t.Errorf("expected daily success count in reply, got %q", reply)
 	}
 	if !strings.Contains(reply, "1 failed") {
-		t.Errorf("expected fail count in reply, got %q", reply)
+		t.Errorf("expected daily fail count in reply, got %q", reply)
 	}
-	if !strings.Contains(reply, "5/10") {
-		t.Errorf("expected dispatch count in reply, got %q", reply)
+	if !strings.Contains(reply, "5/10 ticket dispatches") {
+		t.Errorf("expected labelled dispatch count in reply, got %q", reply)
 	}
 }
 
@@ -937,8 +948,42 @@ func TestHandleStatus_UptimeFormat(t *testing.T) {
 		sessionStart: time.Now().Add(-2*time.Hour - 30*time.Minute),
 	}
 	reply := p.handleStatus(context.Background(), "")
-	if !strings.Contains(reply, "Uptime") {
-		t.Errorf("expected uptime in reply, got %q", reply)
+	if !strings.Contains(reply, "Session (") {
+		t.Errorf("expected session uptime header in reply, got %q", reply)
+	}
+}
+
+// TestHandleStatus_RollsWindowBeforeRead locks in ENG-352 requirement 1: /status
+// invoked after UTC midnight (before any poll) must show 0 for today, not the
+// prior day's counts left over in the fields.
+func TestHandleStatus_RollsWindowBeforeRead(t *testing.T) {
+	p := &Pipeline{
+		cfg: &config.Config{
+			MaxConcurrent: 3,
+			MaxDispatches: 25,
+		},
+		budget: budget.New(budget.Config{}),
+		active: map[string]struct{}{},
+		// Yesterday's window with yesterday's counts still populated.
+		dispatchWindow:    time.Now().UTC().Truncate(24 * time.Hour).Add(-24 * time.Hour),
+		totalDispatches:   13,
+		dailySuccessCount: 13,
+		dailyFailCount:    2,
+		// Session totals survive the roll.
+		successCount: 13,
+		failCount:    2,
+		sessionStart: time.Now().Add(-133 * time.Hour),
+	}
+	reply := p.handleStatus(context.Background(), "")
+	if !strings.Contains(reply, "0/25 ticket dispatches") {
+		t.Errorf("expected today's dispatches rolled to 0/25, got %q", reply)
+	}
+	if !strings.Contains(reply, "*Today (UTC):*\n✅ 0 PRs created\n❌ 0 failed") {
+		t.Errorf("expected today's PR/fail counts rolled to 0, got %q", reply)
+	}
+	// The session-cumulative block keeps the running totals.
+	if !strings.Contains(reply, "13 PRs created") || !strings.Contains(reply, "2 failed") {
+		t.Errorf("expected session totals preserved, got %q", reply)
 	}
 }
 

--- a/internal/pipeline/dispatch_window_test.go
+++ b/internal/pipeline/dispatch_window_test.go
@@ -37,12 +37,18 @@ func TestRollDispatchWindow_ResetsAtUTCMidnight(t *testing.T) {
 	p.rollDispatchWindow(day1)
 	p.totalDispatches = 7
 	p.dispatchCapped = true
+	p.dailySuccessCount = 5
+	p.dailyFailCount = 2
 
 	// Same day, later — must NOT reset.
 	p.rollDispatchWindow(day1.Add(8 * time.Hour))
 	if p.totalDispatches != 7 || !p.dispatchCapped {
 		t.Fatalf("same-day roll reset state: got count=%d capped=%v, want 7/true",
 			p.totalDispatches, p.dispatchCapped)
+	}
+	if p.dailySuccessCount != 5 || p.dailyFailCount != 2 {
+		t.Fatalf("same-day roll reset daily counters: got succ=%d fail=%d, want 5/2",
+			p.dailySuccessCount, p.dailyFailCount)
 	}
 
 	// New UTC day — must reset the counter and clear the alert flag.
@@ -52,5 +58,45 @@ func TestRollDispatchWindow_ResetsAtUTCMidnight(t *testing.T) {
 	}
 	if p.dispatchCapped {
 		t.Fatal("cap alert flag not cleared at new day")
+	}
+	if p.dailySuccessCount != 0 || p.dailyFailCount != 0 {
+		t.Fatalf("daily counters not reset at new day: got succ=%d fail=%d, want 0/0",
+			p.dailySuccessCount, p.dailyFailCount)
+	}
+}
+
+// TestBumpSuccessFeedsDailyCounter locks in ENG-352 requirement 2: any PR-producing
+// path (ticket or sweep) that calls bumpSuccess must raise the daily counter, and
+// the daily counter resets when the UTC-midnight window rolls.
+func TestBumpSuccessFeedsDailyCounter(t *testing.T) {
+	p := &Pipeline{
+		active:         map[string]struct{}{},
+		failedAttempts: map[string]int{},
+		dispatchWindow: time.Now().UTC().Truncate(24 * time.Hour),
+	}
+
+	p.bumpSuccess() // e.g. a sweep-created PR
+	p.bumpSuccess()
+	if p.dailySuccessCount != 2 {
+		t.Fatalf("bumpSuccess did not feed daily counter: got %d, want 2", p.dailySuccessCount)
+	}
+	if p.successCount != 2 {
+		t.Fatalf("bumpSuccess did not feed session counter: got %d, want 2", p.successCount)
+	}
+
+	p.bumpFailed("ENG-1")
+	if p.dailyFailCount != 1 || p.failCount != 1 {
+		t.Fatalf("bumpFailed counters: got daily=%d session=%d, want 1/1", p.dailyFailCount, p.failCount)
+	}
+
+	// Roll to a new day — daily counters reset, session counters persist.
+	p.rollDispatchWindow(p.dispatchWindow.Add(24 * time.Hour))
+	if p.dailySuccessCount != 0 || p.dailyFailCount != 0 {
+		t.Fatalf("daily counters survived window roll: got succ=%d fail=%d, want 0/0",
+			p.dailySuccessCount, p.dailyFailCount)
+	}
+	if p.successCount != 2 || p.failCount != 1 {
+		t.Fatalf("session counters reset by window roll: got succ=%d fail=%d, want 2/1",
+			p.successCount, p.failCount)
 	}
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -71,6 +71,8 @@ type Pipeline struct {
 	dispatchCapped    bool
 	successCount      int
 	failCount         int
+	dailySuccessCount int
+	dailyFailCount    int
 	rateLimitDetected bool
 	paused            bool
 }
@@ -347,6 +349,8 @@ func (p *Pipeline) rollDispatchWindow(now time.Time) {
 		p.dispatchWindow = day
 		p.totalDispatches = 0
 		p.dispatchCapped = false
+		p.dailySuccessCount = 0
+		p.dailyFailCount = 0
 	}
 }
 
@@ -551,8 +555,10 @@ func (p *Pipeline) dispatchPaused() bool {
 
 func (p *Pipeline) bumpFailed(id string) int {
 	p.mu.Lock()
+	p.rollDispatchWindow(time.Now())
 	p.failedAttempts[id]++
 	p.failCount++
+	p.dailyFailCount++
 	attempts := p.failedAttempts[id]
 	p.mu.Unlock()
 	p.publishDashboardChange()
@@ -561,7 +567,9 @@ func (p *Pipeline) bumpFailed(id string) int {
 
 func (p *Pipeline) bumpSuccess() {
 	p.mu.Lock()
+	p.rollDispatchWindow(time.Now())
 	p.successCount++
+	p.dailySuccessCount++
 	p.mu.Unlock()
 	p.publishDashboardChange()
 }


### PR DESCRIPTION
## What

The Telegram `/status` "Session:" block mixed counter windows: `successCount`/`failCount` are cumulative since process start, while `totalDispatches` resets at every UTC midnight. Rendered side by side under one header, a live instance could show `13 PRs created … 0/25 dispatches today` — each counter correct, the juxtaposition misleading (ENG-352).

## Changes

- **`handleStatus` rolls the dispatch window before reading** (`p.rollDispatchWindow(time.Now())` under `p.mu`), so a `/status` between UTC midnight and the next poll shows today's numbers, not yesterday's.
- **New daily success/fail counters** (`dailySuccessCount`/`dailyFailCount`) reset in `rollDispatchWindow` alongside `totalDispatches`. `bumpSuccess`/`bumpFailed` feed them and roll the window first, so **sweep-created PRs raise the daily PR count** (the sweep path goes through `bumpSuccess`) just like ticket PRs.
- **Restructured `/status`** into two unambiguous blocks:
  - `*Today (UTC):*` — PRs created · failed · `N/25 ticket dispatches` (labelled, since sweeps/iterate are exempt from the cap)
  - `*Session (<uptime>):*` — cumulative PRs created · failed

## Scope

Reporting only. Dispatch-cap **enforcement** is unchanged — sweeps and auto-iterate re-engagements remain exempt from `MAX_DISPATCHES`. No dashboard/notifier/budget changes.

## Tests

- `dispatch_window_test.go`: daily counters reset on the UTC-day roll but not intra-day; `bumpSuccess`/`bumpFailed` feed daily + session counters.
- `commands_test.go`: `/status` after midnight (before a poll) shows `0/25` for today while session totals persist; render separates the two windows.
- `go test ./...` and `go vet ./...` pass.

Closes ENG-352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)