### PR TITLE
fix: resolve golangci-lint issues in the repos add flow

### DIFF
--- a/internal/repoadd/repoadd.go
+++ b/internal/repoadd/repoadd.go
@@ -64,7 +64,7 @@ func Add(ctx context.Context, cloner Cloner, projects Projects, req Request) (Re
 		return res, errors.New("no Linear client is configured, so the routing directive was not written")
 	}
 	if req.Project.ID == "" {
-		return res, fmt.Errorf("Linear project %q has no ID, so the routing directive was not written", req.Project.Name)
+		return res, fmt.Errorf("project %q has no Linear ID, so the routing directive was not written", req.Project.Name)
 	}
 
 	content := linear.UpsertRepoDirective(req.Project.Content, ref, req.Branch)

--- a/internal/reposcmd/reposcmd.go
+++ b/internal/reposcmd/reposcmd.go
@@ -123,7 +123,7 @@ func runAdd(scriptDir string, args []string) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not open the state DB (%v); a rotated Linear token won't be persisted\n", err)
 	} else {
-		defer store.Close()
+		defer func() { _ = store.Close() }()
 	}
 	projects := linearclient.New(cfg, store)
 


### PR DESCRIPTION
Fixes the two lint failures CI reported on `main` after #266 merged:

- **errcheck** — `internal/reposcmd/reposcmd.go`: the deferred `store.Close()` now discards the error explicitly (`defer func() { _ = store.Close() }()`), matching the pattern used in `internal/selfupdate`.
- **staticcheck ST1005** — `internal/repoadd/repoadd.go`: reworded the capitalised error string to `project %q has no Linear ID, so the routing directive was not written`.

`go vet` and the affected package tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)